### PR TITLE
Mimic bubble up underlying revert error

### DIFF
--- a/src/contracts/atlas/Mimic.sol
+++ b/src/contracts/atlas/Mimic.sol
@@ -47,7 +47,11 @@ contract Mimic {
                 bytes32(uint256(0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee))
             )
         );
-        if (!success) revert();
+        if (!success) {
+            assembly {
+                revert(add(output, 32), mload(output))
+            }
+        }
         return output;
     }
 }


### PR DESCRIPTION
This is needed for:
- The large error switch in `_solverOpWrapper` (Escrow.sol) consistently returns the default `CallReverted` error (since mimic doesn't bubble up the proper error).
- Tests to correctly identify errors (notably in the executionEnvironment tests).