### PR TITLE
simple arbitrage base helper contract

### DIFF
--- a/test/base/ArbitrageTest.t.sol
+++ b/test/base/ArbitrageTest.t.sol
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import "forge-std/Test.sol";
+
+import { BaseTest } from "./BaseTest.t.sol";
+import { IUniswapV2Router02 } from "./interfaces/IUniswapV2Router.sol";
+import { ERC20 } from "solmate/tokens/ERC20.sol";
+
+contract ArbitrageTest is BaseTest {
+    // Uniswap
+    IUniswapV2Router02 public constant v2Router = IUniswapV2Router02(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D);
+    // Sushiswap
+    IUniswapV2Router02 public constant s2Router = IUniswapV2Router02(0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F);
+
+    address public swapper;
+
+    function setUp() public virtual override {
+        BaseTest.setUp();
+        swapper = vm.addr(666_666);
+    }
+
+    function testSimpleArbitrage() public {
+        // Increase DAI reserve and decrease WETH reserve on Uniswap LP
+        // Increase WETH reserve and decrease DAI reserve on Sushiswap LP
+        // This should create an arbitrage opportunity
+        setUpArbitragePools(chain.weth, chain.dai, 50e18, 100_000e18, v2Router, s2Router);
+
+        // Arbitrage is fulfilled by swapping WETH for DAI on Uniswap, then DAI for WETH on Sushiswap
+        (uint256 revenue, uint256 optimalAmountIn) =
+            ternarySearch(chain.weth, chain.dai, v2Router, s2Router, 1, 50e18, 0, 20);
+
+        assertTrue(revenue - optimalAmountIn > 0, "No arbitrage opportunity");
+
+        deal(chain.weth, swapper, optimalAmountIn);
+        uint256 balanceBefore = ERC20(chain.weth).balanceOf(swapper);
+
+        address[] memory path = new address[](2);
+        path[0] = chain.weth;
+        path[1] = chain.dai;
+
+        vm.startPrank(swapper);
+        ERC20(chain.weth).approve(address(v2Router), optimalAmountIn);
+        uint256 daiOut = v2Router.swapExactTokensForTokens(optimalAmountIn, 0, path, swapper, block.timestamp)[1];
+        vm.stopPrank();
+
+        path[0] = chain.dai;
+        path[1] = chain.weth;
+
+        vm.startPrank(swapper);
+        ERC20(chain.dai).approve(address(s2Router), daiOut);
+        s2Router.swapExactTokensForTokens(daiOut, 0, path, swapper, block.timestamp);
+        vm.stopPrank();
+
+        uint256 balanceAfter = ERC20(chain.weth).balanceOf(swapper);
+
+        assertTrue(balanceAfter > balanceBefore, "Arbitrage failed");
+        console.log("WETH revenue: ", balanceAfter - balanceBefore);
+    }
+
+    // Swap amountB tokenB for tokenA on routerA and amountA tokenA for tokenB on routerB.
+    // This is meant to create an imbalance between the pools and create an arbitrage opportunity.
+    function setUpArbitragePools(
+        address tokenA,
+        address tokenB,
+        uint256 amountA,
+        uint256 amountB,
+        IUniswapV2Router02 routerA,
+        IUniswapV2Router02 routerB
+    )
+        public
+    {
+        deal(tokenA, swapper, amountA);
+        deal(tokenB, swapper, amountB);
+
+        address[] memory path = new address[](2);
+        path[0] = tokenB;
+        path[1] = tokenA;
+
+        vm.startPrank(swapper);
+        ERC20(tokenB).approve(address(routerA), amountB);
+        routerA.swapExactTokensForTokens(amountB, 0, path, swapper, block.timestamp);
+        vm.stopPrank();
+
+        path[0] = tokenA;
+        path[1] = tokenB;
+
+        vm.startPrank(swapper);
+        ERC20(tokenA).approve(address(routerB), amountA);
+        routerB.swapExactTokensForTokens(amountA, 0, path, swapper, block.timestamp);
+        vm.stopPrank();
+    }
+
+    function simulateSimpleArbitrage(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        IUniswapV2Router02 routerIn,
+        IUniswapV2Router02 routerOut
+    )
+        public
+        view
+        returns (uint256 amountOut)
+    {
+        require(amountIn > 0, "Invalid amountIn");
+
+        address[] memory path = new address[](2);
+        path[0] = tokenIn;
+        path[1] = tokenOut;
+
+        amountOut = routerIn.getAmountsOut(amountIn, path)[1];
+
+        path[0] = tokenOut;
+        path[1] = tokenIn;
+
+        amountOut = routerOut.getAmountsOut(amountOut, path)[1];
+    }
+
+    function ternarySearch(
+        address tokenIn,
+        address tokenOut,
+        IUniswapV2Router02 routerIn,
+        IUniswapV2Router02 routerOut,
+        uint256 left,
+        uint256 right,
+        uint24 c,
+        uint24 m
+    )
+        internal
+        returns (uint256 revenue, uint256 optimalAmountIn)
+    {
+        uint256 mid1 = left + (right - left) / 3;
+        uint256 mid2 = right - (right - left) / 3;
+        uint256 revenue1 = simulateSimpleArbitrage(tokenIn, tokenOut, mid1, routerIn, routerOut);
+        uint256 revenue2 = simulateSimpleArbitrage(tokenIn, tokenOut, mid2, routerIn, routerOut);
+        if (revenue1 == revenue2) {
+            return (revenue1, mid1);
+        } else if (revenue1 > revenue2) {
+            if (c == m) return (revenue1, mid1);
+            return ternarySearch(tokenIn, tokenOut, routerIn, routerOut, left, mid2, c + 1, m);
+        } else {
+            if (c == m) return (revenue2, mid2);
+            return ternarySearch(tokenIn, tokenOut, routerIn, routerOut, mid1, right, c + 1, m);
+        }
+    }
+}

