### PR TITLE
Fix Coverage Breaking on Uni V4

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "source": "source .env",
       "allexport": "set -o allexport; source .env; set +o allexport",
       "reinstall": "rm -rf node_modules && rm -f yarn.lock && yarn clean && yarn",
-      "coverage": "forge coverage --ir-minimum --report lcov && node filter_lcov.js && genhtml lcov_filtered.info --output-directory report && open report/index.html",
+      "coverage": "node run_coverage.js",
       "gas": "forge test -vv --gas-report",
       "ftest": "source .env && forge test --gas-price=1500000000",
       "ftest-fork": "source .env && forge test -vvv --fork-url ${ALCHEMY_APIKEY_MUMBAI} --fork-block-number 26702726 --gas-report",

--- a/run_coverage.js
+++ b/run_coverage.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const { exec } = require('child_process');
+
+// Array of files to be ignored during coverage checks
+let filesToIgnore = [
+  'test/V4SwapIntent.t.sol', // Add more files here as needed
+];
+
+// Function to rename a file
+function renameFile(oldName, newName) {
+  return new Promise((resolve, reject) => {
+    fs.rename(oldName, newName, (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+// Function to execute a command
+function executeCommand(command) {
+  return new Promise((resolve, reject) => {
+    exec(command, (error, stdout, stderr) => {
+      if (error) {
+        console.error(`Error: ${error}`);
+        reject(error);
+      }
+      console.log(`stdout: ${stdout}`);
+      console.error(`stderr: ${stderr}`);
+      resolve();
+    });
+  });
+}
+
+// Function to rename files in the ignore list
+async function renameFiles(extensionFrom, extensionTo) {
+  for (let i = 0; i < filesToIgnore.length; i++) {
+    const newName = filesToIgnore[i].replace(extensionFrom, extensionTo);
+    await renameFile(filesToIgnore[i], newName);
+    filesToIgnore[i] = newName; // Update the array with the new file name
+  }
+}
+
+async function runCoverage() {
+  try {
+    // Rename .sol files to .txt
+    await renameFiles('.sol', '.txt');
+
+    // Run coverage command
+    await executeCommand('forge coverage --ir-minimum --report lcov && node filter_lcov.js && genhtml lcov_filtered.info --output-directory report && open report/index.html');
+
+    // Rename .txt files back to .sol
+    await renameFiles('.txt', '.sol');
+  } catch (error) {
+    console.error('An error occurred:', error);
+  }
+}
+
+runCoverage();


### PR DESCRIPTION
Problem: The tests involving Uniswap V4 seem to not compile, specifically during `forge coverage` runs as only the minimum amount of via-IR optimization is used to not disrupt the source code -> bytecode mapping, needed to map test coverage. Because it doesn't compile, no tests or coverage checks can be run at all.

Super hacky solution:

- `npm run coverage` runs a JavaScript `run_coverage.js` script.
- This script contains a list of Solidity files we wish to ignore when checking test coverage. If this happens in more files, we just need to update the array of files at the top of the script. We should keep the Uniswap V4 tests in separate files from the other tests that impact our test coverage.
- The script changes the problematic files to `.txt` files so they aren't compiled.
- Our normal `forge coverage` command is run, and the coverage report is opened in the browser
- The script changes the problematic files back from `.txt` to `.sol` files