### PR TITLE
Bonded atlETH token

### DIFF
--- a/script/deploy-atlas.s.sol
+++ b/script/deploy-atlas.s.sol
@@ -24,7 +24,8 @@ contract DeployAtlasScript is DeployBaseScript {
         // Computes the addresses at which AtlasFactory and AtlasVerification will be deployed
         address expectedAtlasFactoryAddr = computeCreateAddress(deployer, vm.getNonce(deployer) + 1);
         address expectedAtlasVerificationAddr = computeCreateAddress(deployer, vm.getNonce(deployer) + 2);
-        address expectedSimulatorAddr = computeCreateAddress(deployer, vm.getNonce(deployer) + 3);
+        address expectedBoAtlETHAddr = computeCreateAddress(deployer, vm.getNonce(deployer) + 3);
+        address expectedSimulatorAddr = computeCreateAddress(deployer, vm.getNonce(deployer) + 4);
 
         console.log("Deployer address: \t\t\t\t", deployer);
 
@@ -34,6 +35,7 @@ contract DeployAtlasScript is DeployBaseScript {
             _escrowDuration: 64,
             _factory: expectedAtlasFactoryAddr,
             _verification: expectedAtlasVerificationAddr,
+            _boAtlETH: expectedBoAtlETHAddr,
             _simulator: expectedSimulatorAddr
         });
         atlasFactory = new AtlasFactory(address(atlas));

--- a/src/contracts/atlas/AtlETH.sol
+++ b/src/contracts/atlas/AtlETH.sol
@@ -6,6 +6,8 @@ import { SafeTransferLib } from "solmate/utils/SafeTransferLib.sol";
 import "../types/EscrowTypes.sol";
 import { Permit69 } from "../common/Permit69.sol";
 
+import { IBoAtlETH } from "../interfaces/IBoAtlETH.sol";
+
 import "forge-std/Test.sol";
 
 // TODO split out events and errors to share with AtlasEscrow
@@ -30,9 +32,10 @@ abstract contract AtlETH is Permit69 {
         uint256 _escrowDuration,
         address _factory,
         address _verification,
+        address _boAtlETH,
         address _simulator
     )
-        Permit69(_escrowDuration, _factory, _verification, _simulator)
+        Permit69(_escrowDuration, _factory, _verification, _boAtlETH, _simulator)
     { }
 
     /*//////////////////////////////////////////////////////////////
@@ -142,6 +145,7 @@ abstract contract AtlETH is Permit69 {
         }
         accountBalance.bonded += uint128(amount);
         _balanceOf[account] = accountBalance;
+        IBoAtlETH(BOATLETH).mint(account, amount);
     }
 
     // Returns the allowed withdrawal amount which may be <= the requested amount param
@@ -179,6 +183,7 @@ abstract contract AtlETH is Permit69 {
         if (_amount > unlockedBalance) {
             _accessData.unbondingBalance -= _amount - unlockedBalance;
             accountBalance.bonded -= _amount - unlockedBalance;
+            IBoAtlETH(BOATLETH).burn(msg.sender, _amount - unlockedBalance);
         }
 
         accessData[spender] = _accessData;

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -33,9 +33,10 @@ contract Atlas is Escrow {
         uint256 _escrowDuration,
         address _factory,
         address _verification,
+        address _boAtlETH,
         address _simulator
     )
-        Escrow(_escrowDuration, _factory, _verification, _simulator)
+        Escrow(_escrowDuration, _factory, _verification, _boAtlETH, _simulator)
     { }
 
     function createExecutionEnvironment(address dAppControl) external returns (address executionEnvironment) {

--- a/src/contracts/atlas/BoAtlETH.sol
+++ b/src/contracts/atlas/BoAtlETH.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.21;
+
+contract BoAtlETH {
+    /*//////////////////////////////////////////////////////////////
+                                 EVENTS
+    //////////////////////////////////////////////////////////////*/
+
+    event Transfer(address indexed from, address indexed to, uint256 amount);
+
+    /*//////////////////////////////////////////////////////////////
+                            METADATA STORAGE
+    //////////////////////////////////////////////////////////////*/
+
+    string public constant name = "Bonded Atlas ETH";
+    string public constant symbol = "boAtlETH";
+    uint8 public constant decimals = 18;
+
+    /*//////////////////////////////////////////////////////////////
+                              ERC20 STORAGE
+    //////////////////////////////////////////////////////////////*/
+
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+
+    /*//////////////////////////////////////////////////////////////
+                              ATLAS
+    //////////////////////////////////////////////////////////////*/
+
+    address public immutable atlas;
+
+    /*//////////////////////////////////////////////////////////////
+                               CONSTRUCTOR
+    //////////////////////////////////////////////////////////////*/
+
+    constructor(address _atlas) {
+        atlas = _atlas;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                               BOATLETH
+    //////////////////////////////////////////////////////////////*/
+
+    function mint(address to, uint256 amount) external onlyAtlas {
+        totalSupply += amount;
+
+        // Cannot overflow because the sum of all user
+        // balances can't exceed the max uint256 value.
+        unchecked {
+            balanceOf[to] += amount;
+        }
+
+        emit Transfer(address(0), to, amount);
+    }
+
+    function burn(address from, uint256 amount) external onlyAtlas {
+        balanceOf[from] -= amount;
+
+        // Cannot underflow because a user's balance
+        // will never be larger than the total supply.
+        unchecked {
+            totalSupply -= amount;
+        }
+
+        emit Transfer(from, address(0), amount);
+    }
+
+    modifier onlyAtlas() {
+        require(msg.sender == atlas, "BoAtlETH: Only Atlas can call this function");
+        _;
+    }
+}

