### PR TITLE
Verification Nonce Math and Test Fixes

### DIFF
--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -17,6 +17,7 @@ import { EscrowBits } from "../libraries/EscrowBits.sol";
 import { CallVerification } from "../libraries/CallVerification.sol";
 
 import { DAppIntegration } from "./DAppIntegration.sol";
+import { FastLaneErrorsEvents } from "../types/Emissions.sol";
 
 import "forge-std/Test.sol"; // TODO remove
 
@@ -33,6 +34,9 @@ contract AtlasVerification is EIP712, DAppIntegration {
     using CallBits for uint32;
     using CallVerification for UserOperation;
 
+    uint256 internal constant FULL_BITMAP = uint256(0x0000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
+    uint256 internal constant FIRST_16_BITS_FULL = uint256(0xFFFF);
+    uint256 internal constant FIRST_4_BITS_FULL = uint256(0xF);
     uint8 internal constant MAX_SOLVERS = type(uint8).max - 2;
 
     error InvalidCaller();
@@ -270,12 +274,12 @@ contract AtlasVerification is EIP712, DAppIntegration {
         if (!signatories[keccak256(abi.encode(govData.governance, dAppOp.control, dAppOp.from))]) {
             bool bypassSignatoryCheck = isSimulation && dAppOp.from == address(0);
             if (!bypassSignatoryCheck) {
-                return (false);
+                return false;
             }
         }
 
         if (dAppOp.control != dConfig.to) {
-            return (false);
+            return false;
         }
 
         // NOTE: This check does not work if DAppControl is a proxy contract.
@@ -283,7 +287,13 @@ contract AtlasVerification is EIP712, DAppIntegration {
         // former employees, or beneficiary uncertainty during intra-DAO conflict,
         // governance should refrain from using a proxy contract for DAppControl.
         if (dConfig.to.codehash == bytes32(0)) {
-            return (false);
+            return false;
+        }
+
+        // If dAppOp.from is left blank and sim = true,
+        // implies a simUserOp call, so dapp nonce check is skipped.
+        if (dAppOp.from == address(0) && isSimulation) {
+            return true;
         }
 
         // If the dapp indicated that they only accept sequenced nonces
@@ -291,148 +301,96 @@ contract AtlasVerification is EIP712, DAppIntegration {
         // NOTE: allowing only sequenced nonces could create a scenario in
         // which builders or validators may be able to profit via censorship.
         // DApps are encouraged to rely on the deadline parameter.
-        if (!_handleNonces(dAppOp.from, dAppOp.nonce, !dConfig.callConfig.needsSequencedNonces(), isSimulation)) {
-            return (false);
+        if (!_handleNonces(dAppOp.from, dAppOp.nonce, !dConfig.callConfig.needsSequencedDAppNonces(), isSimulation)) {
+            return false;
         }
 
-        return (true);
+        return true;
     }
 
-    function _handleNonces(
-        address account,
-        uint256 nonce,
-        bool async,
-        bool isSimulation
-    )
-        internal
-        returns (bool validNonce)
-    {
-        console.log("account:", account);
-        console.log("nonce:", nonce);
-        console.log("async:", async);
-        console.log("isSimulation:", isSimulation);
-
+    // Returns true if nonce is valid, otherwise returns false
+    function _handleNonces(address account, uint256 nonce, bool async, bool isSimulation) internal returns (bool) {
         if (nonce > type(uint128).max - 1) {
             return false;
         }
 
-        if (!isSimulation) {
-            if (nonce == 0) {
-                // Allow 0 nonce for simulations to avoid unnecessary init txs
+        // 0 Nonces are not allowed. Nonces start at 1 for both sequenced and async.
+        if (nonce == 0) return false;
+
+        NonceTracker memory nonceTracker = nonceTrackers[account];
+
+        if (!async) {
+            // SEQUENTIAL NONCES
+
+            // Nonces must increase by 1 if sequential
+            if (nonce != nonceTracker.lastUsedSeqNonce + 1) return false;
+
+            // Return true here if simulation to avoid storing nonce updates
+            if (isSimulation) return true;
+
+            ++nonceTracker.lastUsedSeqNonce;
+        } else {
+            // ASYNC NONCES
+
+            uint256 bitmapIndex = ((nonce - 1) / 240) + 1; // +1 because highestFullBitmap initializes at 0
+            uint256 bitmapNonce = ((nonce - 1) % 240); // 1 -> 0, 240 -> 239. Needed for shifts in bitmap.
+
+            bytes32 bitmapKey = keccak256(abi.encode(account, bitmapIndex));
+            NonceBitmap memory nonceBitmap = nonceBitmaps[bitmapKey];
+            uint256 bitmap = uint256(nonceBitmap.bitmap);
+
+            // Check if nonce has already been used
+            if (_nonceUsedInBitmap(bitmap, bitmapNonce)) {
                 return false;
-            } else if (nonce == 1) {
-                // Check if nonce needs to be initialized - do so if necessary.
-                _initializeNonce(account);
             }
+
+            // Return true here if simulation to avoid storing nonce updates
+            if (isSimulation) return true;
+
+            // Mark nonce as used in bitmap
+            bitmap |= 1 << bitmapNonce;
+            nonceBitmap.bitmap = uint240(bitmap);
+
+            // Update highestUsedNonce if necessary.
+            // Add 1 back to bitmapNonce: 1 -> 1, 240 -> 240. As opposed to the shift form used above.
+            if (bitmapNonce + 1 > uint256(nonceBitmap.highestUsedNonce)) {
+                nonceBitmap.highestUsedNonce = uint8(bitmapNonce + 1);
+            }
+
+            // Mark bitmap as full if necessary
+            if (bitmap == FULL_BITMAP) {
+                // Update highestFullAsyncBitmap if necessary
+                if (bitmapIndex == nonceTracker.highestFullAsyncBitmap + 1) {
+                    nonceTracker = _incrementHighestFullAsyncBitmap(nonceTracker, account);
+                }
+            }
+
+            nonceBitmaps[bitmapKey] = nonceBitmap;
         }
 
-        uint256 bitmapIndex = (nonce / 240) + 1; // +1 because highestFullBitmap initializes at 0
-        uint256 bitmapNonce = (nonce % 240) + 1;
-
-        console.log("bitmapIndex:", bitmapIndex);
-        console.log("bitmapNonce:", bitmapNonce);
-
-        bytes32 bitmapKey = keccak256(abi.encode(account, bitmapIndex));
-
-        NonceBitmap memory nonceBitmap = asyncNonceBitmap[bitmapKey];
-
-        uint256 bitmap = uint256(nonceBitmap.bitmap);
-        // Check if the nonce has already been used
-        if (bitmap & (1 << bitmapNonce) != 0) {
-            return false;
-        }
-
-        if (isSimulation) {
-            // return early if simulation to avoid storing nonce updates
-            return true;
-        }
-
-        if (bitmap == 0) {
-            // Current bitmap is empty, but about to be used.
-            // So increment lowest empty bitmap index to the next one
-            console.log("bitmap == 0:", bitmapIndex + 1);
-            console.log("Updating lowestEmptyBitmap from", asyncNonceBitIndex[account].LowestEmptyBitmap);
-            console.log("to", bitmapIndex + 1);
-
-            asyncNonceBitIndex[account].LowestEmptyBitmap = uint128(bitmapIndex + 1);
-        }
-
-        // TODO check if caching this shifted nonce in a var is cheaper - already done above
-        // Update the bitmap to reflect the nonce has been used
-        bitmap |= 1 << bitmapNonce;
-        nonceBitmap.bitmap = uint240(bitmap);
-
-        uint256 highestUsedBitmapNonce = uint256(nonceBitmap.highestUsedNonce);
-        if (bitmapNonce > highestUsedBitmapNonce) {
-            nonceBitmap.highestUsedNonce = uint8(bitmapNonce);
-        }
-
-        // Update the nonceBitmap
-        asyncNonceBitmap[bitmapKey] = nonceBitmap;
-
-        // Update the nonce tracker
-        return _updateNonceTracker(account, highestUsedBitmapNonce, bitmapIndex, bitmapNonce, async);
+        nonceTrackers[account] = nonceTracker;
+        return true;
     }
 
-    function _updateNonceTracker(
-        address account,
-        uint256 highestUsedBitmapNonce,
-        uint256 bitmapIndex,
-        uint256 bitmapNonce,
-        bool async
+    function _incrementHighestFullAsyncBitmap(
+        NonceTracker memory nonceTracker,
+        address account
     )
         internal
-        returns (bool)
+        view
+        returns (NonceTracker memory)
     {
-        NonceTracker memory nonceTracker = asyncNonceBitIndex[account];
-
-        uint256 highestFullBitmap = uint256(nonceTracker.HighestFullBitmap);
-        uint256 lowestEmptyBitmap = uint256(nonceTracker.LowestEmptyBitmap);
-
-        console.log("highestFullBitmap:", highestFullBitmap);
-        console.log("lowestEmptyBitmap:", lowestEmptyBitmap);
-
-        // Handle sequential nonce logic
-        if (!async) {
-            // TODO remove this completely if working
-            if (bitmapIndex != highestFullBitmap + 1) {
-                console.log("FALSE 1: bitmapIndex != highestFullBitmap + 1");
-                return false;
+        uint256 bitmap;
+        do {
+            unchecked {
+                ++nonceTracker.highestFullAsyncBitmap;
             }
+            uint256 bitmapIndex = uint256(nonceTracker.highestFullAsyncBitmap) + 1;
+            bytes32 bitmapKey = keccak256(abi.encode(account, bitmapIndex));
+            bitmap = uint256(nonceBitmaps[bitmapKey].bitmap);
+        } while (bitmap == FULL_BITMAP);
 
-            if (bitmapNonce != highestUsedBitmapNonce + 1) {
-                console.log("FALSE 2: bitmapNonce != highestUsedBitmapNonce + 1");
-                return false;
-            }
-        }
-
-        if (bitmapNonce > 239 || !async) {
-            bool updateTracker;
-
-            // Prev working version:
-            // if (bitmapIndex > highestFullBitmap + 1) {
-            //     updateTracker = true;
-            //     highestFullBitmap = bitmapIndex - 1;
-            // }
-
-            if (bitmapIndex > highestFullBitmap) {
-                updateTracker = true;
-                highestFullBitmap = bitmapIndex;
-            }
-
-            if (bitmapIndex + 2 > lowestEmptyBitmap) {
-                updateTracker = true;
-                lowestEmptyBitmap = (lowestEmptyBitmap > bitmapIndex ? lowestEmptyBitmap + 1 : bitmapIndex + 2);
-            }
-
-            if (updateTracker) {
-                asyncNonceBitIndex[account] = NonceTracker({
-                    HighestFullBitmap: uint128(highestFullBitmap),
-                    LowestEmptyBitmap: uint128(lowestEmptyBitmap)
-                });
-            }
-        }
-        return true;
+        return nonceTracker;
     }
 
     function _getProofHash(DAppOperation memory approval) internal pure returns (bytes32 proofHash) {
@@ -501,7 +459,7 @@ contract AtlasVerification is EIP712, DAppIntegration {
         // which builders or validators may be able to profit via censorship.
         // DApps are encouraged to rely on the deadline parameter
         // to prevent replay attacks.
-        if (!_handleNonces(userOp.from, userOp.nonce, !dConfig.callConfig.needsSequencedNonces(), isSimulation)) {
+        if (!_handleNonces(userOp.from, userOp.nonce, !dConfig.callConfig.needsSequencedUserNonces(), isSimulation)) {
             return false;
         }
 
@@ -537,22 +495,86 @@ contract AtlasVerification is EIP712, DAppIntegration {
         payload = _hashTypedDataV4(_getProofHash(userOp));
     }
 
-    function getNextNonce(address account) external view returns (uint256 nextNonce) {
-        NonceTracker memory nonceTracker = asyncNonceBitIndex[account];
+    // Returns the next nonce for the given account, in sequential or async mode
+    function getNextNonce(address account, bool sequenced) external view returns (uint256) {
+        NonceTracker memory nonceTracker = nonceTrackers[account];
 
-        uint256 nextBitmapIndex = uint256(nonceTracker.HighestFullBitmap) + 1;
-        uint256 lowestEmptyBitmap = uint256(nonceTracker.LowestEmptyBitmap);
+        if (sequenced) {
+            return nonceTracker.lastUsedSeqNonce + 1;
+        } else {
+            uint256 n;
+            uint256 bitmap256;
+            do {
+                unchecked {
+                    ++n;
+                }
+                // Async bitmaps start at index 1. I.e. accounts start with bitmap 0 = HighestFullAsyncBitmap
+                bytes32 bitmapKey = keccak256(abi.encode(account, nonceTracker.highestFullAsyncBitmap + n));
+                NonceBitmap memory nonceBitmap = nonceBitmaps[bitmapKey];
+                bitmap256 = uint256(nonceBitmap.bitmap);
+            } while (bitmap256 == FULL_BITMAP);
 
-        if (lowestEmptyBitmap == 0) {
-            return 1; // uninitialized
+            uint256 remainder = _getFirstUnusedNonceInBitmap(bitmap256);
+            return ((nonceTracker.highestFullAsyncBitmap + n - 1) * 240) + remainder;
+        }
+    }
+
+    // Call if highestFullAsyncBitmap doesn't reflect real full bitmap of an account
+    function manuallyUpdateNonceTracker(address account) external {
+        if (msg.sender != account) revert FastLaneErrorsEvents.OnlyAccount();
+
+        NonceTracker memory nonceTracker = nonceTrackers[account];
+        NonceBitmap memory nonceBitmap;
+
+        // Checks the next 10 bitmaps for a higher full bitmap
+        uint128 nonceIndexToCheck = nonceTracker.highestFullAsyncBitmap + 10;
+        for (; nonceIndexToCheck > nonceTracker.highestFullAsyncBitmap; nonceIndexToCheck--) {
+            bytes32 bitmapKey = keccak256(abi.encode(account, nonceIndexToCheck));
+            nonceBitmap = nonceBitmaps[bitmapKey];
+
+            if (nonceBitmap.bitmap == FULL_BITMAP) {
+                nonceTracker.highestFullAsyncBitmap = nonceIndexToCheck;
+                break;
+            }
         }
 
-        bytes32 bitmapKey = keccak256(abi.encode(account, nextBitmapIndex));
+        nonceTrackers[account] = nonceTracker;
+    }
 
-        NonceBitmap memory nonceBitmap = asyncNonceBitmap[bitmapKey];
+    // Only accurate for nonces 1 - 240 within a 256-bit bitmap
+    function _nonceUsedInBitmap(uint256 bitmap, uint256 nonce) internal pure returns (bool) {
+        return (bitmap & (1 << nonce)) != 0;
+    }
 
-        uint256 highestUsedNonce = uint256(nonceBitmap.highestUsedNonce); //  has a +1 offset
+    // Returns the first unused nonce in the given bitmap.
+    // Returned nonce is 1-indexed. If 0 returned, bitmap is full.
+    function _getFirstUnusedNonceInBitmap(uint256 bitmap) internal pure returns (uint256) {
+        // Check the 240-bit bitmap, 16 bits at a time, if a 16 bit chunk is not full.
+        // Then check the located 16-bit chunk, 4 bits at a time, for an unused 4-bit chunk.
+        // Then loop normally from the start of the 4-bit chunk to find the first unused bit.
 
-        nextNonce = ((nextBitmapIndex - 1) * 240) + highestUsedNonce;
+        for (uint256 i = 0; i < 240; i += 16) {
+            // Isolate the next 16 bits to check
+            uint256 chunk16 = (bitmap >> i) & FIRST_16_BITS_FULL;
+            // Find non-full 16-bit chunk
+            if (chunk16 != FIRST_16_BITS_FULL) {
+                for (uint256 j = 0; j < 16; j += 4) {
+                    // Isolate the next 4 bits within the 16-bit chunk to check
+                    uint256 chunk4 = (chunk16 >> j) & FIRST_4_BITS_FULL;
+                    // Find non-full 4-bit chunk
+                    if (chunk4 != FIRST_4_BITS_FULL) {
+                        for (uint256 k = 0; k < 4; k++) {
+                            // Find first unused bit
+                            if ((chunk4 >> k) & 0x1 == 0) {
+                                // Returns 1-indexed nonce
+                                return i + j + k + 1;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return 0;
     }
 }

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -291,7 +291,7 @@ contract AtlasVerification is EIP712, DAppIntegration {
         // NOTE: allowing only sequenced nonces could create a scenario in
         // which builders or validators may be able to profit via censorship.
         // DApps are encouraged to rely on the deadline parameter.
-        if (!_handleNonces(dAppOp.from, dAppOp.nonce, dConfig.callConfig.needsSequencedNonces(), isSimulation)) {
+        if (!_handleNonces(dAppOp.from, dAppOp.nonce, !dConfig.callConfig.needsSequencedNonces(), isSimulation)) {
             return (false);
         }
 
@@ -379,12 +379,12 @@ contract AtlasVerification is EIP712, DAppIntegration {
             }
         }
 
-        if (bitmapNonce > uint256(239) || !async) {
+        if (bitmapNonce > 239 || !async) {
             bool updateTracker;
 
-            if (bitmapIndex > highestFullBitmap) {
+            if (bitmapIndex > highestFullBitmap + 1) {
                 updateTracker = true;
-                highestFullBitmap = bitmapIndex;
+                highestFullBitmap = bitmapIndex - 1;
             }
 
             if (bitmapIndex + 2 > lowestEmptyBitmap) {
@@ -425,7 +425,6 @@ contract AtlasVerification is EIP712, DAppIntegration {
         address signer = _hashTypedDataV4(_getProofHash(dAppOp)).recover(dAppOp.signature);
 
         return signer == dAppOp.from;
-        // return true;
     }
 
     function getDAppOperationPayload(DAppOperation memory dAppOp) public view returns (bytes32 payload) {
@@ -469,7 +468,7 @@ contract AtlasVerification is EIP712, DAppIntegration {
         // which builders or validators may be able to profit via censorship.
         // DApps are encouraged to rely on the deadline parameter
         // to prevent replay attacks.
-        if (!_handleNonces(userOp.from, userOp.nonce, dConfig.callConfig.needsSequencedNonces(), isSimulation)) {
+        if (!_handleNonces(userOp.from, userOp.nonce, !dConfig.callConfig.needsSequencedNonces(), isSimulation)) {
             return false;
         }
 

--- a/src/contracts/atlas/DAppIntegration.sol
+++ b/src/contracts/atlas/DAppIntegration.sol
@@ -9,6 +9,8 @@ import "../types/GovernanceTypes.sol";
 
 import { FastLaneErrorsEvents } from "../types/Emissions.sol";
 
+import "forge-std/Test.sol"; // TODO remove
+
 contract DAppIntegration {
     using CallBits for uint32;
 

--- a/src/contracts/atlas/DAppIntegration.sol
+++ b/src/contracts/atlas/DAppIntegration.sol
@@ -24,17 +24,17 @@ contract DAppIntegration {
     }
 
     struct NonceTracker {
-        uint128 LowestEmptyBitmap;
-        uint128 HighestFullBitmap;
+        uint128 lastUsedSeqNonce; // Sequenced nonces tracked using only this value
+        uint128 highestFullAsyncBitmap; // Async nonces tracked using bitmaps
     }
 
     address public immutable ATLAS;
 
-    //     from         nonceTracker
-    mapping(address => NonceTracker) public asyncNonceBitIndex;
+    // from => nonceTracker
+    mapping(address => NonceTracker) public nonceTrackers;
 
-    //  keccak256(from, bitmapNonceIndex) => to
-    mapping(bytes32 => NonceBitmap) public asyncNonceBitmap;
+    // keccak256(from, bitmapNonceIndex) => nonceBitmap
+    mapping(bytes32 => NonceBitmap) public nonceBitmaps;
 
     // NOTE: To prevent builder censorship, dapp nonces can be
     // processed in any order so long as they arent duplicated and
@@ -67,8 +67,6 @@ contract DAppIntegration {
             GovernanceData({ governance: govAddress, callConfig: callConfig, lastUpdate: uint64(block.number) });
 
         signatories[signatoryKey] = true;
-
-        _initializeNonce(msg.sender);
     }
 
     function addSignatory(address controller, address signatory) external {
@@ -83,8 +81,6 @@ contract DAppIntegration {
         }
 
         signatories[signatoryKey] = true;
-
-        _initializeNonce(signatory);
 
         emit NewDAppSignatory(controller, govData.governance, signatory, govData.callConfig);
     }
@@ -109,23 +105,6 @@ contract DAppIntegration {
         if (msg.sender != govData.governance) revert FastLaneErrorsEvents.OnlyGovernance();
 
         delete governance[dAppControl];
-    }
-
-    function initializeNonce(address account) external {
-        _initializeNonce(account);
-    }
-
-    function _initializeNonce(address account) internal returns (bool initialized) {
-        if (asyncNonceBitIndex[account].LowestEmptyBitmap == uint128(0)) {
-            unchecked {
-                asyncNonceBitIndex[account].LowestEmptyBitmap = 2;
-            }
-            bytes32 bitmapKey = keccak256(abi.encode(account, 1));
-
-            // to skip the 0 nonce
-            asyncNonceBitmap[bitmapKey] = NonceBitmap({ highestUsedNonce: uint8(1), bitmap: 0 });
-            initialized = true;
-        }
     }
 
     function getGovFromControl(address dAppControl) external view returns (address governanceAddress) {

--- a/src/contracts/dapp/DAppControl.sol
+++ b/src/contracts/dapp/DAppControl.sol
@@ -28,6 +28,10 @@ abstract contract DAppControl is Test, DAppControlTemplate, ExecutionBase {
     uint8 private constant _CONTROL_DEPTH = 1 << 2;
 
     constructor(address _escrow, address _governance, CallConfig memory _callConfig) ExecutionBase(_escrow) {
+        if (_callConfig.userNoncesSequenced && _callConfig.dappNoncesSequenced) {
+            revert("DAPP AND USER CANT BOTH BE SEQ"); // TODO convert to custom errors
+        }
+
         control = address(this);
         escrow = _escrow;
         governance = _governance;
@@ -109,8 +113,12 @@ abstract contract DAppControl is Test, DAppControlTemplate, ExecutionBase {
         delegated = CallBits.needsDelegateUser(callConfig);
     }
 
-    function requireSequencedNonces() external view returns (bool isSequenced) {
-        isSequenced = CallBits.needsSequencedNonces(callConfig);
+    function requireSequencedUserNonces() external view returns (bool isSequenced) {
+        isSequenced = CallBits.needsSequencedUserNonces(callConfig);
+    }
+
+    function requireSequencedDAppNonces() external view returns (bool isSequenced) {
+        isSequenced = CallBits.needsSequencedDAppNonces(callConfig);
     }
 
     function getDAppConfig(UserOperation calldata userOp)

--- a/src/contracts/examples/intents-example/SwapIntent.sol
+++ b/src/contracts/examples/intents-example/SwapIntent.sol
@@ -58,7 +58,8 @@ contract SwapIntentController is DAppControl {
             _escrow,
             msg.sender,
             CallConfig({
-                sequenced: false,
+                userNoncesSequenced: false,
+                dappNoncesSequenced: false,
                 requirePreOps: false,
                 trackPreOpsReturnData: false,
                 trackUserReturnData: true,

--- a/src/contracts/examples/intents-example/V4SwapIntent.sol
+++ b/src/contracts/examples/intents-example/V4SwapIntent.sol
@@ -41,7 +41,8 @@ contract V4SwapIntentController is DAppControl {
             _escrow,
             msg.sender,
             CallConfig({
-                sequenced: false,
+                userNoncesSequenced: false,
+                dappNoncesSequenced: false,
                 requirePreOps: false,
                 trackPreOpsReturnData: false,
                 trackUserReturnData: true,

--- a/src/contracts/examples/v2-example/V2DAppControl.sol
+++ b/src/contracts/examples/v2-example/V2DAppControl.sol
@@ -52,7 +52,8 @@ contract V2DAppControl is DAppControl {
             _escrow,
             msg.sender,
             CallConfig({
-                sequenced: false,
+                userNoncesSequenced: false,
+                dappNoncesSequenced: false,
                 requirePreOps: true,
                 trackPreOpsReturnData: false,
                 trackUserReturnData: false,

--- a/src/contracts/examples/v4-example/V4DAppControl.sol
+++ b/src/contracts/examples/v4-example/V4DAppControl.sol
@@ -55,7 +55,8 @@ contract V4DAppControl is DAppControl {
             _escrow,
             msg.sender,
             CallConfig({
-                sequenced: false,
+                userNoncesSequenced: false,
+                dappNoncesSequenced: false,
                 requirePreOps: true,
                 trackPreOpsReturnData: true,
                 trackUserReturnData: false,

--- a/src/contracts/helpers/TxBuilder.sol
+++ b/src/contracts/helpers/TxBuilder.sol
@@ -33,11 +33,16 @@ contract TxBuilder {
     }
 
     function governanceNextNonce(address signatory) public view returns (uint256) {
-        return IAtlasVerification(verification).getNextNonce(signatory);
+        // Assume sequenced = false if control is not set
+        if (control == address(0)) return IAtlasVerification(verification).getNextNonce(signatory, false);
+        return
+            IAtlasVerification(verification).getNextNonce(signatory, IDAppControl(control).requireSequencedDAppNonces());
     }
 
     function userNextNonce(address user) public view returns (uint256) {
-        return IAtlasVerification(verification).getNextNonce(user);
+        // Assume sequenced = false if control is not set
+        if (control == address(0)) return IAtlasVerification(verification).getNextNonce(user, false);
+        return IAtlasVerification(verification).getNextNonce(user, IDAppControl(control).requireSequencedUserNonces());
     }
 
     function getControlCodeHash(address dAppControl) external view returns (bytes32) {

--- a/src/contracts/interfaces/IAtlasVerification.sol
+++ b/src/contracts/interfaces/IAtlasVerification.sol
@@ -33,12 +33,10 @@ interface IAtlasVerification {
     function getUserOperationPayload(UserOperation memory userOp) external view returns (bytes32 payload);
     function getSolverPayload(SolverOperation calldata solverOp) external view returns (bytes32 payload);
     function getDAppOperationPayload(DAppOperation memory dAppOp) external view returns (bytes32 payload);
-    function getNextNonce(address account) external view returns (uint256 nextNonce);
+    function getNextNonce(address account, bool sequenced) external view returns (uint256 nextNonce);
 
     function initializeGovernance(address controller) external;
     function addSignatory(address controller, address signatory) external;
     function removeSignatory(address controller, address signatory) external;
     function disableDApp(address dAppControl) external;
-
-    function initializeNonce(address account) external;
 }

--- a/src/contracts/interfaces/IDAppControl.sol
+++ b/src/contracts/interfaces/IDAppControl.sol
@@ -26,7 +26,9 @@ interface IDAppControl {
 
     function getDAppSignatory() external view returns (address governanceAddress);
 
-    function requireSequencedNonces() external view returns (bool isSequenced);
+    function requireSequencedUserNonces() external view returns (bool isSequenced);
+
+    function requireSequencedDAppNonces() external view returns (bool isSequenced);
 
     function preOpsDelegated() external view returns (bool delegated);
 

--- a/src/contracts/interfaces/IDAppIntegration.sol
+++ b/src/contracts/interfaces/IDAppIntegration.sol
@@ -12,8 +12,6 @@ interface IDAppIntegration {
 
     function disableDApp(address dAppControl) external;
 
-    function initializeNonce(address account) external;
-
     function nextGovernanceNonce(address governanceSignatory) external view returns (uint256 nextNonce);
 
     function getGovFromControl(address dAppControl) external view returns (address governanceAddress);

--- a/src/contracts/libraries/CallBits.sol
+++ b/src/contracts/libraries/CallBits.sol
@@ -14,8 +14,11 @@ library CallBits {
     }
 
     function encodeCallConfig(CallConfig memory callConfig) internal pure returns (uint32 encodedCallConfig) {
-        if (callConfig.sequenced) {
-            encodedCallConfig ^= _ONE << uint32(CallConfigIndex.Sequenced);
+        if (callConfig.userNoncesSequenced) {
+            encodedCallConfig ^= _ONE << uint32(CallConfigIndex.UserNoncesSequenced);
+        }
+        if (callConfig.dappNoncesSequenced) {
+            encodedCallConfig ^= _ONE << uint32(CallConfigIndex.DAppNoncesSequenced);
         }
         if (callConfig.requirePreOps) {
             encodedCallConfig ^= _ONE << uint32(CallConfigIndex.RequirePreOps);
@@ -66,7 +69,7 @@ library CallBits {
 
     function decodeCallConfig(uint32 encodedCallConfig) internal pure returns (CallConfig memory callConfig) {
         callConfig = CallConfig({
-            sequenced: needsSequencedNonces(encodedCallConfig),
+            userNoncesSequenced: needsSequencedUserNonces(encodedCallConfig),
             requirePreOps: needsPreOpsCall(encodedCallConfig),
             trackPreOpsReturnData: needsPreOpsReturnData(encodedCallConfig),
             trackUserReturnData: needsUserReturnData(encodedCallConfig),
@@ -81,12 +84,17 @@ library CallBits {
             unknownAuctioneer: allowsUnknownAuctioneer(encodedCallConfig),
             verifyCallChainHash: verifyCallChainHash(encodedCallConfig),
             forwardReturnData: forwardReturnData(encodedCallConfig),
-            requireFulfillment: needsFulfillment(encodedCallConfig)
-        });
+            requireFulfillment: needsFulfillment(encodedCallConfig),
+            dappNoncesSequenced: needsSequencedDAppNonces(encodedCallConfig) // TODO move to below userNoncesSequenced
+         });
     }
 
-    function needsSequencedNonces(uint32 callConfig) internal pure returns (bool sequenced) {
-        sequenced = (callConfig & 1 << uint32(CallConfigIndex.Sequenced) != 0);
+    function needsSequencedUserNonces(uint32 callConfig) internal pure returns (bool sequenced) {
+        sequenced = (callConfig & 1 << uint32(CallConfigIndex.UserNoncesSequenced) != 0);
+    }
+
+    function needsSequencedDAppNonces(uint32 callConfig) internal pure returns (bool sequenced) {
+        sequenced = (callConfig & 1 << uint32(CallConfigIndex.DAppNoncesSequenced) != 0);
     }
 
     function needsPreOpsCall(uint32 callConfig) internal pure returns (bool needsPreOps) {

--- a/src/contracts/types/DAppApprovalTypes.sol
+++ b/src/contracts/types/DAppApprovalTypes.sol
@@ -27,7 +27,8 @@ struct DAppConfig {
 }
 
 struct CallConfig {
-    bool sequenced;
+    bool userNoncesSequenced;
+    bool dappNoncesSequenced;
     bool requirePreOps;
     bool trackPreOpsReturnData;
     bool trackUserReturnData;
@@ -46,7 +47,8 @@ struct CallConfig {
 }
 
 enum CallConfigIndex {
-    Sequenced,
+    UserNoncesSequenced,
+    DAppNoncesSequenced,
     RequirePreOps,
     TrackPreOpsReturnData,
     TrackUserReturnData,

--- a/src/contracts/types/Emissions.sol
+++ b/src/contracts/types/Emissions.sol
@@ -102,6 +102,10 @@ contract FastLaneErrorsEvents {
     error NotInitialized();
     error AlreadyInitialized();
 
+    // AtlasVerification
+    error NoUnusedNonceInBitmap();
+    error OnlyAccount();
+
     /*
     event NewDAppIntegration(
         address indexed environment,

--- a/test/AtlasVerification.t.sol
+++ b/test/AtlasVerification.t.sol
@@ -8,10 +8,8 @@ import { DAppConfig, DAppOperation, CallConfig } from "src/contracts/types/DAppA
 import { UserOperation } from "src/contracts/types/UserCallTypes.sol";
 import { SolverOperation } from "src/contracts/types/SolverCallTypes.sol";
 import { ValidCallsResult } from "src/contracts/types/ValidCallsTypes.sol";
-import { TxBuilder } from "src/contracts/helpers/TxBuilder.sol";
 import { DummyDAppControl } from "./base/DummyDAppControl.sol";
 import { AtlasBaseTest } from "./base/AtlasBaseTest.t.sol";
-import { SimpleRFQSolver } from "./SwapIntent.t.sol";
 import { CallVerification } from "src/contracts/libraries/CallVerification.sol";
 import { CallBits } from "src/contracts/libraries/CallBits.sol";
 import { DummyDAppControlBuilder } from "./helpers/DummyDAppControlBuilder.sol";
@@ -20,19 +18,23 @@ import { UserOperationBuilder } from "./base/builders/UserOperationBuilder.sol";
 import { SolverOperationBuilder } from "./base/builders/SolverOperationBuilder.sol";
 import { DAppOperationBuilder } from "./base/builders/DAppOperationBuilder.sol";
 
+// 
+// ---- TEST HELPERS BEGIN HERE ---- //
+// --- (Also used in other files) --- //
+// - Scroll down for the actual tests - //
+//
 
-struct ValidCallsCall {
-    UserOperation userOp;
-    SolverOperation[] solverOps;
-    DAppOperation dAppOp;
-    uint256 msgValue;
-    address msgSender;
-    bool isSimulation;
-}
-
-
-contract AtlasVerificationTest is AtlasBaseTest {
+contract AtlasVerificationBase is AtlasBaseTest {
     DummyDAppControl dAppControl;
+
+    struct ValidCallsCall {
+        UserOperation userOp;
+        SolverOperation[] solverOps;
+        DAppOperation dAppOp;
+        uint256 msgValue;
+        address msgSender;
+        bool isSimulation;
+    }
 
     function defaultCallConfig() public returns (CallConfigBuilder) {
         return new CallConfigBuilder();
@@ -153,10 +155,13 @@ contract AtlasVerificationTest is AtlasBaseTest {
         AtlasBaseTest.setUp();
         dAppControl = defaultDAppControl().withCallConfig(callConfig).buildAndIntegrate(atlasVerification);
     }
+}
 
-    //
-    // ---- TESTS BEGIN HERE ---- //
-    //
+//
+// ---- TESTS BEGIN HERE ---- //
+//
+
+contract AtlasVerificationTest is AtlasVerificationBase {
 
     // Valid cases
 
@@ -574,6 +579,8 @@ contract AtlasVerificationTest is AtlasBaseTest {
         doValidCalls(ValidCallsCall({
             userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
         ));
+
+        console.log("\nTX 2\n");
 
         // this is the actual testcase
         userOp = validUserOperation().build();
@@ -1365,5 +1372,4 @@ contract AtlasVerificationTest is AtlasBaseTest {
             userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
         ), ValidCallsResult.NoSolverOp);
     }
-
 }

--- a/test/AtlasVerification.t.sol
+++ b/test/AtlasVerification.t.sol
@@ -523,7 +523,6 @@ contract AtlasVerificationTest is AtlasBaseTest {
         ), ValidCallsResult.Valid);
     }
 
-    // TODO Re-check after AtlasVerification nonce issue is fixed
     //
     // given a default atlas environment
     //   and callConfig.sequenced = true
@@ -534,17 +533,17 @@ contract AtlasVerificationTest is AtlasBaseTest {
     // because one is the first valid nonce for sequenced calls
     //  and this is the first call for the user
     //
-    // function test_validCalls_SequencedNonceIsTwo_DAppSignatureInvalid() public {
-    //     defaultAtlasWithCallConfig(defaultCallConfig().withSequenced(true).build());
+    function test_validCalls_SequencedNonceIsTwo_DAppSignatureInvalid() public {
+        defaultAtlasWithCallConfig(defaultCallConfig().withSequenced(true).build());
 
-    //     UserOperation memory userOp = validUserOperation().build();
-    //     SolverOperation[] memory solverOps = validSolverOperations(userOp);
-    //     DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).withNonce(2).signAndBuild(address(atlasVerification), governancePK);
+        UserOperation memory userOp = validUserOperation().build();
+        SolverOperation[] memory solverOps = validSolverOperations(userOp);
+        DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).withNonce(2).signAndBuild(address(atlasVerification), governancePK);
 
-    //     callAndAssert(ValidCallsCall({
-    //         userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
-    //     ), ValidCallsResult.DAppSignatureInvalid);
-    // }
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ), ValidCallsResult.DAppSignatureInvalid);
+    }
 
     //
     // given an otherwise valid atlas transaction with a dAppOp.nonce of 2
@@ -571,7 +570,7 @@ contract AtlasVerificationTest is AtlasBaseTest {
         // these first ops are to increment the nonce to 1
         UserOperation memory userOp = validUserOperation().build();
         SolverOperation[] memory solverOps = validSolverOperations(userOp);
-        DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).build();
+        DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).signAndBuild(address(atlasVerification), governancePK);
         doValidCalls(ValidCallsCall({
             userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
         ));
@@ -586,8 +585,7 @@ contract AtlasVerificationTest is AtlasBaseTest {
         ), ValidCallsResult.Valid);
     }
 
-    // TODO Re-check after AtlasVerification nonce issue is fixed
-    //
+    // 
     // given a default atlas environment
     //   and callConfig.sequenced = true
     //   and otherwise valid user, solver and dapp operations
@@ -598,26 +596,26 @@ contract AtlasVerificationTest is AtlasBaseTest {
     // because the current nonce for the user is 1
     //  and the next valid nonce is 2
     //
-    // function test_validCalls_SequencedNonceWasOneIsNowThree_DAppSignatureInvalid() public {
-    //     defaultAtlasWithCallConfig(defaultCallConfig().withSequenced(true).build());
+    function test_validCalls_SequencedNonceWasOneIsNowThree_DAppSignatureInvalid() public {
+        defaultAtlasWithCallConfig(defaultCallConfig().withSequenced(true).build());
 
-    //     // these first ops are to increment the nonce to 1
-    //     UserOperation memory userOp = validUserOperation().build();
-    //     SolverOperation[] memory solverOps = validSolverOperations(userOp);
-    //     DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).build();
-    //     doValidCalls(ValidCallsCall({
-    //         userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
-    //     ));
+        // these first ops are to increment the nonce to 1
+        UserOperation memory userOp = validUserOperation().build();
+        SolverOperation[] memory solverOps = validSolverOperations(userOp);
+        DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).build();
+        doValidCalls(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ));
 
-    //     // this is the actual testcase
-    //     userOp = validUserOperation().build();
-    //     solverOps = validSolverOperations(userOp);
-    //     dappOp = validDAppOperation(userOp, solverOps).withNonce(3).signAndBuild(address(atlasVerification), governancePK);
+        // this is the actual testcase
+        userOp = validUserOperation().build();
+        solverOps = validSolverOperations(userOp);
+        dappOp = validDAppOperation(userOp, solverOps).withNonce(3).signAndBuild(address(atlasVerification), governancePK);
 
-    //     callAndAssert(ValidCallsCall({
-    //         userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
-    //     ), ValidCallsResult.DAppSignatureInvalid);
-    // }
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ), ValidCallsResult.DAppSignatureInvalid);
+    }
 
     // UserSignatureInvalid cases
 
@@ -806,7 +804,7 @@ contract AtlasVerificationTest is AtlasBaseTest {
     // then it should return Valid
     // because one has not been used before
     //
-    function test_validCalls_UserOpNonceIsOne_UserSignatureInvalid() public {
+    function test_validCalls_UserOpNonceIsOne_Valid() public {
         defaultAtlasEnvironment();
 
         UserOperation memory userOp = validUserOperation().withNonce(1).signAndBuild(address(atlasVerification), userPK);
@@ -850,7 +848,6 @@ contract AtlasVerificationTest is AtlasBaseTest {
     // then it should return DAppSignatureInvalid
     //
 
-    // TODO Re-check after AtlasVerification nonce issue is fixed
     //
     // given a default atlas environment
     //   and callConfig.sequenced = true
@@ -861,17 +858,17 @@ contract AtlasVerificationTest is AtlasBaseTest {
     // because one is the first valid nonce for sequenced calls
     //  and this is the first call for the user
     //
-    // function test_validCalls_SequencedUserOpNonceIsTwo_DAppSignatureInvalid() public {
-    //     defaultAtlasWithCallConfig(defaultCallConfig().withSequenced(true).build());
+    function test_validCalls_SequencedUserOpNonceIsTwo_UserSignatureInvalid() public {
+        defaultAtlasWithCallConfig(defaultCallConfig().withSequenced(true).build());
 
-    //     UserOperation memory userOp = validUserOperation().withNonce(2).signAndBuild(address(atlasVerification), userPK);
-    //     SolverOperation[] memory solverOps = validSolverOperations(userOp);
-    //     DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).build();
+        UserOperation memory userOp = validUserOperation().withNonce(2).signAndBuild(address(atlasVerification), userPK);
+        SolverOperation[] memory solverOps = validSolverOperations(userOp);
+        DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).build();
 
-    //     callAndAssert(ValidCallsCall({
-    //         userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
-    //     ), ValidCallsResult.DAppSignatureInvalid);
-    // }
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ), ValidCallsResult.UserSignatureInvalid);
+    }
 
     //
     // given a default atlas environment
@@ -913,7 +910,6 @@ contract AtlasVerificationTest is AtlasBaseTest {
     // then it should return DAppSignatureInvalid
     //
 
-    // TODO Re-check after AtlasVerification nonce issue is fixed
     //
     // given a default atlas environment
     //   and callConfig.sequenced = true
@@ -925,26 +921,26 @@ contract AtlasVerificationTest is AtlasBaseTest {
     // because the current nonce for the user is 1
     //   and the next valid nonce is 2
     //
-    // function test_validCalls_SequencedUserOpNonceIsThree_DAppSignatureInvalid() public {
-    //     defaultAtlasWithCallConfig(defaultCallConfig().withSequenced(true).build());
+    function test_validCalls_SequencedUserOpNonceIsThree_UserSignatureInvalid() public {
+        defaultAtlasWithCallConfig(defaultCallConfig().withSequenced(true).build());
 
-    //     // increment the nonce to 1
-    //     UserOperation memory userOp = validUserOperation().withNonce(1).signAndBuild(address(atlasVerification), userPK);
-    //     SolverOperation[] memory solverOps = validSolverOperations(userOp);
-    //     DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).build();
-    //     doValidCalls(ValidCallsCall({
-    //         userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: governanceEOA, isSimulation: false}
-    //     ));
+        // increment the nonce to 1
+        UserOperation memory userOp = validUserOperation().withNonce(1).signAndBuild(address(atlasVerification), userPK);
+        SolverOperation[] memory solverOps = validSolverOperations(userOp);
+        DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).build();
+        doValidCalls(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: governanceEOA, isSimulation: false}
+        ));
 
-    //     // this is the actual testcase
-    //     userOp = validUserOperation().withNonce(3).signAndBuild(address(atlasVerification), userPK);
-    //     solverOps = validSolverOperations(userOp);
-    //     dappOp = validDAppOperation(userOp, solverOps).build();
+        // this is the actual testcase
+        userOp = validUserOperation().withNonce(3).signAndBuild(address(atlasVerification), userPK);
+        solverOps = validSolverOperations(userOp);
+        dappOp = validDAppOperation(userOp, solverOps).build();
 
-    //     callAndAssert(ValidCallsCall({
-    //         userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
-    //     ), ValidCallsResult.DAppSignatureInvalid);
-    // }
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ), ValidCallsResult.UserSignatureInvalid);
+    }
 
     // TooManySolverOps cases
 

--- a/test/AtlasVerificationNonces.t.sol
+++ b/test/AtlasVerificationNonces.t.sol
@@ -7,61 +7,424 @@ import { DAppConfig, DAppOperation, CallConfig } from "src/contracts/types/DAppA
 import { UserOperation } from "src/contracts/types/UserCallTypes.sol";
 import { SolverOperation } from "src/contracts/types/SolverCallTypes.sol";
 import { ValidCallsResult } from "src/contracts/types/ValidCallsTypes.sol";
+import { AtlasVerification } from "src/contracts/atlas/AtlasVerification.sol";
 import { AtlasVerificationBase } from "./AtlasVerification.t.sol";
-
+import { FastLaneErrorsEvents } from "src/contracts/types/Emissions.sol";
 
 contract AtlasVerificationNoncesTest is AtlasVerificationBase {
 
-    // Q: Why track lowestEmptyBitmap and highestFullBitmap?
-    // A:   - lowestEmptyBitmap = ??
-    //      - highestFullBitmap = to calc getNextNonce (highestFullBitmap * 240) + highestUsedNonce
-    // --> can we just track highestFullBitmap and highestUsedNonce?
+    function testGetNextNonceReturnsOneForNewAccount_Sequenced() public {
+        defaultAtlasWithCallConfig(defaultCallConfig().withUserNoncesSequenced(true).build());
+        assertEq(atlasVerification.getNextNonce(userEOA, true), 1, "User seq next nonce should be 1");
+        assertEq(atlasVerification.getNextNonce(governanceEOA, true), 1, "Gov seq next nonce should be 1");
+    }
 
+    function testGetNextNonceReturnsOneForNewAccount_Async() public {
+        defaultAtlasWithCallConfig(defaultCallConfig().withUserNoncesSequenced(false).build());
+        assertEq(atlasVerification.getNextNonce(userEOA, false), 1, "User async next nonce should be 1");
+        assertEq(atlasVerification.getNextNonce(governanceEOA, false), 1, "Gov async next nonce should be 1");
+    }
 
-    function testFirstTenNonces_Sequenced() public {
-        defaultAtlasWithCallConfig(defaultCallConfig().withSequenced(true).build());
-        
-        UserOperation memory userOp = validUserOperation().build();
+    function testUsingSeqNoncesDoNotChangeNextAsyncNonce() public {
+        defaultAtlasWithCallConfig(defaultCallConfig().withUserNoncesSequenced(true).build());
+        assertEq(atlasVerification.getNextNonce(userEOA, true), 1, "User next seq nonce should be 1");
+        assertEq(atlasVerification.getNextNonce(userEOA, false), 1, "User next async nonce should be 1");
+
+        UserOperation memory userOp = validUserOperation().withNonce(1).build();
         SolverOperation[] memory solverOps = validSolverOperations(userOp);
         DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).signAndBuild(address(atlasVerification), governancePK);
         doValidCalls(AtlasVerificationBase.ValidCallsCall({
             userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
         ));
+        assertEq(atlasVerification.getNextNonce(userEOA, true), 2, "User next seq nonce should now be 2");
+        assertEq(atlasVerification.getNextNonce(userEOA, false), 1, "User next async nonce should still be 1");
+    }
 
+    function testUsingAsyncNoncesDoNotChangeNextSeqNonce() public {
+        defaultAtlasWithCallConfig(defaultCallConfig().withUserNoncesSequenced(false).build());
+        assertEq(atlasVerification.getNextNonce(userEOA, true), 1, "User next seq nonce should be 1");
+        assertEq(atlasVerification.getNextNonce(userEOA, false), 1, "User next async nonce should be 1");
 
-        for (uint256 i = 0; i < 10; i++) {
-            // TODO make calls, check nonces
+        UserOperation memory userOp = validUserOperation().withNonce(1).build();
+        SolverOperation[] memory solverOps = validSolverOperations(userOp);
+        DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).signAndBuild(address(atlasVerification), governancePK);
+        doValidCalls(AtlasVerificationBase.ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ));
+        assertEq(atlasVerification.getNextNonce(userEOA, true), 1, "User next seq nonce should still be 1");
+        assertEq(atlasVerification.getNextNonce(userEOA, false), 2, "User next async nonce should now be 2");
+    }
+
+    function testSameNonceCannotBeUsedTwice_UserSequenced_DAppAsync() public {
+        defaultAtlasWithCallConfig(defaultCallConfig().withUserNoncesSequenced(true).withDappNoncesSequenced(false).build());
+
+        UserOperation memory userOp = validUserOperation().withNonce(1).build();
+        SolverOperation[] memory solverOps = validSolverOperations(userOp);
+        DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).withNonce(1).signAndBuild(address(atlasVerification), governancePK);
+        doValidCalls(AtlasVerificationBase.ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ));
+
+        // Fails with UserSignatureInvalid due to re-used user nonce
+        userOp = validUserOperation().withNonce(1).build();
+        solverOps = validSolverOperations(userOp);
+        dappOp = validDAppOperation(userOp, solverOps).withNonce(5).signAndBuild(address(atlasVerification), governancePK);
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ), ValidCallsResult.UserSignatureInvalid);
+
+        // Fails with DAppSignatureInvalid due to re-used dapp nonce
+        userOp = validUserOperation().withNonce(2).build();
+        solverOps = validSolverOperations(userOp);
+        dappOp = validDAppOperation(userOp, solverOps).withNonce(1).signAndBuild(address(atlasVerification), governancePK);
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ), ValidCallsResult.DAppSignatureInvalid);
+    }
+
+    function testSameNonceValidForSeqAndAsyncDApps() public {
+        // Set up DApp with sequenced user nonces
+        defaultAtlasWithCallConfig(defaultCallConfig().withUserNoncesSequenced(true).build());
+
+        // In Sequential DApp: User nonces 1 and 2 are valid
+        UserOperation memory userOp = validUserOperation().withNonce(1).build();
+        SolverOperation[] memory solverOps = validSolverOperations(userOp);
+        DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).withNonce(1).signAndBuild(address(atlasVerification), governancePK);
+        doValidCalls(AtlasVerificationBase.ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ));
+
+        userOp = validUserOperation().withNonce(2).build();
+        solverOps = validSolverOperations(userOp);
+        dappOp = validDAppOperation(userOp, solverOps).withNonce(2).signAndBuild(address(atlasVerification), governancePK);
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ), ValidCallsResult.Valid);
+
+        // Set up DApp with async user nonces
+        defaultAtlasWithCallConfig(defaultCallConfig().withUserNoncesSequenced(false).build());
+
+        // In Async DApp: User nonces 1 and 2 are valid even though already used in sequential dapp
+        userOp = validUserOperation().withNonce(1).build();
+        solverOps = validSolverOperations(userOp);
+        dappOp = validDAppOperation(userOp, solverOps).withNonce(3).signAndBuild(address(atlasVerification), governancePK);
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ), ValidCallsResult.Valid);
+
+        userOp = validUserOperation().withNonce(2).build();
+        solverOps = validSolverOperations(userOp);
+        dappOp = validDAppOperation(userOp, solverOps).withNonce(4).signAndBuild(address(atlasVerification), governancePK);
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ), ValidCallsResult.Valid);
+    }
+
+    function testSeqNoncesMustBePerfectlySequential() public {
+        defaultAtlasWithCallConfig(defaultCallConfig().withUserNoncesSequenced(true).build());
+
+        UserOperation memory userOp = validUserOperation().withNonce(1).build();
+        SolverOperation[] memory solverOps = validSolverOperations(userOp);
+        DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).withNonce(1).signAndBuild(address(atlasVerification), governancePK);
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ), ValidCallsResult.Valid);
+
+        // Fails with UserSignatureInvalid due to non-sequential user nonce
+        userOp = validUserOperation().withNonce(3).build();
+        solverOps = validSolverOperations(userOp);
+        dappOp = validDAppOperation(userOp, solverOps).withNonce(2).signAndBuild(address(atlasVerification), governancePK);
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: governanceEOA, isSimulation: false}
+        ), ValidCallsResult.UserSignatureInvalid);
+
+        // Valid if using the sequential user nonce
+        userOp = validUserOperation().withNonce(2).build();
+        solverOps = validSolverOperations(userOp);
+        dappOp = validDAppOperation(userOp, solverOps).withNonce(3).signAndBuild(address(atlasVerification), governancePK);
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ), ValidCallsResult.Valid);
+
+        // Fails with UserSignatureInvalid due to non-sequential user nonce
+        userOp = validUserOperation().withNonce(999).build();
+        solverOps = validSolverOperations(userOp);
+        dappOp = validDAppOperation(userOp, solverOps).withNonce(4).signAndBuild(address(atlasVerification), governancePK);
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: governanceEOA, isSimulation: false}
+        ), ValidCallsResult.UserSignatureInvalid);
+
+        // Valid if using the sequential user nonce
+        userOp = validUserOperation().withNonce(3).build();
+        solverOps = validSolverOperations(userOp);
+        dappOp = validDAppOperation(userOp, solverOps).withNonce(5).signAndBuild(address(atlasVerification), governancePK);
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ), ValidCallsResult.Valid);
+    }
+
+    function testAsyncNoncesAreValidEvenIfNotSequential() public {
+        defaultAtlasWithCallConfig(defaultCallConfig().withUserNoncesSequenced(false).build());
+
+        UserOperation memory userOp = validUserOperation().withNonce(1).build();
+        SolverOperation[] memory solverOps = validSolverOperations(userOp);
+        DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).withNonce(1).signAndBuild(address(atlasVerification), governancePK);
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ), ValidCallsResult.Valid);
+
+        // Valid if using the async user nonce
+        userOp = validUserOperation().withNonce(100).build();
+        solverOps = validSolverOperations(userOp);
+        dappOp = validDAppOperation(userOp, solverOps).withNonce(2).signAndBuild(address(atlasVerification), governancePK);
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, isSimulation: false, msgValue: 0, msgSender: userEOA}
+        ), ValidCallsResult.Valid);
+
+        // Valid if using the async user nonce
+        userOp = validUserOperation().withNonce(500).build();
+        solverOps = validSolverOperations(userOp);
+        dappOp = validDAppOperation(userOp, solverOps).withNonce(3).signAndBuild(address(atlasVerification), governancePK);
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, isSimulation: false, msgValue: 0, msgSender: userEOA}
+        ), ValidCallsResult.Valid);
+
+        // Valid if using the async user nonce
+        userOp = validUserOperation().withNonce(2).build();
+        solverOps = validSolverOperations(userOp);
+        dappOp = validDAppOperation(userOp, solverOps).withNonce(4).signAndBuild(address(atlasVerification), governancePK);
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, isSimulation: false, msgValue: 0, msgSender: userEOA}
+        ), ValidCallsResult.Valid);
+    }
+
+    function testFirstEightNonces_DAppSequenced() public {
+        defaultAtlasWithCallConfig(defaultCallConfig().withDappNoncesSequenced(true).build());
+        
+        UserOperation memory userOp = validUserOperation().build();
+        SolverOperation[] memory solverOps = validSolverOperations(userOp);
+        DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).signAndBuild(address(atlasVerification), governancePK);
+        // First call initializes at nonce = 1
+        doValidCalls(AtlasVerificationBase.ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ));
+
+        // Testing nonces 2 - 8
+        for (uint256 i = 2; i < 9; i++) {
+            assertEq(atlasVerification.getNextNonce(governanceEOA, true), i, "Next nonce not incrementing as expected");
+            
+            userOp = validUserOperation().withNonce(i).build();
+            solverOps = validSolverOperations(userOp);
+            dappOp = validDAppOperation(userOp, solverOps).withNonce(i).signAndBuild(address(atlasVerification), governancePK);
+            callAndAssert(ValidCallsCall({
+                userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+            ), ValidCallsResult.Valid);
         }
+
+        assertEq(atlasVerification.getNextNonce(governanceEOA, true), 9, "Next nonce should be 9 after 8 seq nonces used");
     }
 
-    function test_bitmap2UsedAfterBitmap1Fulled_Sequenced() public {}
+    function testHighestFullBitmapIncreasesWhenFilled_Async() public {
+        // To avoid doing 240 calls, we just modify the relevant storage slot
+        // such that the bitmap at index 1 has 239 of 240 nonces used.
+        // We test the 240th nonce properly from that point.
 
-    function test_bitmap3UsedAfterBitmap2Fulled_Sequenced() public {
-        // Use nonce 1 in bitmap 1
-        // Use nonce 239 in bitmap 1 (last in bitmap)
-        // Next nonce is 240, which should tick over to bitmap 2
-        // Use nonce 279 in bitmap 2 (last in bitmap)
-        // Next nonce is 280, which should tick over to bitmap 3
+        uint128 highestFullBitmap;
+        uint256 noncesUsed = 239;
+        uint256 bitmap = (2 ** noncesUsed - 1) << 8;
+        uint256 highestUsedNonceInBitmap = uint256(noncesUsed);
+        uint256 nonceBitmapSlot = highestUsedNonceInBitmap | bitmap;
+        bytes32 bitmapKey = keccak256(abi.encode(userEOA, 1));
+
+        // Only concerned with async user nonces in this test
+        defaultAtlasWithCallConfig(defaultCallConfig().withUserNoncesSequenced(false).withDappNoncesSequenced(true).build());
+        
+        // Modifying storage slot to have 239 nonces used
+        vm.record();
+        (uint8 highestUsedNonce,) = atlasVerification.nonceBitmaps(bitmapKey);
+        (bytes32[] memory reads, ) = vm.accesses(address(atlasVerification));
+        vm.store(address(atlasVerification), reads[0], bytes32(nonceBitmapSlot));
+        
+        // Check storage slot has been modified correctly
+        (, highestFullBitmap) = atlasVerification.nonceTrackers(userEOA);
+        assertEq(highestFullBitmap, 0, "Highest full bitmap should 0 if 239 nonces used");
+        (highestUsedNonce,) = atlasVerification.nonceBitmaps(bitmapKey);
+        assertEq(highestUsedNonce, noncesUsed, "Highest used nonce should be 239");
+        assertEq(atlasVerification.getNextNonce(userEOA, false), 240, "Next nonce should be 240 if 239 nonces used");
+
+        // Testing nonce 240
+        UserOperation memory userOp = validUserOperation().withNonce(240).build();
+        SolverOperation[] memory solverOps = validSolverOperations(userOp);
+        DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).signAndBuild(address(atlasVerification), governancePK);
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ), ValidCallsResult.Valid);
+
+        // The next recommended async nonce should be 241 and the highest full bitmap should have increased from 0 to 1
+        (, highestFullBitmap) = atlasVerification.nonceTrackers(userEOA);
+        assertEq(highestFullBitmap, 1, "Highest full bitmap should be 1 after 240 nonces used");
+        assertEq(atlasVerification.getNextNonce(userEOA, false), 241, "Next nonce should be 241 after 240 nonces used");
     }
 
-    function test_emptyNoncesInUsedBitmapsCanBeUsed() public {
-        // Use nonce 1 in bitmap 1
-        // Use nonce 239 in bitmap 1 (last in bitmap)
-        // Try using nonce 2 in bitmap 1, should work - unused
-        // Next nonce is 240, which should tick over to bitmap 2
-        // Try using nonce 3 in bitmap 1, should work - unused
+    function testGetFirstUnusedNonceInBitmap() public {
+        MockVerification mockVerification = new MockVerification(address(atlas));
+
+        // empty bitmap should return 1
+        assertEq(mockVerification.getFirstUnusedNonceInBitmap(0), 1, "Empty bitmap should return 1");
+
+        // full bitmap should return 0
+        // vm.expectRevert(FastLaneErrorsEvents.NoUnusedNonceInBitmap.selector);
+        // mockVerification.getFirstUnusedNonceInBitmap(type(uint240).max);
+        assertEq(mockVerification.getFirstUnusedNonceInBitmap(type(uint240).max), 0, "Full bitmap should return 0");
+
+        // bitmap 000...01 should return 2
+        assertEq(mockVerification.getFirstUnusedNonceInBitmap(1), 2, "Bitmap 000...01 should return 2");
+
+        // bitmap 000...10 should return 1
+        assertEq(mockVerification.getFirstUnusedNonceInBitmap(2), 1, "Bitmap 000...10 should return 1");
+
+        // bitmap 000...11 should return 3
+        assertEq(mockVerification.getFirstUnusedNonceInBitmap(3), 3, "Bitmap 000...11 should return 3");
+
+        // bitmap 000...1101_1111_1111_1111_1111_1111_1111_1111_1111 should return 34
+        // because 2 full 16-bit chunks used, and 1 bit used in the 3rd chunk before an unused bit
+        // 60129542143 = 000...1101_1111_1111_1111_1111_1111_1111_1111_1111
+        assertEq(mockVerification.getFirstUnusedNonceInBitmap(60129542143), 34, "Bitmap 000...1101 (+32 more 1s) should return 34");
+
+        // bitmap 0111...111 should return 240 - only last bit unused
+        // type(uint240).max - (2 ** 239) = 0111...111 (only last bit unused)
+        uint256 leftmostBitFree = type(uint240).max - (2 ** 239);
+        assertEq(mockVerification.getFirstUnusedNonceInBitmap(leftmostBitFree), 240, "Bitmap 0111...111 should return 240");
     }
 
-    // does this need sequenced and non sequenced versions?
-    function test_usedNoncesCannotBeReused() public {
-        // Test nonce 1 works, uses bitmap 1
-        // Test using nonce 1 again fails
-        // Test nonce 2 works, uses bitmap 1
-        // Test using nonce 2 again fails
-        // Jump to bitmap 2
-        // Test nonce x works, uses bitmap 2
-        // Test using nonce x again fails
-        // Test using nonce 1 in bitmap 1 still fails
+    function testIncrementFullBitmapEdgeCase() public {
+        // For edge cases when highestFullAsyncBitmap needs to be re-synced. Example:
+        // Bitmap 4 is full
+        // Bitmap 3 is full
+        // Bitmap 2 only has last nonce unused
+        // Bitmap 1 is full
+        // ^ in the example above, once last bitmap 2 nonce is used, highestFullAsyncBitmap will be set to 2 but should be 4
+
+        uint128 highestFullBitmap;
+        uint8 highestUsedNonce;
+
+        uint256 almostFullBitmapSlot = uint256(239) | (uint256(type(uint240).max - (2 ** 239)) << 8);
+        uint256 fullBitmapSlot = uint256(240) | (uint256(type(uint240).max) << 8);
+
+        bytes32 bitmap1Key = keccak256(abi.encode(userEOA, 1));
+        bytes32 bitmap2Key = keccak256(abi.encode(userEOA, 2));
+        bytes32 bitmap3Key = keccak256(abi.encode(userEOA, 3));
+        bytes32 bitmap4Key = keccak256(abi.encode(userEOA, 4));
+
+        // Only concerned with async user nonces in this test
+        defaultAtlasWithCallConfig(defaultCallConfig().withUserNoncesSequenced(false).withDappNoncesSequenced(true).build());
+        
+        // Modify bitmaps 3 and 4 to be full
+        vm.record();
+        (highestUsedNonce,) = atlasVerification.nonceBitmaps(bitmap3Key);
+        (highestUsedNonce,) = atlasVerification.nonceBitmaps(bitmap4Key);
+        (bytes32[] memory reads, ) = vm.accesses(address(atlasVerification));
+        vm.store(address(atlasVerification), reads[0], bytes32(fullBitmapSlot));
+        vm.store(address(atlasVerification), reads[1], bytes32(fullBitmapSlot));
+
+        // Modify bitmaps 1 and 2 to be almost full
+        vm.record();
+        (highestUsedNonce,) = atlasVerification.nonceBitmaps(bitmap1Key);
+        (highestUsedNonce,) = atlasVerification.nonceBitmaps(bitmap2Key);
+        (reads, ) = vm.accesses(address(atlasVerification));
+        vm.store(address(atlasVerification), reads[0], bytes32(almostFullBitmapSlot));
+        vm.store(address(atlasVerification), reads[1], bytes32(almostFullBitmapSlot));
+
+        // Check highestFullAsyncBitmap is still 0
+        (, highestFullBitmap) = atlasVerification.nonceTrackers(userEOA);
+        assertEq(highestFullBitmap, 0, "Highest full bitmap should 0 if 239 nonces used");
+
+        // Now use nonce 240, which should set highestFullAsyncBitmap to 1
+        UserOperation memory userOp = validUserOperation().withNonce(240).build();
+        SolverOperation[] memory solverOps = validSolverOperations(userOp);
+        DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).withNonce(1).signAndBuild(address(atlasVerification), governancePK);
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ), ValidCallsResult.Valid);
+
+        // Check highestFullAsyncBitmap is now 1
+        (, highestFullBitmap) = atlasVerification.nonceTrackers(userEOA);
+        assertEq(highestFullBitmap, 1, "Highest full bitmap value should be 1");
+
+        // getNextNonce should return 480 = (240 used in slot 1 + 239 used in slot 2)
+        assertEq(atlasVerification.getNextNonce(userEOA, false), 480, "Next unused nonce should be 480");
+
+        // Now use nonce 480, which should full bitmap 2 and set highest bitmap to the next consecutive full bitmap (4)
+        userOp = validUserOperation().withNonce(480).build();
+        solverOps = validSolverOperations(userOp);
+        dappOp = validDAppOperation(userOp, solverOps).withNonce(2).signAndBuild(address(atlasVerification), governancePK);
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, isSimulation: false, msgValue: 0, msgSender: userEOA}
+        ), ValidCallsResult.Valid);
+
+        // Check highestFullAsyncBitmap is now 4
+        (, highestFullBitmap) = atlasVerification.nonceTrackers(userEOA);
+        assertEq(highestFullBitmap, 4, "Highest full bitmap value should be 4");
+
+        // getNextNonce should return the correct next nonce = 240 * 4 + 1 = 961
+        assertEq(atlasVerification.getNextNonce(userEOA, false), 961, "Next unused nonce should be 961");
+
+        // MAIN PART OF TEST: Call manuallyUpdateNonceTracker to set highestFullAsyncBitmap to 4
+        vm.prank(userEOA);
+        atlasVerification.manuallyUpdateNonceTracker(userEOA);
+
+        // Check highestFullAsyncBitmap is now 4 and getNextNonce returns 240 * 4 + 1 = 961
+        (, highestFullBitmap) = atlasVerification.nonceTrackers(userEOA);
+        assertEq(highestFullBitmap, 4, "Highest full bitmap should be 4 after manually updating");
+        assertEq(atlasVerification.getNextNonce(userEOA, false), 961, "Next unused nonce should be 961");
     }
-   
+
+    function testManuallyUpdateNonceTracker() public {
+        uint128 highestFullBitmap;
+        uint8 highestUsedNonce;
+
+        uint256 fullBitmapSlot = uint256(240) | (uint256(type(uint240).max) << 8);
+        bytes32 bitmap1Key = keccak256(abi.encode(userEOA, 1));
+        bytes32 bitmap2Key = keccak256(abi.encode(userEOA, 2));
+        bytes32 bitmap3Key = keccak256(abi.encode(userEOA, 3));
+        bytes32 bitmap4Key = keccak256(abi.encode(userEOA, 4));
+
+        // Only concerned with async user nonces in this test
+        defaultAtlasWithCallConfig(defaultCallConfig().withUserNoncesSequenced(false).withDappNoncesSequenced(true).build());
+        
+        // Modify bitmaps 1 - 4 to be full
+        vm.record();
+        (highestUsedNonce,) = atlasVerification.nonceBitmaps(bitmap1Key);
+        (highestUsedNonce,) = atlasVerification.nonceBitmaps(bitmap2Key);
+        (highestUsedNonce,) = atlasVerification.nonceBitmaps(bitmap3Key);
+        (highestUsedNonce,) = atlasVerification.nonceBitmaps(bitmap4Key);
+        (bytes32[] memory reads, ) = vm.accesses(address(atlasVerification));
+        vm.store(address(atlasVerification), reads[0], bytes32(fullBitmapSlot));
+        vm.store(address(atlasVerification), reads[1], bytes32(fullBitmapSlot));
+        vm.store(address(atlasVerification), reads[2], bytes32(fullBitmapSlot));
+        vm.store(address(atlasVerification), reads[3], bytes32(fullBitmapSlot));
+
+        // Check highestFullAsyncBitmap is still 0
+        (, highestFullBitmap) = atlasVerification.nonceTrackers(userEOA);
+        assertEq(highestFullBitmap, 0, "Highest full bitmap should 0 because not updated yet");
+
+        // MAIN PART OF TEST: Call manuallyUpdateNonceTracker to update highestFullAsyncBitmap to 4
+        vm.prank(userEOA);
+        atlasVerification.manuallyUpdateNonceTracker(userEOA);
+
+        // Check highestFullAsyncBitmap is now 4
+        (, highestFullBitmap) = atlasVerification.nonceTrackers(userEOA);
+        assertEq(highestFullBitmap, 4, "Highest full bitmap should be 4 after manually updating");
+
+        // getNextNonce should return 240 * 4 + 1 = 961
+        assertEq(atlasVerification.getNextNonce(userEOA, false), 961, "Next unused nonce should be 961");
+    }
+}
+
+contract MockVerification is AtlasVerification {
+    constructor(address _atlas) AtlasVerification(_atlas) {}
+
+    function getFirstUnusedNonceInBitmap(uint256 bitmap) public pure returns (uint256) {
+        return _getFirstUnusedNonceInBitmap(bitmap);
+    }
 }

--- a/test/AtlasVerificationNonces.t.sol
+++ b/test/AtlasVerificationNonces.t.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import "forge-std/Test.sol";
+
+import { DAppConfig, DAppOperation, CallConfig } from "src/contracts/types/DAppApprovalTypes.sol";
+import { UserOperation } from "src/contracts/types/UserCallTypes.sol";
+import { SolverOperation } from "src/contracts/types/SolverCallTypes.sol";
+import { ValidCallsResult } from "src/contracts/types/ValidCallsTypes.sol";
+import { AtlasVerificationBase } from "./AtlasVerification.t.sol";
+
+
+contract AtlasVerificationNoncesTest is AtlasVerificationBase {
+
+
+
+    function testFirstTenNonces_Sequenced() public {
+        defaultAtlasWithCallConfig(defaultCallConfig().withSequenced(true).build());
+        
+        UserOperation memory userOp = validUserOperation().build();
+        SolverOperation[] memory solverOps = validSolverOperations(userOp);
+        DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).signAndBuild(address(atlasVerification), governancePK);
+        doValidCalls(AtlasVerificationBase.ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ));
+
+
+        for (uint256 i = 0; i < 10; i++) {
+            // TODO make calls, check nonces
+        }
+    } 
+   
+}

--- a/test/AtlasVerificationNonces.t.sol
+++ b/test/AtlasVerificationNonces.t.sol
@@ -12,6 +12,10 @@ import { AtlasVerificationBase } from "./AtlasVerification.t.sol";
 
 contract AtlasVerificationNoncesTest is AtlasVerificationBase {
 
+    // Q: Why track lowestEmptyBitmap and highestFullBitmap?
+    // A:   - lowestEmptyBitmap = ??
+    //      - highestFullBitmap = to calc getNextNonce (highestFullBitmap * 240) + highestUsedNonce
+    // --> can we just track highestFullBitmap and highestUsedNonce?
 
 
     function testFirstTenNonces_Sequenced() public {
@@ -28,6 +32,36 @@ contract AtlasVerificationNoncesTest is AtlasVerificationBase {
         for (uint256 i = 0; i < 10; i++) {
             // TODO make calls, check nonces
         }
-    } 
+    }
+
+    function test_bitmap2UsedAfterBitmap1Fulled_Sequenced() public {}
+
+    function test_bitmap3UsedAfterBitmap2Fulled_Sequenced() public {
+        // Use nonce 1 in bitmap 1
+        // Use nonce 239 in bitmap 1 (last in bitmap)
+        // Next nonce is 240, which should tick over to bitmap 2
+        // Use nonce 279 in bitmap 2 (last in bitmap)
+        // Next nonce is 280, which should tick over to bitmap 3
+    }
+
+    function test_emptyNoncesInUsedBitmapsCanBeUsed() public {
+        // Use nonce 1 in bitmap 1
+        // Use nonce 239 in bitmap 1 (last in bitmap)
+        // Try using nonce 2 in bitmap 1, should work - unused
+        // Next nonce is 240, which should tick over to bitmap 2
+        // Try using nonce 3 in bitmap 1, should work - unused
+    }
+
+    // does this need sequenced and non sequenced versions?
+    function test_usedNoncesCannotBeReused() public {
+        // Test nonce 1 works, uses bitmap 1
+        // Test using nonce 1 again fails
+        // Test nonce 2 works, uses bitmap 1
+        // Test using nonce 2 again fails
+        // Jump to bitmap 2
+        // Test nonce x works, uses bitmap 2
+        // Test using nonce x again fails
+        // Test using nonce 1 in bitmap 1 still fails
+    }
    
 }

--- a/test/DAppIntegration.t.sol
+++ b/test/DAppIntegration.t.sol
@@ -12,10 +12,6 @@ import "src/contracts/types/GovernanceTypes.sol";
 
 contract MockDAppIntegration is DAppIntegration {
     constructor(address _atlas) DAppIntegration(_atlas) { }
-
-    function initializeNonceInternal(address account) external returns (bool) {
-        return _initializeNonce(account);
-    }
 }
 
 contract DAppIntegrationTest is Test {
@@ -174,24 +170,6 @@ contract DAppIntegrationTest is Test {
         vm.prank(invalid);
         vm.expectRevert(FastLaneErrorsEvents.OnlyGovernance.selector);
         dAppIntegration.disableDApp(address(dAppControl));
-    }
-
-    function test_initializeNonce() public {
-        dAppIntegration.initializeNonce(governance);
-
-        bytes32 bitmapKey = keccak256(abi.encode(governance, 1));
-        (uint128 LowestEmptyBitmap, uint128 HighestEmptyBitmap) = dAppIntegration.asyncNonceBitIndex(governance);
-        (uint8 highestUsedNonce, uint240 bitmap) = dAppIntegration.asyncNonceBitmap(bitmapKey);
-
-        assertEq(LowestEmptyBitmap, uint128(2));
-        assertEq(HighestEmptyBitmap, uint128(0));
-        assertEq(highestUsedNonce, uint8(1));
-        assertEq(bitmap, uint240(0));
-    }
-
-    function test_initializeNonce_internal() public {
-        assertTrue(dAppIntegration.initializeNonceInternal(governance), "should return true when initialized");
-        assertFalse(dAppIntegration.initializeNonceInternal(governance), "should return false when already initialized");
     }
 
     function test_getGovFromControl() public {

--- a/test/base/AtlasBaseTest.t.sol
+++ b/test/base/AtlasBaseTest.t.sol
@@ -89,6 +89,9 @@ contract AtlasBaseTest is Test, TestConstants {
         vm.stopPrank();
 
         vm.label(userEOA, "USER");
+        vm.label(governanceEOA, "GOVERNANCE");
+        vm.label(solverOneEOA, "SOLVER_ONE");
+        vm.label(solverTwoEOA, "SOLVER_TWO");
         vm.label(escrow, "ESCROW");
         vm.label(address(atlas), "ATLAS");
     }

--- a/test/base/builders/DAppOperationBuilder.sol
+++ b/test/base/builders/DAppOperationBuilder.sol
@@ -50,7 +50,20 @@ contract DAppOperationBuilder is Test {
     }
 
     function withNonce(address atlasVerification, address account) public returns (DAppOperationBuilder) {
-        dappOperation.nonce = IAtlasVerification(atlasVerification).getNextNonce(account);
+        // Assumes sequenced = false. Use withNonce(address, address, bool) to specify sequenced.
+        dappOperation.nonce = IAtlasVerification(atlasVerification).getNextNonce(account, false);
+        return this;
+    }
+
+    function withNonce(
+        address atlasVerification,
+        address account,
+        bool sequenced
+    )
+        public
+        returns (DAppOperationBuilder)
+    {
+        dappOperation.nonce = IAtlasVerification(atlasVerification).getNextNonce(account, sequenced);
         return this;
     }
 
@@ -108,7 +121,7 @@ contract DAppOperationBuilder is Test {
         return this;
     }
 
-    function build() public view returns (DAppOperation memory) {
+    function build() public returns (DAppOperation memory) {
         return dappOperation;
     }
 

--- a/test/base/builders/UserOperationBuilder.sol
+++ b/test/base/builders/UserOperationBuilder.sol
@@ -41,12 +41,31 @@ contract UserOperationBuilder is Test {
     }
 
     function withNonce(address atlasVerification) public returns (UserOperationBuilder) {
-        userOperation.nonce = IAtlasVerification(atlasVerification).getNextNonce(userOperation.from);
+        // Assumes sequenced = false. Use withNonce(address, bool) to specify sequenced.
+        userOperation.nonce = IAtlasVerification(atlasVerification).getNextNonce(userOperation.from, false);
+        return this;
+    }
+
+    function withNonce(address atlasVerification, bool sequenced) public returns (UserOperationBuilder) {
+        userOperation.nonce = IAtlasVerification(atlasVerification).getNextNonce(userOperation.from, sequenced);
         return this;
     }
 
     function withNonce(address atlasVerification, address account) public returns (UserOperationBuilder) {
-        userOperation.nonce = IAtlasVerification(atlasVerification).getNextNonce(account);
+        // Assumes sequenced = false. Use withNonce(address, address, bool) to specify sequenced.
+        userOperation.nonce = IAtlasVerification(atlasVerification).getNextNonce(account, false);
+        return this;
+    }
+
+    function withNonce(
+        address atlasVerification,
+        address account,
+        bool sequenced
+    )
+        public
+        returns (UserOperationBuilder)
+    {
+        userOperation.nonce = IAtlasVerification(atlasVerification).getNextNonce(account, sequenced);
         return this;
     }
 
@@ -87,7 +106,7 @@ contract UserOperationBuilder is Test {
         return this;
     }
 
-    function build() public view returns (UserOperation memory) {
+    function build() public returns (UserOperation memory) {
         return userOperation;
     }
 

--- a/test/helpers/CallConfigBuilder.sol
+++ b/test/helpers/CallConfigBuilder.sol
@@ -6,7 +6,8 @@ import { CallConfig } from "src/contracts/types/DAppApprovalTypes.sol";
 import "forge-std/Test.sol";
 
 contract CallConfigBuilder is Test {
-    bool sequenced;
+    bool userNoncesSequenced;
+    bool dappNoncesSequenced;
     bool requirePreOps;
     bool trackPreOpsReturnData;
     bool trackUserReturnData;
@@ -23,8 +24,13 @@ contract CallConfigBuilder is Test {
     bool forwardReturnData;
     bool requireFulfillment;
 
-    function withSequenced(bool _sequenced) public returns (CallConfigBuilder) {
-        sequenced = _sequenced;
+    function withUserNoncesSequenced(bool _sequenced) public returns (CallConfigBuilder) {
+        userNoncesSequenced = _sequenced;
+        return this;
+    }
+
+    function withDappNoncesSequenced(bool _sequenced) public returns (CallConfigBuilder) {
+        dappNoncesSequenced = _sequenced;
         return this;
     }
 
@@ -105,7 +111,8 @@ contract CallConfigBuilder is Test {
 
     function build() public view returns (CallConfig memory) {
         return CallConfig(
-            sequenced,
+            userNoncesSequenced,
+            dappNoncesSequenced,
             requirePreOps,
             trackPreOpsReturnData,
             trackUserReturnData,

--- a/test/libraries/CallBits.t.sol
+++ b/test/libraries/CallBits.t.sol
@@ -15,7 +15,8 @@ contract CallBitsTest is Test {
 
     function setUp() public {
         callConfig1 = CallConfig({
-            sequenced: true,
+            userNoncesSequenced: false,
+            dappNoncesSequenced: true,
             requirePreOps: false,
             trackPreOpsReturnData: true,
             trackUserReturnData: false,
@@ -34,7 +35,8 @@ contract CallBitsTest is Test {
         });
 
         callConfig2 = CallConfig({
-            sequenced: !callConfig1.sequenced,
+            userNoncesSequenced: !callConfig1.userNoncesSequenced,
+            dappNoncesSequenced: !callConfig1.dappNoncesSequenced,
             requirePreOps: !callConfig1.requirePreOps,
             trackPreOpsReturnData: !callConfig1.trackPreOpsReturnData,
             trackUserReturnData: !callConfig1.trackUserReturnData,
@@ -54,14 +56,14 @@ contract CallBitsTest is Test {
     }
 
     function testEncodeCallConfig() public {
-        string memory expectedBitMapString = "00000000000000000101010101010101";
+        string memory expectedBitMapString = "00000000000000001010101010101010";
         assertEq(
             TestUtils.uint32ToBinaryString(CallBits.encodeCallConfig(callConfig1)),
             expectedBitMapString,
             "callConfig1 incorrect"
         );
 
-        expectedBitMapString = "00000000000000001010101010101010";
+        expectedBitMapString = "00000000000000010101010101010101";
         assertEq(
             TestUtils.uint32ToBinaryString(CallBits.encodeCallConfig(callConfig2)),
             expectedBitMapString,
@@ -72,7 +74,8 @@ contract CallBitsTest is Test {
     function testDecodeCallConfig() public {
         uint32 encodedCallConfig = CallBits.encodeCallConfig(callConfig1);
         CallConfig memory decodedCallConfig = encodedCallConfig.decodeCallConfig();
-        assertEq(decodedCallConfig.sequenced, true, "sequenced 1 incorrect");
+        assertEq(decodedCallConfig.userNoncesSequenced, false, "userNoncesSequenced 1 incorrect");
+        assertEq(decodedCallConfig.dappNoncesSequenced, true, "dappNoncesSequenced 1 incorrect");
         assertEq(decodedCallConfig.requirePreOps, false, "requirePreOps 1 incorrect");
         assertEq(decodedCallConfig.trackPreOpsReturnData, true, "trackPreOpsReturnData 1 incorrect");
         assertEq(decodedCallConfig.trackUserReturnData, false, "trackUserReturnData 1 incorrect");
@@ -91,7 +94,8 @@ contract CallBitsTest is Test {
 
         encodedCallConfig = CallBits.encodeCallConfig(callConfig2);
         decodedCallConfig = encodedCallConfig.decodeCallConfig();
-        assertEq(decodedCallConfig.sequenced, false, "sequenced 2 incorrect");
+        assertEq(decodedCallConfig.userNoncesSequenced, true, "userNoncesSequenced 2 incorrect");
+        assertEq(decodedCallConfig.dappNoncesSequenced, false, "dappNoncesSequenced 2 incorrect");
         assertEq(decodedCallConfig.requirePreOps, true, "requirePreOps 2 incorrect");
         assertEq(decodedCallConfig.trackPreOpsReturnData, false, "trackPreOpsReturnData 2 incorrect");
         assertEq(decodedCallConfig.trackUserReturnData, true, "trackUserReturnData 2 incorrect");
@@ -106,12 +110,13 @@ contract CallBitsTest is Test {
         assertEq(decodedCallConfig.unknownAuctioneer, false, "unknownAuctioneer 2 incorrect");
         assertEq(decodedCallConfig.verifyCallChainHash, true, "verifyCallChainHash 2 incorrect");
         assertEq(decodedCallConfig.forwardReturnData, false, "forwardPreOpsReturnData 2 incorrect");
-        assertEq(decodedCallConfig.requireFulfillment, true, "requireFulfillment 2 incorrect");
+        assertEq(decodedCallConfig.requireFulfillment, true, "requireFulfillment 2 incorrect");   
     }
 
     function testConfigParameters() public {
         uint32 encodedCallConfig = CallBits.encodeCallConfig(callConfig1);
-        assertEq(encodedCallConfig.needsSequencedNonces(), true, "needsSequencedNonces 1 incorrect");
+        assertEq(encodedCallConfig.needsSequencedUserNonces(), false, "needsSequencedUserNonces 1 incorrect");
+        assertEq(encodedCallConfig.needsSequencedDAppNonces(), true, "needsSequencedDAppNonces 1 incorrect");
         assertEq(encodedCallConfig.needsPreOpsCall(), false, "needsPreOpsCall 1 incorrect");
         assertEq(encodedCallConfig.needsPreOpsReturnData(), true, "needsPreOpsReturnData 1 incorrect");
         assertEq(encodedCallConfig.needsUserReturnData(), false, "needsUserReturnData 1 incorrect");
@@ -127,8 +132,11 @@ contract CallBitsTest is Test {
         assertEq(encodedCallConfig.verifyCallChainHash(), false, "verifyCallChainHash 1 incorrect");
         assertEq(encodedCallConfig.forwardReturnData(), true, "forwardPreOpsReturnData 1 incorrect");
         assertEq(encodedCallConfig.needsFulfillment(), false, "needsFulfillment 1 incorrect");
+        
+
         encodedCallConfig = CallBits.encodeCallConfig(callConfig2);
-        assertEq(encodedCallConfig.needsSequencedNonces(), false, "needsSequencedNonces 2 incorrect");
+        assertEq(encodedCallConfig.needsSequencedUserNonces(), true, "needsSequencedUserNonces 2 incorrect");
+        assertEq(encodedCallConfig.needsSequencedDAppNonces(), false, "needsSequencedDAppNonces 2 incorrect");
         assertEq(encodedCallConfig.needsPreOpsCall(), true, "needsPreOpsCall 2 incorrect");
         assertEq(encodedCallConfig.needsPreOpsReturnData(), false, "needsPreOpsReturnData 2 incorrect");
         assertEq(encodedCallConfig.needsUserReturnData(), true, "needsUserReturnData 2 incorrect");


### PR DESCRIPTION
This PR serves to fix any core Atlas contract bugs (and test bugs) so #79 tests fully pass and can be merged into `main`.

Changes made:

- In CallConfig, the param is named `bool sequenced` or `needsSequencedNonces()` but when the param is received in `_handleNonces()` and `_updateNonceTracker()`, it is called `bool async`. So we need to negate `callConfig.needsSequencedNonces()` when passing it as a param, to turn it into `async` as those 2 mean the opposite.
- Some tests were expecting a fail with DAppSignatureInvalid when it was UserSignatureInvalid causing the fail
- I made a small change to the `bitmapIndex` check math on lines 385 and 387 in AtlasVerification.sol. @thogard785 please double check this change especially. 