### PR TITLE
Remove all relative imports

### DIFF
--- a/test/Accounting.t.sol
+++ b/test/Accounting.t.sol
@@ -6,21 +6,21 @@ import "forge-std/Test.sol";
 import { ERC20 } from "solmate/tokens/ERC20.sol";
 
 import { BaseTest } from "./base/BaseTest.t.sol";
-import { TxBuilder } from "../src/contracts/helpers/TxBuilder.sol";
-import { SolverOperation } from "../src/contracts/types/SolverCallTypes.sol";
-import { UserOperation } from "../src/contracts/types/UserCallTypes.sol";
-import { DAppOperation, DAppConfig } from "../src/contracts/types/DAppApprovalTypes.sol";
+import { TxBuilder } from "src/contracts/helpers/TxBuilder.sol";
+import { SolverOperation } from "src/contracts/types/SolverCallTypes.sol";
+import { UserOperation } from "src/contracts/types/UserCallTypes.sol";
+import { DAppOperation, DAppConfig } from "src/contracts/types/DAppApprovalTypes.sol";
 
-import { SafetyBits } from "../src/contracts/libraries/SafetyBits.sol";
-import "../src/contracts/types/LockTypes.sol";
+import { SafetyBits } from "src/contracts/libraries/SafetyBits.sol";
+import "src/contracts/types/LockTypes.sol";
 
 import { TestUtils } from "./base/TestUtils.sol";
 
-import { SwapIntentController, SwapIntent, Condition } from "../src/contracts/examples/intents-example/SwapIntent.sol";
+import { SwapIntentController, SwapIntent, Condition } from "src/contracts/examples/intents-example/SwapIntent.sol";
 
-import { SolverBase } from "../src/contracts/solver/SolverBase.sol";
+import { SolverBase } from "src/contracts/solver/SolverBase.sol";
 
