### PR TITLE
Change atlasSolverCall to a low level call

### DIFF
--- a/src/contracts/atlas/ExecutionEnvironment.sol
+++ b/src/contracts/atlas/ExecutionEnvironment.sol
@@ -207,13 +207,15 @@ contract ExecutionEnvironment is Base {
         }
 
         // Execute the solver call.
-        (success,) = ISolverContract(solverOp.solver).atlasSolverCall{ gas: gasLimit, value: solverOp.value }(
+        bytes memory solverCallData = abi.encodeWithSelector(
+            ISolverContract.atlasSolverCall.selector,
             solverOp.from,
             solverOp.bidToken,
             solverOp.bidAmount,
             solverOp.data,
             _config().forwardReturnData() ? dAppReturnData : new bytes(0)
         );
+        (success,) = solverOp.solver.call{ gas: gasLimit, value: solverOp.value }(solverCallData);
 
         // Verify that it was successful
         if (!success) {


### PR DESCRIPTION
Changed this from a regular contract call to a low level call. With the former version, the if `(!success)` could never be reached when the solverOp reverts. The new version is needed for unit tests to properly catch errors.