### PR TITLE
Update Coverage Doc

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -91,7 +91,43 @@ Last updated: 2024-Jan-30
 
 ### AtlasVerification.sol
 
+Coverage as per coverage report:
+
+- Lines: 145/151 (96%)
+- Functions: 18/19 (94.7%)
+
+Work Needed:
+
+- L163 return with `ValidCallResult.NoSolverOp`
+- L278 return false if `dAppOp.control != dConfig.to`
+- L360 `_handleNonces` returns true at end. Probably a bug and already covered.
+- L381 `_incrementHighestFullAsyncBitmap` returns nonceTracker at end. Probably a bug and already covered.
+- L414 `getDomainSeparator` view function.
+- L525 `manuallyUpdateNonceTracker` breaks if `nonceBitmap.bitmap == FULL_BITMAP` in loop. Probably a bug and already covered.
+
+Last updated: 2024-Jan-30
+
 ### DAppIntegration.sol
+
+Coverage as per coverage report:
+
+- Lines: 26/26 (100%)
+- Functions: 5/5 (100%)
+
+Last updated: 2024-Jan-30
+
+### Mimic.sol
+
+Coverage as per coverage report:
+
+- Lines: 0/3 (0%)
+- Functions: 0/1 (0%)
+
+Work Needed:
+
+- Full tests, its just a fallback function so may be hard to reflect in coverage report.
+
+Last updated: 2024-Jan-30
 
 ## Common Contracts - `/contracts/common`
 

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -129,6 +129,19 @@ Work Needed:
 
 Last updated: 2024-Jan-30
 
+### ExecutionEnvironment.sol
+
+Coverage as per coverage report:
+
+- Lines: 0/86 (0%)
+- Functions: 0/14 (0%)
+
+Work Needed:
+
+- EE and ExecutionBase should be tested together. May be difficult because delegatecall involved.
+
+Last updated: 2024-Jan-30
+
 ## Common Contracts - `/contracts/common`
 
 ### Permit69.sol

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -6,6 +6,17 @@ Some parts of the codebase are either difficult to reach in tests, or do not reg
 
 ### Atlas.sol
 
+Coverage as per coverage report:
+
+- Lines: 33/73 (45.2%)
+- Functions: 4/6 (66.7%)
+
+Work Needed:
+
+- Lots of work needed.
+
+Last updated: 2024-Jan-30
+
 ### Escrow.sol
 
 Fully tested in `/test/Escrow.t.sol`, besides the following unreachable lines:
@@ -16,6 +27,17 @@ Fully tested in `/test/Escrow.t.sol`, besides the following unreachable lines:
 Last updated: 2024-Jan-25
 
 ### Factory.sol
+
+Coverage as per coverage report:
+
+- Lines: 14/16 (87.5%)
+- Functions: 6/6 (100%)
+
+Work Needed:
+
+- Only L78 and L80 in `_setExecutionEnvironment`. L80 is assembly, coverage might get tricky.
+
+Last updated: 2024-Jan-30
 
 ### AtlETH.sol
 

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -41,7 +41,33 @@ Last updated: 2024-Jan-30
 
 ### AtlETH.sol
 
+Coverage as per coverage report:
+
+- Lines: 42/78 (53.8%)
+- Functions: 12/23 (52.2%)
+
+Work Needed:
+
+- View function tests
+- AtlETH's ERC20 functions (approve, transfer, transferFrom)
+- Permit (Also for ERC20 functionality)
+- Branches in `_deduct`
+- All `redeem` and `_redeem` functionality
+
+Last updated: 2024-Jan-30
+
 ### GasAccounting.sol
+
+Coverage as per coverage report:
+
+- Lines: 81/82 (98.8%)
+- Functions: 12/12 (100%)
+
+Work Needed:
+
+- Just 1 line: L36 in `contribute` (which calls `_contribute`)
+
+Last updated: 2024-Jan-30
 
 ### SafetyLocks.sol
 

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -71,7 +71,23 @@ Last updated: 2024-Jan-30
 
 ### SafetyLocks.sol
 
+Coverage as per coverage report:
+
+- Lines: 18/20 (90%)
+- Functions: 5/6 (83.3%)
+
+Work Needed:
+
+- L32 calling `_checkIfUnlocked` in `_initializeEscrowLock`
+- L86 `isUnlocked` view function (in true and false states)
+
+Last updated: 2024-Jan-30
+
 ### Storage.sol
+
+Does not show up on coverage report. Check `Storage.t.sol`.
+
+Last updated: 2024-Jan-30
 
 ### AtlasVerification.sol
 


### PR DESCRIPTION
Update coverage doc to reflect current state of test coverage in repo. Should reflect info from coverage report and explain where report is inaccurate.