-import { IEscrow } from "../src/contracts/interfaces/IEscrow.sol";
+import { IEscrow } from "src/contracts/interfaces/IEscrow.sol";
 
 contract AccountingTest is BaseTest {
     SwapIntentController public swapIntentController;

--- a/test/DAppIntegration.t.sol
+++ b/test/DAppIntegration.t.sol
@@ -3,12 +3,12 @@ pragma solidity 0.8.21;
 
 import "forge-std/Test.sol";
 
-import { DAppIntegration } from "../src/contracts/atlas/DAppIntegration.sol";
-import { FastLaneErrorsEvents } from "../src/contracts/types/Emissions.sol";
+import { DAppIntegration } from "src/contracts/atlas/DAppIntegration.sol";
+import { FastLaneErrorsEvents } from "src/contracts/types/Emissions.sol";
 
 import { DummyDAppControl, CallConfigBuilder } from "./base/DummyDAppControl.sol";
 
-import "../src/contracts/types/GovernanceTypes.sol";
+import "src/contracts/types/GovernanceTypes.sol";
 
 contract MockDAppIntegration is DAppIntegration {
     constructor(address _atlas) DAppIntegration(_atlas) { }

--- a/test/ExecutionEnvironment.t.sol
+++ b/test/ExecutionEnvironment.t.sol
@@ -4,25 +4,25 @@ pragma solidity 0.8.21;
 import "forge-std/Test.sol";
 import { BaseTest } from "./base/BaseTest.t.sol";
 
-import { ExecutionEnvironment } from "../src/contracts/atlas/ExecutionEnvironment.sol";
-import { DAppControl } from "../src/contracts/dapp/DAppControl.sol";
+import { ExecutionEnvironment } from "src/contracts/atlas/ExecutionEnvironment.sol";
+import { DAppControl } from "src/contracts/dapp/DAppControl.sol";
 
-import { IFactory } from "../src/contracts/interfaces/IFactory.sol";
+import { IFactory } from "src/contracts/interfaces/IFactory.sol";
 
-import { SafetyBits } from "../src/contracts/libraries/SafetyBits.sol";
+import { SafetyBits } from "src/contracts/libraries/SafetyBits.sol";
 
-import { SolverBase } from "../src/contracts/solver/SolverBase.sol";
+import { SolverBase } from "src/contracts/solver/SolverBase.sol";
 
 import { ERC20 } from "solmate/tokens/ERC20.sol";
 
-import { FastLaneErrorsEvents } from "../src/contracts/types/Emissions.sol";
+import { FastLaneErrorsEvents } from "src/contracts/types/Emissions.sol";
 
-import "../src/contracts/types/DAppApprovalTypes.sol";
-import "../src/contracts/types/UserCallTypes.sol";
-import "../src/contracts/types/SolverCallTypes.sol";
-import "../src/contracts/types/LockTypes.sol";
+import "src/contracts/types/DAppApprovalTypes.sol";
+import "src/contracts/types/UserCallTypes.sol";
+import "src/contracts/types/SolverCallTypes.sol";
+import "src/contracts/types/LockTypes.sol";
 
-import "../src/contracts/libraries/CallBits.sol";
+import "src/contracts/libraries/CallBits.sol";
 
 /// @notice ExecutionEnvironmentTest tests deploy ExecutionEnvironment contracts through the factory. Because all calls
 /// are delegated through the mimic contract, the reported coverage is at 0%, but the actual coverage is close to 100%.

--- a/test/Factory.t.sol
+++ b/test/Factory.t.sol
@@ -3,11 +3,11 @@ pragma solidity 0.8.21;
 
 import "forge-std/Test.sol";
 
-import { Factory } from "../src/contracts/atlas/Factory.sol";
+import { Factory } from "src/contracts/atlas/Factory.sol";
 import { ExecutionEnvironment } from "src/contracts/atlas/ExecutionEnvironment.sol";
 import { DummyDAppControl, CallConfigBuilder } from "./base/DummyDAppControl.sol";
 
-import "../src/contracts/types/UserCallTypes.sol";
+import "src/contracts/types/UserCallTypes.sol";
 
 import "./base/TestUtils.sol";
 

--- a/test/MainTest.t.sol
+++ b/test/MainTest.t.sol
@@ -3,21 +3,21 @@ pragma solidity 0.8.21;
 
 import { SafeTransferLib, ERC20 } from "solmate/utils/SafeTransferLib.sol";
 
-import { IDAppIntegration } from "../src/contracts/interfaces/IDAppIntegration.sol";
-import { IExecutionEnvironment } from "../src/contracts/interfaces/IExecutionEnvironment.sol";
+import { IDAppIntegration } from "src/contracts/interfaces/IDAppIntegration.sol";
+import { IExecutionEnvironment } from "src/contracts/interfaces/IExecutionEnvironment.sol";
 
-import { Atlas } from "../src/contracts/atlas/Atlas.sol";
-import { Mimic } from "../src/contracts/atlas/Mimic.sol";
+import { Atlas } from "src/contracts/atlas/Atlas.sol";
+import { Mimic } from "src/contracts/atlas/Mimic.sol";
 
-import { V2DAppControl } from "../src/contracts/examples/v2-example/V2DAppControl.sol";
+import { V2DAppControl } from "src/contracts/examples/v2-example/V2DAppControl.sol";
 
 import { Solver } from "src/contracts/solver/src/TestSolver.sol";
 
-import "../src/contracts/types/UserCallTypes.sol";
-import "../src/contracts/types/SolverCallTypes.sol";
-import "../src/contracts/types/EscrowTypes.sol";
-import "../src/contracts/types/LockTypes.sol";
-import "../src/contracts/types/DAppApprovalTypes.sol";
+import "src/contracts/types/UserCallTypes.sol";
+import "src/contracts/types/SolverCallTypes.sol";
+import "src/contracts/types/EscrowTypes.sol";
+import "src/contracts/types/LockTypes.sol";
+import "src/contracts/types/DAppApprovalTypes.sol";
 
 import { BaseTest } from "./base/BaseTest.t.sol";
 import { V2Helper } from "./V2Helper.sol";

--- a/test/Permit69.t.sol
+++ b/test/Permit69.t.sol
@@ -8,15 +8,15 @@ import { ERC20 } from "solmate/tokens/ERC20.sol";
 import { BaseTest } from "./base/BaseTest.t.sol";
 import "./base/TestUtils.sol";
 
-import { Permit69 } from "../src/contracts/common/Permit69.sol";
-import { Mimic } from "../src/contracts/atlas/Mimic.sol";
+import { Permit69 } from "src/contracts/common/Permit69.sol";
+import { Mimic } from "src/contracts/atlas/Mimic.sol";
 
-import { EXECUTION_PHASE_OFFSET } from "../src/contracts/libraries/SafetyBits.sol";
-import { SAFE_USER_TRANSFER, SAFE_DAPP_TRANSFER } from "../src/contracts/common/Permit69.sol";
+import { EXECUTION_PHASE_OFFSET } from "src/contracts/libraries/SafetyBits.sol";
+import { SAFE_USER_TRANSFER, SAFE_DAPP_TRANSFER } from "src/contracts/common/Permit69.sol";
 
-import { FastLaneErrorsEvents } from "../src/contracts/types/Emissions.sol";
+import { FastLaneErrorsEvents } from "src/contracts/types/Emissions.sol";
 
-import "../src/contracts/types/LockTypes.sol";
+import "src/contracts/types/LockTypes.sol";
 
 contract Permit69Test is BaseTest {
     uint16 constant EXEC_PHASE_PRE_OPS = uint16(1 << (EXECUTION_PHASE_OFFSET + uint16(ExecutionPhase.PreOps)));

--- a/test/SafetyLocks.t.sol
+++ b/test/SafetyLocks.t.sol
@@ -3,11 +3,11 @@ pragma solidity 0.8.21;
 
 import "forge-std/Test.sol";
 
-import { SafetyLocks } from "../src/contracts/atlas/SafetyLocks.sol";
-import { FastLaneErrorsEvents } from "../src/contracts/types/Emissions.sol";
+import { SafetyLocks } from "src/contracts/atlas/SafetyLocks.sol";
+import { FastLaneErrorsEvents } from "src/contracts/types/Emissions.sol";
 
-import "../src/contracts/types/DAppApprovalTypes.sol";
-import "../src/contracts/types/LockTypes.sol";
+import "src/contracts/types/DAppApprovalTypes.sol";
+import "src/contracts/types/LockTypes.sol";
 
 contract MockSafetyLocks is SafetyLocks {
     constructor() SafetyLocks(0, address(0), address(0)) { }

--- a/test/SwapIntent.t.sol
+++ b/test/SwapIntent.t.sol
@@ -6,14 +6,14 @@ import "forge-std/Test.sol";
 import { ERC20 } from "solmate/tokens/ERC20.sol";
 
 import { BaseTest } from "./base/BaseTest.t.sol";
-import { TxBuilder } from "../src/contracts/helpers/TxBuilder.sol";
+import { TxBuilder } from "src/contracts/helpers/TxBuilder.sol";
 
-import { SolverOperation } from "../src/contracts/types/SolverCallTypes.sol";
-import { UserOperation } from "../src/contracts/types/UserCallTypes.sol";
-import { DAppOperation, DAppConfig } from "../src/contracts/types/DAppApprovalTypes.sol";
+import { SolverOperation } from "src/contracts/types/SolverCallTypes.sol";
+import { UserOperation } from "src/contracts/types/UserCallTypes.sol";
+import { DAppOperation, DAppConfig } from "src/contracts/types/DAppApprovalTypes.sol";
 
-import { SwapIntentController, SwapIntent, Condition } from "../src/contracts/examples/intents-example/SwapIntent.sol";
-import { SolverBase } from "../src/contracts/solver/SolverBase.sol";
+import { SwapIntentController, SwapIntent, Condition } from "src/contracts/examples/intents-example/SwapIntent.sol";
+import { SolverBase } from "src/contracts/solver/SolverBase.sol";
 
 interface IUniV2Router02 {
     function swapExactTokensForTokens(

--- a/test/V2Helper.sol
+++ b/test/V2Helper.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
-import { TxBuilder } from "../src/contracts/helpers/TxBuilder.sol";
+import { TxBuilder } from "src/contracts/helpers/TxBuilder.sol";
 
-import { IUniswapV2Pair } from "../src/contracts/examples/v2-example/interfaces/IUniswapV2Pair.sol";
+import { IUniswapV2Pair } from "src/contracts/examples/v2-example/interfaces/IUniswapV2Pair.sol";
 
 import { BlindBackrun } from "src/contracts/solver/src/BlindBackrun/BlindBackrun.sol";
 
-import "../src/contracts/types/SolverCallTypes.sol";
-import "../src/contracts/types/UserCallTypes.sol";
-import "../src/contracts/types/DAppApprovalTypes.sol";
-import "../src/contracts/types/EscrowTypes.sol";
-import "../src/contracts/types/LockTypes.sol";
-import "../src/contracts/types/DAppApprovalTypes.sol";
+import "src/contracts/types/SolverCallTypes.sol";
+import "src/contracts/types/UserCallTypes.sol";
+import "src/contracts/types/DAppApprovalTypes.sol";
+import "src/contracts/types/EscrowTypes.sol";
+import "src/contracts/types/LockTypes.sol";
+import "src/contracts/types/DAppApprovalTypes.sol";
 
 import { TestConstants } from "./base/TestConstants.sol";
 

--- a/test/V4SwapIntent.t.sol
+++ b/test/V4SwapIntent.t.sol
@@ -6,18 +6,18 @@ import "forge-std/Test.sol";
 import { ERC20 } from "solmate/tokens/ERC20.sol";
 
 import { BaseTest } from "./base/BaseTest.t.sol";
-import { TxBuilder } from "../src/contracts/helpers/TxBuilder.sol";
+import { TxBuilder } from "src/contracts/helpers/TxBuilder.sol";
 
-import { SolverOperation } from "../src/contracts/types/SolverCallTypes.sol";
-import { UserOperation } from "../src/contracts/types/UserCallTypes.sol";
-import { DAppOperation, DAppConfig } from "../src/contracts/types/DAppApprovalTypes.sol";
+import { SolverOperation } from "src/contracts/types/SolverCallTypes.sol";
+import { UserOperation } from "src/contracts/types/UserCallTypes.sol";
+import { DAppOperation, DAppConfig } from "src/contracts/types/DAppApprovalTypes.sol";
 
 import { UserOperationBuilder } from "./base/builders/UserOperationBuilder.sol";
 import { SolverOperationBuilder } from "./base/builders/SolverOperationBuilder.sol";
 import { DAppOperationBuilder } from "./base/builders/DAppOperationBuilder.sol";
 
-import { V4SwapIntentController, SwapData } from "../src/contracts/examples/intents-example/V4SwapIntent.sol";
-import { SolverBase } from "../src/contracts/solver/SolverBase.sol";
+import { V4SwapIntentController, SwapData } from "src/contracts/examples/intents-example/V4SwapIntent.sol";
+import { SolverBase } from "src/contracts/solver/SolverBase.sol";
 
 import { PoolManager, IPoolManager, PoolKey, Currency, IHooks } from "v4-core/PoolManager.sol";
 

--- a/test/base/DummyDAppControl.sol
+++ b/test/base/DummyDAppControl.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
-import { DAppControl } from "../../src/contracts/dapp/DAppControl.sol";
+import { DAppControl } from "src/contracts/dapp/DAppControl.sol";
 
-import "../../src/contracts/types/DAppApprovalTypes.sol";
-import "../../src/contracts/types/UserCallTypes.sol";
-import "../../src/contracts/types/SolverCallTypes.sol";
+import "src/contracts/types/DAppApprovalTypes.sol";
+import "src/contracts/types/UserCallTypes.sol";
+import "src/contracts/types/SolverCallTypes.sol";
 
 contract DummyDAppControl is DAppControl {
     constructor(

--- a/test/base/TestConstants.sol
+++ b/test/base/TestConstants.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.21;
 
 import { ERC20 } from "solmate/tokens/ERC20.sol";
 
-import { IUniswapV2Pair } from "../../src/contracts/examples/v2-example/interfaces/IUniswapV2Pair.sol";
+import { IUniswapV2Pair } from "src/contracts/examples/v2-example/interfaces/IUniswapV2Pair.sol";
 
 contract TestConstants {
     uint256 public constant BLOCK_START = 17_441_786;

--- a/test/base/TestUtils.sol
+++ b/test/base/TestUtils.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
-import { IDAppControl } from "../../src/contracts/interfaces/IDAppControl.sol";
-import { Mimic } from "../../src/contracts/atlas/Mimic.sol";
+import { IDAppControl } from "src/contracts/interfaces/IDAppControl.sol";
+import { Mimic } from "src/contracts/atlas/Mimic.sol";
 
-import "../../src/contracts/types/UserCallTypes.sol";
-import "../../src/contracts/types/SolverCallTypes.sol";
-import "../../src/contracts/types/DAppApprovalTypes.sol";
+import "src/contracts/types/UserCallTypes.sol";
+import "src/contracts/types/SolverCallTypes.sol";
+import "src/contracts/types/DAppApprovalTypes.sol";
 
 library TestUtils {
     // String <> uint16 binary Converter Utility

--- a/test/base/builders/DAppOperationBuilder.sol
+++ b/test/base/builders/DAppOperationBuilder.sol
@@ -3,16 +3,16 @@ pragma solidity 0.8.21;
 
 import "forge-std/Test.sol";
 
-import { UserOperation } from "../../../src/contracts/types/UserCallTypes.sol";
-import { SolverOperation } from "../../../src/contracts/types/SolverCallTypes.sol";
-import { DAppOperation } from "../../../src/contracts/types/DAppApprovalTypes.sol";
+import { UserOperation } from "src/contracts/types/UserCallTypes.sol";
+import { SolverOperation } from "src/contracts/types/SolverCallTypes.sol";
+import { DAppOperation } from "src/contracts/types/DAppApprovalTypes.sol";
 
-import { CallVerification } from "../../../src/contracts/libraries/CallVerification.sol";
+import { CallVerification } from "src/contracts/libraries/CallVerification.sol";
 
-import { IDAppControl } from "../../../src/contracts/interfaces/IDAppControl.sol";
-import { IAtlasVerification } from "../../../src/contracts/interfaces/IAtlasVerification.sol";
+import { IDAppControl } from "src/contracts/interfaces/IDAppControl.sol";
+import { IAtlasVerification } from "src/contracts/interfaces/IAtlasVerification.sol";
 
-import "../../../src/contracts/types/DAppApprovalTypes.sol";
+import "src/contracts/types/DAppApprovalTypes.sol";
 
 contract DAppOperationBuilder is Test {
     using CallVerification for UserOperation;

--- a/test/base/builders/SolverOperationBuilder.sol
+++ b/test/base/builders/SolverOperationBuilder.sol
@@ -3,13 +3,13 @@ pragma solidity 0.8.21;
 
 import "forge-std/Test.sol";
 
-import { UserOperation } from "../../../src/contracts/types/UserCallTypes.sol";
-import { SolverOperation } from "../../../src/contracts/types/SolverCallTypes.sol";
+import { UserOperation } from "src/contracts/types/UserCallTypes.sol";
+import { SolverOperation } from "src/contracts/types/SolverCallTypes.sol";
 
-import { CallVerification } from "../../../src/contracts/libraries/CallVerification.sol";
+import { CallVerification } from "src/contracts/libraries/CallVerification.sol";
 
-import { IAtlasVerification } from "../../../src/contracts/interfaces/IAtlasVerification.sol";
-import { IDAppControl } from "../../../src/contracts/interfaces/IDAppControl.sol";
+import { IAtlasVerification } from "src/contracts/interfaces/IAtlasVerification.sol";
+import { IDAppControl } from "src/contracts/interfaces/IDAppControl.sol";
 
 contract SolverOperationBuilder is Test {
     using CallVerification for UserOperation;

--- a/test/base/builders/UserOperationBuilder.sol
+++ b/test/base/builders/UserOperationBuilder.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.21;
 
 import "forge-std/Test.sol";
 
-import { UserOperation } from "../../../src/contracts/types/UserCallTypes.sol";
+import { UserOperation } from "src/contracts/types/UserCallTypes.sol";
 
-import { IAtlasVerification } from "../../../src/contracts/interfaces/IAtlasVerification.sol";
+import { IAtlasVerification } from "src/contracts/interfaces/IAtlasVerification.sol";
 
 contract UserOperationBuilder is Test {
     UserOperation userOperation;

--- a/test/helpers/CallConfigBuilder.sol
+++ b/test/helpers/CallConfigBuilder.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
-import { CallConfig } from "../../src/contracts/types/DAppApprovalTypes.sol";
+import { CallConfig } from "src/contracts/types/DAppApprovalTypes.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/helpers/DummyDAppControlBuilder.sol
+++ b/test/helpers/DummyDAppControlBuilder.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.21;
 
 import { DummyDAppControl } from "../base/DummyDAppControl.sol";
-import { CallConfig } from "../../src/contracts/types/DAppApprovalTypes.sol";
-import { AtlasVerification } from "../../src/contracts/atlas/AtlasVerification.sol";
+import { CallConfig } from "src/contracts/types/DAppApprovalTypes.sol";
+import { AtlasVerification } from "src/contracts/atlas/AtlasVerification.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/libraries/CallBits.t.sol
+++ b/test/libraries/CallBits.t.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.21;
 
 import "forge-std/Test.sol";
 
-import { CallBits } from "../../src/contracts/libraries/CallBits.sol";
-import "../../src/contracts/types/UserCallTypes.sol";
+import { CallBits } from "src/contracts/libraries/CallBits.sol";
+import "src/contracts/types/UserCallTypes.sol";
 import "../base/TestUtils.sol";
 
 contract CallBitsTest is Test {

--- a/test/libraries/CallVerification.t.sol
+++ b/test/libraries/CallVerification.t.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.21;
 
 import "forge-std/Test.sol";
 
-import { CallVerification } from "../../src/contracts/libraries/CallVerification.sol";
-import "../../src/contracts/types/UserCallTypes.sol";
+import { CallVerification } from "src/contracts/libraries/CallVerification.sol";
+import "src/contracts/types/UserCallTypes.sol";
 import "../base/TestUtils.sol";
 
 contract CallVerificationTest is Test {

--- a/test/libraries/EscrowBits.t.sol
+++ b/test/libraries/EscrowBits.t.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.21;
 
 import "forge-std/Test.sol";
 
-import { EscrowBits } from "../../src/contracts/libraries/EscrowBits.sol";
-import "../../src/contracts/types/EscrowTypes.sol";
+import { EscrowBits } from "src/contracts/libraries/EscrowBits.sol";
+import "src/contracts/types/EscrowTypes.sol";
 import "../base/TestUtils.sol";
 
 contract EscrowBitsTest is Test {

--- a/test/libraries/SafetyBits.t.sol
+++ b/test/libraries/SafetyBits.t.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.21;
 
 import "forge-std/Test.sol";
 
-import { SafetyBits } from "../../src/contracts/libraries/SafetyBits.sol";
-import "../../src/contracts/types/LockTypes.sol";
+import { SafetyBits } from "src/contracts/libraries/SafetyBits.sol";
+import "src/contracts/types/LockTypes.sol";
 import "../base/TestUtils.sol";
 
 contract SafetyBitsTest is Test {


### PR DESCRIPTION
Sometimes relative imports (i.e. `../../src/contracts/Atlas.sol` as opposed to `src/contracts/Atlas.sol`) cause issues with the compilation process in Foundry, requiring re-compiling all Solidity files, even when no changes have been made since the last compilation.

I suggest we standardize our imports in smart contracts (that contain `src` in the import path - if it doesn't contain `src` it doesn't seem to cause an issue) to rather use the absolute path structure of `src/contracts/Xyz.sol`. Thoughts?