--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -32,9 +32,10 @@ abstract contract Escrow is AtlETH {
         uint256 _escrowDuration,
         address _factory,
         address _verification,
+        address _boAtlETH,
         address _simulator
     )
-        AtlETH(_escrowDuration, _factory, _verification, _simulator)
+        AtlETH(_escrowDuration, _factory, _verification, _boAtlETH, _simulator)
     { }
 
     ///////////////////////////////////////////////////

--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -18,9 +18,10 @@ abstract contract GasAccounting is SafetyLocks {
         uint256 _escrowDuration,
         address _factory,
         address _verification,
+        address _boAtlETH,
         address _simulator
     )
-        SafetyLocks(_escrowDuration, _factory, _verification, _simulator)
+        SafetyLocks(_escrowDuration, _factory, _verification, _boAtlETH, _simulator)
     { }
 
     // ---------------------------------------

--- a/src/contracts/atlas/SafetyLocks.sol
+++ b/src/contracts/atlas/SafetyLocks.sol
@@ -24,9 +24,10 @@ abstract contract SafetyLocks is Storage, FastLaneErrorsEvents {
         uint256 _escrowDuration,
         address _factory,
         address _verification,
+        address _boAtlETH,
         address _simulator
     )
-        Storage(_escrowDuration, _factory, _verification, _simulator)
+        Storage(_escrowDuration, _factory, _verification, _boAtlETH, _simulator)
     { }
 
     function _initializeEscrowLock(address executionEnvironment, uint256 gasMarker, uint256 userOpValue) internal {

--- a/src/contracts/atlas/Storage.sol
+++ b/src/contracts/atlas/Storage.sol
@@ -13,6 +13,7 @@ contract Storage {
     uint256 public immutable ESCROW_DURATION;
     address public immutable FACTORY;
     address public immutable VERIFICATION;
+    address public immutable BOATLETH;
     address public immutable SIMULATOR;
 
     // AtlETH ERC-20 constants
@@ -50,10 +51,19 @@ contract Storage {
     uint256 public withdrawals; // transient storage
     uint256 public deposits; // transient storage
 
-    constructor(uint256 _escrowDuration, address _factory, address _verification, address _simulator) payable {
+    constructor(
+        uint256 _escrowDuration,
+        address _factory,
+        address _verification,
+        address _boAtlETH,
+        address _simulator
+    )
+        payable
+    {
         ESCROW_DURATION = _escrowDuration;
         FACTORY = _factory;
         VERIFICATION = _verification;
+        BOATLETH = _boAtlETH;
         SIMULATOR = _simulator;
         INITIAL_CHAIN_ID = block.chainid;
         INITIAL_DOMAIN_SEPARATOR = _computeDomainSeparator();

--- a/src/contracts/common/Permit69.sol
+++ b/src/contracts/common/Permit69.sol
@@ -32,9 +32,10 @@ abstract contract Permit69 is GasAccounting {
         uint256 _escrowDuration,
         address _factory,
         address _verification,
+        address _boAtlETH,
         address _simulator
     )
-        GasAccounting(_escrowDuration, _factory, _verification, _simulator)
+        GasAccounting(_escrowDuration, _factory, _verification, _boAtlETH, _simulator)
     { }
 
     // Virtual Functions defined by other Atlas modules

--- a/src/contracts/interfaces/IBoAtlETH.sol
+++ b/src/contracts/interfaces/IBoAtlETH.sol
@@ -1,0 +1,7 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.21;
+
+interface IBoAtlETH {
+    function mint(address to, uint256 amount) external;
+    function burn(address from, uint256 amount) external;
+}

--- a/test/AtlETH.t.sol
+++ b/test/AtlETH.t.sol
@@ -8,8 +8,6 @@ import { BoAtlETH } from "src/contracts/atlas/BoAtlETH.sol";
 
 import { BaseTest } from "./base/BaseTest.t.sol";
 
-import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-
 contract AtlETHTest is BaseTest {
     function testBasicFunctionalities() public {
         // solverOne deposited 1 ETH into Atlas in BaseTest.setUp
@@ -81,7 +79,7 @@ contract AtlETHTest is BaseTest {
         boAthETH = new BoAtlETH(address(atlas));
         vm.stopPrank();
 
-        ERC20 boAtlETH = ERC20(atlas.BOATLETH());
+        BoAtlETH boAtlETH = BoAtlETH(atlas.BOATLETH());
 
         vm.prank(solverOneEOA);
         atlas.deposit{ value: 1 ether }();

--- a/test/Permit69.t.sol
+++ b/test/Permit69.t.sol
@@ -42,7 +42,7 @@ contract Permit69Test is BaseTest {
             callDepth: 0
         });
 
-        mockAtlas = new MockAtlasForPermit69Tests(10, address(0), address(0), address(0));
+        mockAtlas = new MockAtlasForPermit69Tests(10, address(0), address(0), address(0), address(0));
         mockAtlas.setEscrowKey(escrowKey);
         mockAtlas.setEnvironment(mockExecutionEnvAddress);
 
@@ -262,9 +262,10 @@ contract MockAtlasForPermit69Tests is Permit69 {
         uint256 _escrowDuration,
         address _factory,
         address _verification,
+        address _boAtlETH,
         address _simulator
     )
-        Permit69(_escrowDuration, _factory, _verification, _simulator)
+        Permit69(_escrowDuration, _factory, _verification, _boAtlETH, _simulator)
     { }
 
     // Declared in SafetyLocks.sol in the canonical Atlas system

--- a/test/base/BaseTest.t.sol
+++ b/test/base/BaseTest.t.sol
@@ -8,6 +8,7 @@ import { IDAppIntegration } from "src/contracts/interfaces/IDAppIntegration.sol"
 import { Atlas } from "src/contracts/atlas/Atlas.sol";
 import { AtlasFactory } from "src/contracts/atlas/AtlasFactory.sol";
 import { AtlasVerification } from "src/contracts/atlas/AtlasVerification.sol";
+import { BoAtlETH } from "src/contracts/atlas/BoAtlETH.sol";
 
 import { Sorter } from "src/contracts/helpers/Sorter.sol";
 import { Simulator } from "src/contracts/helpers/Simulator.sol";
@@ -42,6 +43,7 @@ contract BaseTest is Test, TestConstants {
     Atlas public atlas;
     AtlasFactory public atlasFactory;
     AtlasVerification public atlasVerification;
+    BoAtlETH public boAthETH;
 
     Simulator public simulator;
     Sorter public sorter;
@@ -78,15 +80,18 @@ contract BaseTest is Test, TestConstants {
         // Computes the addresses at which AtlasFactory and AtlasVerification will be deployed
         address expectedAtlasFactoryAddr = computeCreateAddress(payee, vm.getNonce(payee) + 1);
         address expectedAtlasVerificationAddr = computeCreateAddress(payee, vm.getNonce(payee) + 2);
+        address expectedBoAtlEthAddr = computeCreateAddress(payee, vm.getNonce(payee) + 3);
 
         atlas = new Atlas({
             _escrowDuration: 64,
             _factory: expectedAtlasFactoryAddr,
             _verification: expectedAtlasVerificationAddr,
+            _boAtlETH: expectedBoAtlEthAddr,
             _simulator: address(simulator)
         });
         atlasFactory = new AtlasFactory(address(atlas));
         atlasVerification = new AtlasVerification(address(atlas));
+        boAthETH = new BoAtlETH(address(atlas));
 
         simulator.setAtlas(address(atlas));
 


### PR DESCRIPTION
A new contract with ERC20 limited capacity (mint and burn only), to properly track atlETH bonded balances.
The internal logic of Atlas and AtlETH stays the same, the only difference is when bonding and withdrawing, boAtlETH tokens are minted and burned respectively.

By tracking the bonded balances in another token, we can query `balanceOf` on Atlas to get the "free" athETH balance of a user. And query `balanceOf` on boAthETH to get the bonded balance of a user.

The token is not transferrable.