--- a/test/base/interfaces/IUniswapV2Router.sol
+++ b/test/base/interfaces/IUniswapV2Router.sol
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+interface IUniswapV2Router01 {
+    function factory() external pure returns (address);
+    function WETH() external pure returns (address);
+
+    function addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 amountADesired,
+        uint256 amountBDesired,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    )
+        external
+        returns (uint256 amountA, uint256 amountB, uint256 liquidity);
+    function addLiquidityETH(
+        address token,
+        uint256 amountTokenDesired,
+        uint256 amountTokenMin,
+        uint256 amountETHMin,
+        address to,
+        uint256 deadline
+    )
+        external
+        payable
+        returns (uint256 amountToken, uint256 amountETH, uint256 liquidity);
+    function removeLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    )
+        external
+        returns (uint256 amountA, uint256 amountB);
+    function removeLiquidityETH(
+        address token,
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountETHMin,
+        address to,
+        uint256 deadline
+    )
+        external
+        returns (uint256 amountToken, uint256 amountETH);
+    function removeLiquidityWithPermit(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    )
+        external
+        returns (uint256 amountA, uint256 amountB);
+    function removeLiquidityETHWithPermit(
+        address token,
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountETHMin,
+        address to,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    )
+        external
+        returns (uint256 amountToken, uint256 amountETH);
+    function swapExactTokensForTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    )
+        external
+        returns (uint256[] memory amounts);
+    function swapTokensForExactTokens(
+        uint256 amountOut,
+        uint256 amountInMax,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    )
+        external
+        returns (uint256[] memory amounts);
+    function swapExactETHForTokens(
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    )
+        external
+        payable
+        returns (uint256[] memory amounts);
+    function swapTokensForExactETH(
+        uint256 amountOut,
+        uint256 amountInMax,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    )
+        external
+        returns (uint256[] memory amounts);
+    function swapExactTokensForETH(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    )
+        external
+        returns (uint256[] memory amounts);
+    function swapETHForExactTokens(
+        uint256 amountOut,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    )
+        external
+        payable
+        returns (uint256[] memory amounts);
+
+    function quote(uint256 amountA, uint256 reserveA, uint256 reserveB) external pure returns (uint256 amountB);
+    function getAmountOut(
+        uint256 amountIn,
+        uint256 reserveIn,
+        uint256 reserveOut
+    )
+        external
+        pure
+        returns (uint256 amountOut);
+    function getAmountIn(
+        uint256 amountOut,
+        uint256 reserveIn,
+        uint256 reserveOut
+    )
+        external
+        pure
+        returns (uint256 amountIn);
+    function getAmountsOut(
+        uint256 amountIn,
+        address[] calldata path
+    )
+        external
+        view
+        returns (uint256[] memory amounts);
+    function getAmountsIn(
+        uint256 amountOut,
+        address[] calldata path
+    )
+        external
+        view
+        returns (uint256[] memory amounts);
+}
+
+interface IUniswapV2Router02 is IUniswapV2Router01 {
+    function removeLiquidityETHSupportingFeeOnTransferTokens(
+        address token,
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountETHMin,
+        address to,
+        uint256 deadline
+    )
+        external
+        returns (uint256 amountETH);
+    function removeLiquidityETHWithPermitSupportingFeeOnTransferTokens(
+        address token,
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountETHMin,
+        address to,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    )
+        external
+        returns (uint256 amountETH);
+
+    function swapExactTokensForTokensSupportingFeeOnTransferTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    )
+        external;
+    function swapExactETHForTokensSupportingFeeOnTransferTokens(
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    )
+        external
+        payable;
+    function swapExactTokensForETHSupportingFeeOnTransferTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    )
+        external;
+}


### PR DESCRIPTION
A helper contract for simple arbitrage.

To use in other tests, create a contract inheriting `ArbitrageTest`.
Call `setUpArbitragePools` to create an imbalance between 2 uniswapV2 fork pools.
Call `ternarySearch` to get the revenue and recommended amountIn to profit from the arb opportunity.
Perform the arbitrage manually (example in `testSimpleArbitrage`).