### PR TITLE
Optimize solverOps array in Verification

### DIFF
--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -168,13 +168,13 @@ contract Atlas is Escrow {
         }
 
         for (; winningSearcherIndex < solverOps.length;) {
-            // Only execute solver meta tx if userOpHash matches
-            if (!auctionWon && solverOps[winningSearcherIndex].from != address(0)) {
-                (auctionWon, key) = _solverExecutionIteration(
-                    dConfig, solverOps[winningSearcherIndex], returnData, auctionWon, executionEnvironment, bundler, key
-                );
-                if (auctionWon) break;
-            }
+            // valid solverOps are packed from left of array - break at first invalid solverOp
+            if (solverOps[winningSearcherIndex].from == address(0)) break;
+
+            (auctionWon, key) = _solverExecutionIteration(
+                dConfig, solverOps[winningSearcherIndex], returnData, auctionWon, executionEnvironment, bundler, key
+            );
+            if (auctionWon) break;
 
             unchecked {
                 ++winningSearcherIndex;

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -18,7 +18,7 @@ import { CallVerification } from "../libraries/CallVerification.sol";
 
 import { DAppIntegration } from "./DAppIntegration.sol";
 
-// import "forge-std/Test.sol"; // TODO remove
+import "forge-std/Test.sol"; // TODO remove
 
 // NOTE: AtlasVerification is the separate contract version of the DappVerification/DAppIntegration
 // inheritance slice of the original Atlas design
@@ -98,13 +98,7 @@ contract AtlasVerification is EIP712, DAppIntegration {
                 }
             }
 
-            // Some checks are only needed when call is not a simulation
-            if (isSimulation) {
-                // Add all solver ops if simulation
-                return (solverOps, ValidCallsResult.Valid);
-            }
-
-            // Check
+            // Check bundler matches dAppOp bundler
             if (dAppOp.bundler != address(0) && msgSender != dAppOp.bundler) {
                 return (prunedSolverOps, ValidCallsResult.InvalidBundler);
             }
@@ -148,6 +142,12 @@ contract AtlasVerification is EIP712, DAppIntegration {
                     ++validSolverCount;
                 }
             }
+        }
+
+        // Some checks are only needed when call is not a simulation
+        if (isSimulation) {
+            // Add all solver ops if simulation
+            return (prunedSolverOps, ValidCallsResult.Valid);
         }
 
         // Verify a solver was successfully verified.

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -143,7 +143,7 @@ contract AtlasVerification is EIP712, DAppIntegration {
                 if (solverOp.userOpHash != userOpHash) continue;
 
                 // If all initial checks succeed, add solver op to new array
-                prunedSolverOps[i] = solverOp;
+                prunedSolverOps[validSolverCount] = solverOp;
                 unchecked {
                     ++validSolverCount;
                 }

--- a/src/contracts/helpers/Simulator.sol
+++ b/src/contracts/helpers/Simulator.sol
@@ -46,7 +46,7 @@ contract Simulator is FastLaneErrorsEvents {
 
     function simUserOperation(UserOperation calldata userOp) external payable returns (bool success) {
         // SolverOperation memory solverOp;
-        SolverOperation[] memory solverOps = new SolverOperation[](1);
+        SolverOperation[] memory solverOps = new SolverOperation[](0);
         // solverOps[0] = solverOp;
         DAppOperation memory dAppOp;
         dAppOp.control = userOp.control;


### PR DESCRIPTION
When `AtlasVerification.validCalls()` is called, it returns a filtered solverOps array.

Instead of leaving blank solverOps objects (checked using `solverOp.from == address(0)`) in their prev spots in the array, we can pack the array with only the valid ones from the start.

This should see a gas improvement in some cases - in the `_execute` part of a `metacall` tx, we can simplify the checks while looping, as well as breaking early after checking only the valid solverOps.

One concern is that rearranging the order of the solverOps array could mess with the simulator. In `validCalls`, if the call is in simulator mode, the original solverOps array is returned before being filtered. These differences in orders could be problematic.

First pass at mitigating these concerns:
- The `isSimulation == true` check is now below the solverOps pruning loop, so solverOps returned are in the same pruned form that `_execute` will receive.
- In the simulator, `simUserOperation` simulates the metacall with an empty solverOps array (length 0) instead of one of length 1, where it's a single empty solverOp. This change stops the sim call from reverting when it tries to verify the blank solverOp in that pruning loop. 