### PR TITLE
Smart wallet support

### DIFF
--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -21,6 +21,44 @@ import { FastLaneErrorsEvents } from "../types/Emissions.sol";
 
 import "forge-std/Test.sol"; // TODO remove
 
+// FROM ETH-INFINITISM REPO:
+// https://github.com/eth-infinitism/account-abstraction/blob/develop/contracts/interfaces/IAccount.sol
+
+interface IAccount {
+    /**
+     * Validate user's signature and nonce
+     * the entryPoint will make the call to the recipient only if this validation call returns successfully.
+     * signature failure should be reported by returning SIG_VALIDATION_FAILED (1).
+     * This allows making a "simulation call" without a valid signature
+     * Other failures (e.g. nonce mismatch, or invalid signature format) should still revert to signal failure.
+     *
+     * @dev Must validate caller is the entryPoint.
+     *      Must validate the signature and nonce
+     * @param userOp              - The operation that is about to be executed.
+     * @param userOpHash          - Hash of the user's request data. can be used as the basis for signature.
+     * @param missingAccountFunds - Missing funds on the account's deposit in the entrypoint.
+     *                              This is the minimum amount to transfer to the sender(entryPoint) to be
+     *                              able to make the call. The excess is left as a deposit in the entrypoint
+     *                              for future calls. Can be withdrawn anytime using "entryPoint.withdrawTo()".
+     *                              In case there is a paymaster in the request (or the current deposit is high
+     *                              enough), this value will be zero.
+     * @return validationData       - Packaged ValidationData structure. use `_packValidationData` and
+     *                              `_unpackValidationData` to encode and decode.
+     *                              <20-byte> sigAuthorizer - 0 for valid signature, 1 to mark signature failure,
+     *                                 otherwise, an address of an "authorizer" contract.
+     *                              <6-byte> validUntil - Last timestamp this operation is valid. 0 for "indefinite"
+     *                              <6-byte> validAfter - First timestamp this operation is valid
+     *                                                    If an account doesn't use time-range, it is enough to
+     *                                                    return SIG_VALIDATION_FAILED value (1) for signature failure.
+     *                              Note that the validation code cannot use block.timestamp (or block.number) directly.
+     */
+    function validateUserOp(
+        UserOperation calldata userOp,
+        bytes32 userOpHash,
+        uint256 missingAccountFunds
+    ) external returns (uint256 validationData);
+}
+
 // NOTE: AtlasVerification is the separate contract version of the DappVerification/DAppIntegration
 // inheritance slice of the original Atlas design
 
@@ -430,6 +468,12 @@ contract AtlasVerification is EIP712, DAppIntegration {
     {
         // Verify the signature before storing any data to avoid
         // spoof transactions clogging up dapp userNonces
+
+        if (userOp.from.code.length > 0) {
+            // TODO: not sure if 30k gas limit is accurate
+            bool validSmartWallet = IAccount(userOp.from).validateUserOp{gas: 30_000}(userOp, _getProofHash(userOp), 0) == 0;
+            return (isSimulation || validSmartWallet);
+        }
 
         bool bypassSignature = msgSender == userOp.from || (isSimulation && userOp.signature.length == 0);
 

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -56,7 +56,9 @@ interface IAccount {
         UserOperation calldata userOp,
         bytes32 userOpHash,
         uint256 missingAccountFunds
-    ) external returns (uint256 validationData);
+    )
+        external
+        returns (uint256 validationData);
 }
 
 // NOTE: AtlasVerification is the separate contract version of the DappVerification/DAppIntegration
@@ -474,7 +476,8 @@ contract AtlasVerification is EIP712, DAppIntegration {
             if (userOp.from == address(this) || userOp.from == ATLAS || userOp.from == userOp.control) {
                 return false;
             }
-            bool validSmartWallet = IAccount(userOp.from).validateUserOp{gas: 30_000}(userOp, _getProofHash(userOp), 0) == 0;
+            bool validSmartWallet =
+                IAccount(userOp.from).validateUserOp{ gas: 30_000 }(userOp, _getProofHash(userOp), 0) == 0;
             return (isSimulation || validSmartWallet);
         }
 

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -471,6 +471,9 @@ contract AtlasVerification is EIP712, DAppIntegration {
 
         if (userOp.from.code.length > 0) {
             // TODO: not sure if 30k gas limit is accurate
+            if (userOp.from == address(this) || userOp.from == ATLAS || userOp.from == userOp.control) {
+                return false;
+            }
             bool validSmartWallet = IAccount(userOp.from).validateUserOp{gas: 30_000}(userOp, _getProofHash(userOp), 0) == 0;
             return (isSimulation || validSmartWallet);
         }


### PR DESCRIPTION
This is *very* limited support for smart wallets.  Note that the Atlas UserOperation format doesn't match the 4337 UserOperation format,  so the smart wallets would have to explicitly build in support for Atlas.

In future versions, we'll have to choose between matching the 4337 format (which may hurt gas efficiency for regular EOAs) or potentially using a different entrypoint contract.  

But for now, this is a very simple implementation.  