### PR TITLE
msg value refund to sender on fail

### DIFF
--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -5,6 +5,8 @@ import { IExecutionEnvironment } from "../interfaces/IExecutionEnvironment.sol";
 import { IDAppControl } from "../interfaces/IDAppControl.sol";
 import { IAtlasVerification } from "../interfaces/IAtlasVerification.sol";
 
+import { SafeTransferLib, ERC20 } from "solmate/utils/SafeTransferLib.sol";
+
 import { Escrow } from "./Escrow.sol";
 import { Factory } from "./Factory.sol";
 
@@ -232,6 +234,9 @@ contract Atlas is Escrow, Factory {
                 revert(0, 4)
             }
         }
+
+        // Refund the msg.value to sender if it errored
+        SafeTransferLib.safeTransferETH(msg.sender, msg.value);
     }
 
     function _verifyCallerIsExecutionEnv(address user, address controller, uint32 callConfig) internal view override {

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -81,6 +81,9 @@ contract Atlas is Escrow, Factory {
         } catch (bytes memory revertData) {
             // Bubble up some specific errors
             _handleErrors(bytes4(revertData), dConfig.callConfig);
+
+            // Refund the msg.value to sender if it errored
+            if (msg.value != 0) SafeTransferLib.safeTransferETH(msg.sender, msg.value);
         }
 
         // Release the lock
@@ -234,9 +237,6 @@ contract Atlas is Escrow, Factory {
                 revert(0, 4)
             }
         }
-
-        // Refund the msg.value to sender if it errored
-        SafeTransferLib.safeTransferETH(msg.sender, msg.value);
     }
 
     function _verifyCallerIsExecutionEnv(address user, address controller, uint32 callConfig) internal view override {

--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -3,8 +3,6 @@ pragma solidity 0.8.21;
 
 import { IExecutionEnvironment } from "../interfaces/IExecutionEnvironment.sol";
 
-import { SafeTransferLib, ERC20 } from "solmate/utils/SafeTransferLib.sol";
-
 import "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
 
 import { AtlasVerification } from "./AtlasVerification.sol";


### PR DESCRIPTION
To prevent bundler's msg.value from accumulating on the Atlas contract when UserOps error out but are stored for nonce increments or other reasons. 

There may be other interactions here that we'll have to be careful of - please review thoroughly. 