### PR TITLE
Split Errors and Events Into Separate Files

### DIFF
--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -10,9 +10,8 @@ import { SafeTransferLib, ERC20 } from "solmate/utils/SafeTransferLib.sol";
 import { Escrow } from "./Escrow.sol";
 import { Factory } from "./Factory.sol";
 
-import { UserSimulationFailed, UserUnexpectedSuccess, UserSimulationSucceeded } from "../types/Emissions.sol";
-
-import { FastLaneErrorsEvents } from "../types/Emissions.sol";
+import { AtlasEvents } from "src/contracts/types/AtlasEvents.sol";
+import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 
 import "../types/SolverCallTypes.sol";
 import "../types/UserCallTypes.sol";

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -17,7 +17,7 @@ import { EscrowBits } from "../libraries/EscrowBits.sol";
 import { CallVerification } from "../libraries/CallVerification.sol";
 
 import { DAppIntegration } from "./DAppIntegration.sol";
-import { FastLaneErrorsEvents } from "../types/Emissions.sol";
+import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 
 import "forge-std/Test.sol"; // TODO remove
 
@@ -58,7 +58,7 @@ contract AtlasVerification is EIP712, DAppIntegration {
         // Verify that the calldata injection came from the dApp frontend
         // and that the signatures are valid.
 
-        if (msg.sender != ATLAS) revert InvalidCaller();
+        if (msg.sender != ATLAS) revert AtlasErrors.InvalidCaller();
 
         uint256 solverOpCount = solverOps.length;
         SolverOperation[] memory prunedSolverOps = new SolverOperation[](solverOpCount);
@@ -509,7 +509,7 @@ contract AtlasVerification is EIP712, DAppIntegration {
 
     // Call if highestFullAsyncBitmap doesn't reflect real full bitmap of an account
     function manuallyUpdateNonceTracker(address account) external {
-        if (msg.sender != account) revert FastLaneErrorsEvents.OnlyAccount();
+        if (msg.sender != account) revert AtlasErrors.OnlyAccount();
 
         NonceTracker memory nonceTracker = nonceTrackers[account];
         NonceBitmap memory nonceBitmap;

--- a/src/contracts/atlas/DAppIntegration.sol
+++ b/src/contracts/atlas/DAppIntegration.sol
@@ -7,7 +7,7 @@ import { CallBits } from "../libraries/CallBits.sol";
 
 import "../types/GovernanceTypes.sol";
 
-import { FastLaneErrorsEvents } from "../types/Emissions.sol";
+import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 
 import "forge-std/Test.sol"; // TODO remove
 
@@ -55,11 +55,11 @@ contract DAppIntegration {
     function initializeGovernance(address controller) external {
         address govAddress = IDAppControl(controller).getDAppSignatory();
 
-        if (msg.sender != govAddress) revert FastLaneErrorsEvents.OnlyGovernance();
+        if (msg.sender != govAddress) revert AtlasErrors.OnlyGovernance();
 
         bytes32 signatoryKey = keccak256(abi.encode(msg.sender, controller, msg.sender));
 
-        if (signatories[signatoryKey]) revert FastLaneErrorsEvents.OwnerActive();
+        if (signatories[signatoryKey]) revert AtlasErrors.OwnerActive();
 
         uint32 callConfig = CallBits.buildCallConfig(controller);
 
@@ -72,12 +72,12 @@ contract DAppIntegration {
     function addSignatory(address controller, address signatory) external {
         GovernanceData memory govData = governance[controller];
 
-        if (msg.sender != govData.governance) revert FastLaneErrorsEvents.OnlyGovernance();
+        if (msg.sender != govData.governance) revert AtlasErrors.OnlyGovernance();
 
         bytes32 signatoryKey = keccak256(abi.encode(msg.sender, controller, signatory));
 
         if (signatories[signatoryKey]) {
-            revert FastLaneErrorsEvents.SignatoryActive();
+            revert AtlasErrors.SignatoryActive();
         }
 
         signatories[signatoryKey] = true;
@@ -89,12 +89,12 @@ contract DAppIntegration {
         GovernanceData memory govData = governance[controller];
 
         if (msg.sender != govData.governance && msg.sender != signatory) {
-            revert FastLaneErrorsEvents.InvalidCaller();
+            revert AtlasErrors.InvalidCaller();
         }
 
         bytes32 signatoryKey = keccak256(abi.encode(govData.governance, controller, signatory));
 
-        if (!signatories[signatoryKey]) revert FastLaneErrorsEvents.InvalidDAppControl();
+        if (!signatories[signatoryKey]) revert AtlasErrors.InvalidDAppControl();
 
         delete signatories[signatoryKey];
     }
@@ -102,14 +102,14 @@ contract DAppIntegration {
     function disableDApp(address dAppControl) external {
         GovernanceData memory govData = governance[dAppControl];
 
-        if (msg.sender != govData.governance) revert FastLaneErrorsEvents.OnlyGovernance();
+        if (msg.sender != govData.governance) revert AtlasErrors.OnlyGovernance();
 
         delete governance[dAppControl];
     }
 
     function getGovFromControl(address dAppControl) external view returns (address governanceAddress) {
         GovernanceData memory govData = governance[dAppControl];
-        if (govData.lastUpdate == 0) revert FastLaneErrorsEvents.DAppNotEnabled();
+        if (govData.lastUpdate == 0) revert AtlasErrors.DAppNotEnabled();
         governanceAddress = govData.governance;
     }
 }

--- a/src/contracts/atlas/ExecutionEnvironment.sol
+++ b/src/contracts/atlas/ExecutionEnvironment.sol
@@ -19,9 +19,9 @@ import { Base } from "../common/ExecutionBase.sol";
 
 import { CallBits } from "../libraries/CallBits.sol";
 
-import "forge-std/Test.sol";
+import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 
-import { FastLaneErrorsEvents } from "../types/Emissions.sol";
+import "forge-std/Test.sol";
 
 contract ExecutionEnvironment is Base {
     using CallBits for uint32;
@@ -162,7 +162,7 @@ contract ExecutionEnvironment is Base {
 
         // Verify that the DAppControl contract matches the solver's expectations
         if (solverOp.control != _control()) {
-            revert FastLaneErrorsEvents.AlteredControlHash();
+            revert AtlasErrors.AlteredControlHash();
         }
 
         bool success;
@@ -176,12 +176,12 @@ contract ExecutionEnvironment is Base {
             (success, data) = _control().delegatecall(forwardSpecial(data, ExecutionPhase.PreSolver));
 
             if (!success) {
-                revert FastLaneErrorsEvents.PreSolverFailed();
+                revert AtlasErrors.PreSolverFailed();
             }
 
             success = abi.decode(data, (bool));
             if (!success) {
-                revert FastLaneErrorsEvents.PreSolverFailed();
+                revert AtlasErrors.PreSolverFailed();
             }
         }
 
@@ -198,7 +198,7 @@ contract ExecutionEnvironment is Base {
 
         // Verify that it was successful
         if (!success) {
-            revert FastLaneErrorsEvents.SolverOperationReverted();
+            revert AtlasErrors.SolverOperationReverted();
         }
 
         // If this was a user intent, handle and verify fulfillment
@@ -212,12 +212,12 @@ contract ExecutionEnvironment is Base {
             (success, data) = _control().delegatecall(forwardSpecial(data, ExecutionPhase.PostSolver));
 
             if (!success) {
-                revert FastLaneErrorsEvents.PostSolverFailed();
+                revert AtlasErrors.PostSolverFailed();
             }
 
             success = abi.decode(data, (bool));
             if (!success) {
-                revert FastLaneErrorsEvents.IntentUnfulfilled();
+                revert AtlasErrors.IntentUnfulfilled();
             }
         }
 
@@ -225,12 +225,12 @@ contract ExecutionEnvironment is Base {
         uint256 balance = etherIsBidToken ? address(this).balance : ERC20(solverOp.bidToken).balanceOf(address(this));
 
         if (balance < bidBalance + solverOp.bidAmount) {
-            revert FastLaneErrorsEvents.SolverBidUnpaid();
+            revert AtlasErrors.SolverBidUnpaid();
         }
 
         // Verify that the solver repaid their msg.value
         if (!IEscrow(atlas).validateBalances()) {
-            revert FastLaneErrorsEvents.SolverMsgValueUnpaid();
+            revert AtlasErrors.SolverMsgValueUnpaid();
         }
     }
 

--- a/src/contracts/atlas/Factory.sol
+++ b/src/contracts/atlas/Factory.sol
@@ -5,7 +5,8 @@ import { IDAppControl } from "../interfaces/IDAppControl.sol";
 import { Mimic } from "./Mimic.sol";
 import { DAppConfig } from "src/contracts/types/DAppApprovalTypes.sol";
 import { UserOperation } from "../types/UserCallTypes.sol";
-import { AtlasEvents } from "../types/Emissions.sol";
+import { AtlasEvents } from "src/contracts/types/AtlasEvents.sol";
+import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 
 import "forge-std/Test.sol";
 

--- a/src/contracts/atlas/SafetyLocks.sol
+++ b/src/contracts/atlas/SafetyLocks.sol
@@ -12,11 +12,10 @@ import "../types/EscrowTypes.sol";
 import "../types/LockTypes.sol";
 
 import { Storage } from "./Storage.sol";
-import { FastLaneErrorsEvents, AtlasEvents } from "../types/Emissions.sol";
 
 // import "forge-std/Test.sol";
 
-abstract contract SafetyLocks is Storage, FastLaneErrorsEvents, AtlasEvents {
+abstract contract SafetyLocks is Storage {
     using SafetyBits for EscrowKey;
     using CallBits for uint32;
 

--- a/src/contracts/atlas/Storage.sol
+++ b/src/contracts/atlas/Storage.sol
@@ -4,9 +4,10 @@ pragma solidity 0.8.22;
 import "../types/EscrowTypes.sol";
 import "../types/LockTypes.sol";
 
-import { AtlasEvents } from "src/contracts/types/Emissions.sol";
+import { AtlasEvents } from "src/contracts/types/AtlasEvents.sol";
+import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 
-contract Storage {
+contract Storage is AtlasEvents, AtlasErrors {
     // Atlas constants
     uint256 internal constant _MAX_GAS = 1_500_000;
     uint256 internal constant LEDGER_LENGTH = 6; // type(Party).max = 6
@@ -77,7 +78,7 @@ contract Storage {
         withdrawals = type(uint256).max;
         deposits = type(uint256).max;
 
-        emit AtlasEvents.SurchargeRecipientTransferred(_surchargeRecipient);
+        emit SurchargeRecipientTransferred(_surchargeRecipient);
     }
 
     function _computeDomainSeparator() internal view virtual returns (bytes32) { }

--- a/src/contracts/helpers/Simulator.sol
+++ b/src/contracts/helpers/Simulator.sol
@@ -3,9 +3,7 @@ pragma solidity 0.8.22;
 
 import { IAtlas } from "../interfaces/IAtlas.sol";
 
-import { UserSimulationFailed, UserUnexpectedSuccess, UserSimulationSucceeded } from "../types/Emissions.sol";
-
-import { FastLaneErrorsEvents } from "../types/Emissions.sol";
+import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 
 import "../types/SolverCallTypes.sol";
 import "../types/UserCallTypes.sol";
@@ -18,7 +16,7 @@ import { SafetyBits } from "../libraries/SafetyBits.sol";
 
 import "forge-std/Test.sol";
 
-contract Simulator is FastLaneErrorsEvents {
+contract Simulator is AtlasErrors {
     using CallVerification for UserOperation;
     using CallBits for uint32;
 

--- a/src/contracts/types/AtlasErrors.sol
+++ b/src/contracts/types/AtlasErrors.sol
@@ -7,7 +7,7 @@ contract AtlasErrors {
     error UserSimulationFailed();
     error UserSimulationSucceeded();
     error UserUnexpectedSuccess();
-    
+
     error SolverBidUnpaid();
     error SolverMsgValueUnpaid();
     error SolverOperationReverted();
@@ -30,7 +30,6 @@ contract AtlasErrors {
     error PostOpsSimFail();
     error SimulationPassed();
     error ValidCalls(ValidCallsResult);
-
 
     // Atlas
     error PreOpsFail();
@@ -93,32 +92,4 @@ contract AtlasErrors {
     // AtlasVerification
     error NoUnusedNonceInBitmap();
     error OnlyAccount();
-}
-
-contract AtlasEvents {
-    // Metacall events
-    event MetacallResult(address indexed bundler, address indexed user, address indexed winningSolver);
-    event SolverExecution(address indexed solver, uint256 index, bool isWin);
-
-    // Escrow call step events
-    event PreOpsCall(address environment, bool success, bytes returnData);
-    event UserCall(address environment, bool success, bytes returnData);
-    event PostOpsCall(address environment, bool success); // No return data tracking for post ops?
-
-    // Factory
-    event ExecutionEnvironmentCreated(address indexed user, address indexed executionEnvironment);
-
-    // Gas accounting
-    event GasRefundSettled(address indexed bundler, uint256 refundedETH);
-
-    // Surcharge events
-    event SurchargeWithdrawn(address to, uint256 amount);
-    event SurchargeRecipientTransferStarted(address currentRecipient, address newRecipient);
-    event SurchargeRecipientTransferred(address newRecipient);
-
-    event SolverTxResult(
-        address indexed solverTo, address indexed solverFrom, bool executed, bool success, uint256 result
-    );
-    event UserTxResult(address indexed user, uint256 valueReturned, uint256 gasRefunded);
-    event MEVPaymentFailure(address indexed controller, uint32 callConfig, address bidToken, uint256 bidAmount);
 }

--- a/src/contracts/types/AtlasEvents.sol
+++ b/src/contracts/types/AtlasEvents.sol
@@ -1,0 +1,30 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.22;
+
+contract AtlasEvents {
+    // Metacall events
+    event MetacallResult(address indexed bundler, address indexed user, address indexed winningSolver);
+    event SolverExecution(address indexed solver, uint256 index, bool isWin);
+
+    // Escrow call step events
+    event PreOpsCall(address environment, bool success, bytes returnData);
+    event UserCall(address environment, bool success, bytes returnData);
+    event PostOpsCall(address environment, bool success); // No return data tracking for post ops?
+
+    // Factory
+    event ExecutionEnvironmentCreated(address indexed user, address indexed executionEnvironment);
+
+    // Gas accounting
+    event GasRefundSettled(address indexed bundler, uint256 refundedETH);
+
+    // Surcharge events
+    event SurchargeWithdrawn(address to, uint256 amount);
+    event SurchargeRecipientTransferStarted(address currentRecipient, address newRecipient);
+    event SurchargeRecipientTransferred(address newRecipient);
+
+    event SolverTxResult(
+        address indexed solverTo, address indexed solverFrom, bool executed, bool success, uint256 result
+    );
+    event UserTxResult(address indexed user, uint256 valueReturned, uint256 gasRefunded);
+    event MEVPaymentFailure(address indexed controller, uint32 callConfig, address bidToken, uint256 bidAmount);
+}

--- a/src/contracts/types/Emissions.sol
+++ b/src/contracts/types/Emissions.sol
@@ -3,20 +3,11 @@ pragma solidity 0.8.22;
 
 import "../types/ValidCallsTypes.sol";
 
-error UserSimulationFailed();
-error UserSimulationSucceeded();
-error UserUnexpectedSuccess();
-
-contract FastLaneErrorsEvents {
-    // NOTE: nonce is the executed nonce
-    event SolverTxResult(
-        address indexed solverTo, address indexed solverFrom, bool executed, bool success, uint256 result
-    );
-
-    event UserTxResult(address indexed user, uint256 valueReturned, uint256 gasRefunded);
-
-    event MEVPaymentFailure(address indexed controller, uint32 callConfig, address bidToken, uint256 bidAmount);
-
+contract AtlasErrors {
+    error UserSimulationFailed();
+    error UserSimulationSucceeded();
+    error UserUnexpectedSuccess();
+    
     error SolverBidUnpaid();
     error SolverMsgValueUnpaid();
     error SolverOperationReverted();
@@ -38,10 +29,8 @@ contract FastLaneErrorsEvents {
     error SolverSimFail();
     error PostOpsSimFail();
     error SimulationPassed();
-
     error ValidCalls(ValidCallsResult);
 
-    // NEW Custom Errors to replace string errors
 
     // Atlas
     error PreOpsFail();
@@ -104,22 +93,6 @@ contract FastLaneErrorsEvents {
     // AtlasVerification
     error NoUnusedNonceInBitmap();
     error OnlyAccount();
-
-    /*
-    event NewDAppIntegration(
-        address indexed environment,
-        address indexed user,
-        address indexed controller,
-        uint32 callConfig
-    );
-
-    event DAppDisabled(
-        address indexed environment,
-        address indexed user,
-        address indexed controller,
-        uint32 callConfig
-    );
-    */
 }
 
 contract AtlasEvents {
@@ -142,4 +115,10 @@ contract AtlasEvents {
     event SurchargeWithdrawn(address to, uint256 amount);
     event SurchargeRecipientTransferStarted(address currentRecipient, address newRecipient);
     event SurchargeRecipientTransferred(address newRecipient);
+
+    event SolverTxResult(
+        address indexed solverTo, address indexed solverFrom, bool executed, bool success, uint256 result
+    );
+    event UserTxResult(address indexed user, uint256 valueReturned, uint256 gasRefunded);
+    event MEVPaymentFailure(address indexed controller, uint32 callConfig, address bidToken, uint256 bidAmount);
 }

--- a/test/AtlasVerificationNonces.t.sol
+++ b/test/AtlasVerificationNonces.t.sol
@@ -9,7 +9,6 @@ import { SolverOperation } from "src/contracts/types/SolverCallTypes.sol";
 import { ValidCallsResult } from "src/contracts/types/ValidCallsTypes.sol";
 import { AtlasVerification } from "src/contracts/atlas/AtlasVerification.sol";
 import { AtlasVerificationBase } from "./AtlasVerification.t.sol";
-import { FastLaneErrorsEvents } from "src/contracts/types/Emissions.sol";
 
 contract AtlasVerificationNoncesTest is AtlasVerificationBase {
 
@@ -273,8 +272,6 @@ contract AtlasVerificationNoncesTest is AtlasVerificationBase {
         assertEq(mockVerification.getFirstUnusedNonceInBitmap(0), 1, "Empty bitmap should return 1");
 
         // full bitmap should return 0
-        // vm.expectRevert(FastLaneErrorsEvents.NoUnusedNonceInBitmap.selector);
-        // mockVerification.getFirstUnusedNonceInBitmap(type(uint240).max);
         assertEq(mockVerification.getFirstUnusedNonceInBitmap(type(uint240).max), 0, "Full bitmap should return 0");
 
         // bitmap 000...01 should return 2

--- a/test/DAppIntegration.t.sol
+++ b/test/DAppIntegration.t.sol
@@ -4,7 +4,8 @@ pragma solidity 0.8.22;
 import "forge-std/Test.sol";
 
 import { DAppIntegration } from "src/contracts/atlas/DAppIntegration.sol";
-import { FastLaneErrorsEvents } from "src/contracts/types/Emissions.sol";
+// import { AtlasEvents } from "src/contracts/types/AtlasEvents.sol";
+import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 
 import { DummyDAppControl, CallConfigBuilder } from "./base/DummyDAppControl.sol";
 
@@ -45,14 +46,14 @@ contract DAppIntegrationTest is Test {
 
     function test_initializeGovernance_onlyGovernanceAllowed() public {
         vm.prank(invalid);
-        vm.expectRevert(FastLaneErrorsEvents.OnlyGovernance.selector);
+        vm.expectRevert(AtlasErrors.OnlyGovernance.selector);
         dAppIntegration.initializeGovernance(address(dAppControl));
     }
 
     function test_initializeGovernance_alreadyInitialized() public {
         vm.startPrank(governance);
         dAppIntegration.initializeGovernance(address(dAppControl));
-        vm.expectRevert(FastLaneErrorsEvents.OwnerActive.selector);
+        vm.expectRevert(AtlasErrors.OwnerActive.selector);
         dAppIntegration.initializeGovernance(address(dAppControl));
         vm.stopPrank();
     }
@@ -82,7 +83,7 @@ contract DAppIntegrationTest is Test {
         dAppIntegration.initializeGovernance(address(dAppControl));
 
         vm.prank(invalid);
-        vm.expectRevert(FastLaneErrorsEvents.OnlyGovernance.selector);
+        vm.expectRevert(AtlasErrors.OnlyGovernance.selector);
         dAppIntegration.addSignatory(address(dAppControl), signatory);
     }
 
@@ -90,7 +91,7 @@ contract DAppIntegrationTest is Test {
         vm.startPrank(governance);
         dAppIntegration.initializeGovernance(address(dAppControl));
         dAppIntegration.addSignatory(address(dAppControl), signatory);
-        vm.expectRevert(FastLaneErrorsEvents.SignatoryActive.selector);
+        vm.expectRevert(AtlasErrors.SignatoryActive.selector);
         dAppIntegration.addSignatory(address(dAppControl), signatory);
         vm.stopPrank();
     }
@@ -134,7 +135,7 @@ contract DAppIntegrationTest is Test {
         vm.stopPrank();
 
         vm.prank(invalid);
-        vm.expectRevert(FastLaneErrorsEvents.InvalidCaller.selector);
+        vm.expectRevert(AtlasErrors.InvalidCaller.selector);
         dAppIntegration.removeSignatory(address(dAppControl), signatory);
     }
 
@@ -144,7 +145,7 @@ contract DAppIntegrationTest is Test {
         dAppIntegration.addSignatory(address(dAppControl), signatory);
         dAppIntegration.removeSignatory(address(dAppControl), signatory);
         // signatoryKey is now invalid
-        vm.expectRevert(FastLaneErrorsEvents.InvalidDAppControl.selector);
+        vm.expectRevert(AtlasErrors.InvalidDAppControl.selector);
         dAppIntegration.removeSignatory(address(dAppControl), signatory);
         vm.stopPrank();
     }
@@ -168,7 +169,7 @@ contract DAppIntegrationTest is Test {
         vm.stopPrank();
 
         vm.prank(invalid);
-        vm.expectRevert(FastLaneErrorsEvents.OnlyGovernance.selector);
+        vm.expectRevert(AtlasErrors.OnlyGovernance.selector);
         dAppIntegration.disableDApp(address(dAppControl));
     }
 
@@ -181,7 +182,7 @@ contract DAppIntegrationTest is Test {
     }
 
     function test_getGovFromControl_dAppNotEnabled() public {
-        vm.expectRevert(FastLaneErrorsEvents.DAppNotEnabled.selector);
+        vm.expectRevert(AtlasErrors.DAppNotEnabled.selector);
         dAppIntegration.getGovFromControl(address(dAppControl));
     }
 }

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -6,7 +6,8 @@ import "forge-std/Test.sol";
 import { SafeTransferLib } from "solmate/utils/SafeTransferLib.sol";
 
 import { IEscrow } from "src/contracts/interfaces/IEscrow.sol";
-import { FastLaneErrorsEvents, AtlasEvents } from "src/contracts/types/Emissions.sol";
+import { AtlasEvents } from "src/contracts/types/AtlasEvents.sol";
+import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 import { CallBits } from "src/contracts/libraries/CallBits.sol";
 import { EscrowBits } from "src/contracts/libraries/EscrowBits.sol";
 
@@ -147,7 +148,7 @@ contract EscrowTest is AtlasBaseTest {
                 .withReuseUserOp(true) // Allow metacall to revert
                 .build()
         );
-        executeHookCase(true, 0, FastLaneErrorsEvents.PreOpsFail.selector);
+        executeHookCase(true, 0, AtlasErrors.PreOpsFail.selector);
     }
 
     // Ensure the user operation executes successfully. To ensure the operation's returned data is as expected, we
@@ -170,7 +171,7 @@ contract EscrowTest is AtlasBaseTest {
                 .withReuseUserOp(true) // Allow metacall to revert
                 .build()
         );
-        executeHookCase(true, 0, FastLaneErrorsEvents.UserOpFail.selector);
+        executeHookCase(true, 0, AtlasErrors.UserOpFail.selector);
     }
 
     // Ensure the postOps hook is successfully called. No return data is expected from the postOps hook, so we do not
@@ -194,7 +195,7 @@ contract EscrowTest is AtlasBaseTest {
                 .withReuseUserOp(true) // Allow metacall to revert
                 .build()
         );
-        executeHookCase(false, 1, FastLaneErrorsEvents.PostOpsFail.selector);
+        executeHookCase(false, 1, AtlasErrors.PostOpsFail.selector);
     }
 
     // Ensure the allocateValue hook is successfully called. No return data is expected from the allocateValue hook, so

--- a/test/ExecutionEnvironment.t.sol
+++ b/test/ExecutionEnvironment.t.sol
@@ -15,7 +15,7 @@ import { SolverBase } from "src/contracts/solver/SolverBase.sol";
 
 import { ERC20 } from "solmate/tokens/ERC20.sol";
 
-import { FastLaneErrorsEvents } from "src/contracts/types/Emissions.sol";
+import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 
 import "src/contracts/types/DAppApprovalTypes.sol";
 import "src/contracts/types/UserCallTypes.sol";
@@ -376,7 +376,7 @@ contract ExecutionEnvironmentTest is BaseTest {
         );
         solverMetaData = abi.encodePacked(solverMetaData, escrowKey.pack());
         vm.prank(address(atlas));
-        vm.expectRevert(FastLaneErrorsEvents.AlteredControlHash.selector);
+        vm.expectRevert(AtlasErrors.AlteredControlHash.selector);
         (status,) = address(executionEnvironment).call(solverMetaData);
         assertTrue(status, "expectRevert AlteredControlHash: call did not revert");
         solverOp.control = address(dAppControl);
@@ -389,7 +389,7 @@ contract ExecutionEnvironmentTest is BaseTest {
         );
         solverMetaData = abi.encodePacked(solverMetaData, escrowKey.pack());
         vm.prank(address(atlas));
-        vm.expectRevert(FastLaneErrorsEvents.SolverOperationReverted.selector);
+        vm.expectRevert(AtlasErrors.SolverOperationReverted.selector);
         (status,) = address(executionEnvironment).call(solverMetaData);
         assertTrue(status, "expectRevert SolverOperationReverted: call did not revert");
 
@@ -402,7 +402,7 @@ contract ExecutionEnvironmentTest is BaseTest {
         );
         solverMetaData = abi.encodePacked(solverMetaData, escrowKey.pack());
         vm.prank(address(atlas));
-        vm.expectRevert(FastLaneErrorsEvents.SolverBidUnpaid.selector);
+        vm.expectRevert(AtlasErrors.SolverBidUnpaid.selector);
         (status,) = address(executionEnvironment).call(solverMetaData);
         assertTrue(status, "expectRevert SolverBidUnpaid: call did not revert");
         solverOp.bidAmount = 0;
@@ -416,7 +416,7 @@ contract ExecutionEnvironmentTest is BaseTest {
         );
         solverMetaData = abi.encodePacked(solverMetaData, escrowKey.pack());
         vm.prank(address(atlas));
-        vm.expectRevert(FastLaneErrorsEvents.SolverMsgValueUnpaid.selector);
+        vm.expectRevert(AtlasErrors.SolverMsgValueUnpaid.selector);
         (status,) = address(executionEnvironment).call(solverMetaData);
         assertTrue(status, "expectRevert SolverMsgValueUnpaid: call did not revert");
 
@@ -432,7 +432,7 @@ contract ExecutionEnvironmentTest is BaseTest {
         );
         solverMetaData = abi.encodePacked(solverMetaData, escrowKey.pack());
         vm.prank(address(atlas));
-        vm.expectRevert(FastLaneErrorsEvents.PreSolverFailed.selector);
+        vm.expectRevert(AtlasErrors.PreSolverFailed.selector);
         (status,) = address(executionEnvironment).call(solverMetaData);
         assertTrue(status, "expectRevert PreSolverFailed: call did not revert");
 
@@ -443,7 +443,7 @@ contract ExecutionEnvironmentTest is BaseTest {
         );
         solverMetaData = abi.encodePacked(solverMetaData, escrowKey.pack());
         vm.prank(address(atlas));
-        vm.expectRevert(FastLaneErrorsEvents.PreSolverFailed.selector);
+        vm.expectRevert(AtlasErrors.PreSolverFailed.selector);
         (status,) = address(executionEnvironment).call(solverMetaData);
         assertTrue(status, "expectRevert PreSolverFailed 2: call did not revert");
 
@@ -461,7 +461,7 @@ contract ExecutionEnvironmentTest is BaseTest {
         );
         solverMetaData = abi.encodePacked(solverMetaData, escrowKey.pack());
         vm.prank(address(atlas));
-        vm.expectRevert(FastLaneErrorsEvents.PostSolverFailed.selector);
+        vm.expectRevert(AtlasErrors.PostSolverFailed.selector);
         (status,) = address(executionEnvironment).call(solverMetaData);
         assertTrue(status, "expectRevert PostSolverFailed: call did not revert");
 
@@ -473,7 +473,7 @@ contract ExecutionEnvironmentTest is BaseTest {
         );
         solverMetaData = abi.encodePacked(solverMetaData, escrowKey.pack());
         vm.prank(address(atlas));
-        vm.expectRevert(FastLaneErrorsEvents.IntentUnfulfilled.selector);
+        vm.expectRevert(AtlasErrors.IntentUnfulfilled.selector);
         (status,) = address(executionEnvironment).call(solverMetaData);
         assertTrue(status, "expectRevert IntentUnfulfilled: call did not revert");
     }

--- a/test/Factory.t.sol
+++ b/test/Factory.t.sol
@@ -6,7 +6,8 @@ import "forge-std/Test.sol";
 import { Factory } from "src/contracts/atlas/Factory.sol";
 import { ExecutionEnvironment } from "src/contracts/atlas/ExecutionEnvironment.sol";
 import { DummyDAppControl, CallConfigBuilder } from "./base/DummyDAppControl.sol";
-import { AtlasEvents } from "src/contracts/types/Emissions.sol";
+import { AtlasEvents } from "src/contracts/types/AtlasEvents.sol";
+import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 
 import "src/contracts/types/UserCallTypes.sol";
 

--- a/test/FlashLoan.t.sol
+++ b/test/FlashLoan.t.sol
@@ -14,7 +14,8 @@ import { SolverOutcome } from "src/contracts/types/EscrowTypes.sol";
 import { UserOperation } from "src/contracts/types/UserCallTypes.sol";
 import { SolverOperation } from "src/contracts/types/SolverCallTypes.sol";
 import { DAppOperation } from "src/contracts/types/DAppApprovalTypes.sol";
-import { FastLaneErrorsEvents } from "src/contracts/types/Emissions.sol";
+import { AtlasEvents } from "src/contracts/types/AtlasEvents.sol";
+import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 import { IEscrow } from "src/contracts/interfaces/IEscrow.sol";
 import { UserOperationBuilder } from "./base/builders/UserOperationBuilder.sol";
 import { SolverOperationBuilder } from "./base/builders/SolverOperationBuilder.sol";
@@ -119,7 +120,7 @@ contract FlashLoanTest is BaseTest {
         vm.startPrank(userEOA);
         vm.expectEmit(true, true, true, true);
         uint256 result = (1 << uint256(SolverOutcome.BidNotPaid)) | (1 << uint256(SolverOutcome.ExecutionCompleted));
-        emit FastLaneErrorsEvents.SolverTxResult(address(solver), solverOneEOA, true, false, result);
+        emit AtlasEvents.SolverTxResult(address(solver), solverOneEOA, true, false, result);
         vm.expectRevert();
         atlas.metacall({ userOp: userOp, solverOps: solverOps, dAppOp: dAppOp });
         vm.stopPrank();
@@ -164,7 +165,7 @@ contract FlashLoanTest is BaseTest {
         vm.startPrank(userEOA);
         vm.expectEmit(true, true, true, true);
         result = (1 << uint256(SolverOutcome.CallValueTooHigh)) | (1 << uint256(SolverOutcome.ExecutionCompleted));
-        emit FastLaneErrorsEvents.SolverTxResult(address(solver), solverOneEOA, true, false, result);
+        emit AtlasEvents.SolverTxResult(address(solver), solverOneEOA, true, false, result);
         vm.expectRevert();
         atlas.metacall({ userOp: userOp, solverOps: solverOps, dAppOp: dAppOp });
         vm.stopPrank();
@@ -216,7 +217,7 @@ contract FlashLoanTest is BaseTest {
         vm.startPrank(userEOA);
         result = (1 << uint256(SolverOutcome.Success)) | (1 << uint256(SolverOutcome.ExecutionCompleted));
         vm.expectEmit(true, true, true, true);
-        emit FastLaneErrorsEvents.SolverTxResult(address(solver), solverOneEOA, true, true, result);
+        emit AtlasEvents.SolverTxResult(address(solver), solverOneEOA, true, true, result);
         atlas.metacall({ userOp: userOp, solverOps: solverOps, dAppOp: dAppOp });
         vm.stopPrank();
 

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -4,7 +4,8 @@ pragma solidity 0.8.22;
 import "forge-std/Test.sol";
 
 import { GasAccounting } from "../src/contracts/atlas/GasAccounting.sol";
-import { FastLaneErrorsEvents, AtlasEvents } from "../src/contracts/types/Emissions.sol";
+import { AtlasEvents } from "src/contracts/types/AtlasEvents.sol";
+import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 
 import { EscrowBits } from "../src/contracts/libraries/EscrowBits.sol";
 
@@ -95,7 +96,7 @@ contract GasAccountingTest is Test {
 
     function test_contribute() public {
         vm.expectRevert(
-            abi.encodeWithSelector(FastLaneErrorsEvents.InvalidExecutionEnvironment.selector, executionEnvironment)
+            abi.encodeWithSelector(AtlasErrors.InvalidExecutionEnvironment.selector, executionEnvironment)
         );
         mockGasAccounting.contribute();
 
@@ -113,13 +114,13 @@ contract GasAccountingTest is Test {
         uint256 borrowedAmount = 5000;
 
         vm.expectRevert(
-            abi.encodeWithSelector(FastLaneErrorsEvents.InvalidExecutionEnvironment.selector, executionEnvironment)
+            abi.encodeWithSelector(AtlasErrors.InvalidExecutionEnvironment.selector, executionEnvironment)
         );
         mockGasAccounting.borrow(borrowedAmount);
 
         vm.prank(executionEnvironment);
         vm.expectRevert(
-            abi.encodeWithSelector(FastLaneErrorsEvents.InsufficientAtlETHBalance.selector, 0, borrowedAmount)
+            abi.encodeWithSelector(AtlasErrors.InsufficientAtlETHBalance.selector, 0, borrowedAmount)
         );
         mockGasAccounting.borrow(borrowedAmount);
 
@@ -146,15 +147,15 @@ contract GasAccountingTest is Test {
 
     function test_reconcile() public {
         vm.expectRevert(
-            abi.encodeWithSelector(FastLaneErrorsEvents.InvalidExecutionEnvironment.selector, executionEnvironment)
+            abi.encodeWithSelector(AtlasErrors.InvalidExecutionEnvironment.selector, executionEnvironment)
         );
         mockGasAccounting.reconcile(makeAddr("wrongExecutionEnvironment"), solverOp.from, 0);
 
         mockGasAccounting.trySolverLock(solverOp);
-        vm.expectRevert(abi.encodeWithSelector(FastLaneErrorsEvents.InvalidSolverFrom.selector, solverOp.from));
+        vm.expectRevert(abi.encodeWithSelector(AtlasErrors.InvalidSolverFrom.selector, solverOp.from));
         mockGasAccounting.reconcile(executionEnvironment, makeAddr("wrongSolver"), 0);
 
-        vm.expectRevert(abi.encodeWithSelector(FastLaneErrorsEvents.InsufficientTotalBalance.selector, initialClaims));
+        vm.expectRevert(abi.encodeWithSelector(AtlasErrors.InsufficientTotalBalance.selector, initialClaims));
         mockGasAccounting.reconcile(executionEnvironment, solverOp.from, 0);
 
         assertEq(mockGasAccounting.solver(), solverOp.from);
@@ -310,7 +311,7 @@ contract GasAccountingTest is Test {
 
         // UncoveredResult
         result = 0;
-        vm.expectRevert(FastLaneErrorsEvents.UncoveredResult.selector);
+        vm.expectRevert(AtlasErrors.UncoveredResult.selector);
         mockGasAccounting.releaseSolverLock(solverOp, gasWaterMark, result);
     }
 
@@ -320,7 +321,7 @@ contract GasAccountingTest is Test {
         uint128 bondedAfter;
 
         vm.expectRevert();
-        // This reverts with FastLaneErrorsEvents.InsufficientTotalBalance(shortfall).
+        // This reverts with AtlasErrors.InsufficientTotalBalance(shortfall).
         // The shortfall argument can't be reliably calculated in this test, hence
         // we expect a generic revert. Run this test with high verbosity to confirm
         // it reverts with the correct error.

--- a/test/Permit69.t.sol
+++ b/test/Permit69.t.sol
@@ -13,8 +13,8 @@ import { Mimic } from "src/contracts/atlas/Mimic.sol";
 
 import { EXECUTION_PHASE_OFFSET } from "src/contracts/libraries/SafetyBits.sol";
 import { SAFE_USER_TRANSFER, SAFE_DAPP_TRANSFER } from "src/contracts/common/Permit69.sol";
-
-import { FastLaneErrorsEvents } from "src/contracts/types/Emissions.sol";
+import { AtlasEvents } from "src/contracts/types/AtlasEvents.sol";
+import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 
 import "src/contracts/types/LockTypes.sol";
 
@@ -53,7 +53,7 @@ contract Permit69Test is BaseTest {
 
     function testTransferUserERC20RevertsIsCallerNotExecutionEnv() public {
         vm.prank(solverOneEOA);
-        vm.expectRevert(FastLaneErrorsEvents.EnvironmentMismatch.selector);
+        vm.expectRevert(AtlasErrors.EnvironmentMismatch.selector);
         mockAtlas.transferUserERC20(
             WETH_ADDRESS, solverOneEOA, 10e18, userEOA, address(0), uint16(0), escrowKey.lockState
         );
@@ -66,7 +66,7 @@ contract Permit69Test is BaseTest {
         // Uninitialized
         escrowKey.lockState = uint16(1 << (mockAtlas.getExecutionPhaseOffset() + uint16(ExecutionPhase.Uninitialized)));
         mockAtlas.setEscrowKey(escrowKey);
-        vm.expectRevert(FastLaneErrorsEvents.InvalidLockState.selector);
+        vm.expectRevert(AtlasErrors.InvalidLockState.selector);
         mockAtlas.transferUserERC20(
             WETH_ADDRESS, solverOneEOA, 10e18, userEOA, mockDAppControl, uint16(0), escrowKey.lockState
         );
@@ -75,7 +75,7 @@ contract Permit69Test is BaseTest {
         escrowKey.lockState =
             uint16(1 << (mockAtlas.getExecutionPhaseOffset() + uint16(ExecutionPhase.HandlingPayments)));
         mockAtlas.setEscrowKey(escrowKey);
-        vm.expectRevert(FastLaneErrorsEvents.InvalidLockState.selector);
+        vm.expectRevert(AtlasErrors.InvalidLockState.selector);
         mockAtlas.transferUserERC20(
             WETH_ADDRESS, solverOneEOA, 10e18, userEOA, mockDAppControl, uint16(0), escrowKey.lockState
         );
@@ -83,7 +83,7 @@ contract Permit69Test is BaseTest {
         // Releasing
         escrowKey.lockState = uint16(1 << (mockAtlas.getExecutionPhaseOffset() + uint16(ExecutionPhase.Releasing)));
         mockAtlas.setEscrowKey(escrowKey);
-        vm.expectRevert(FastLaneErrorsEvents.InvalidLockState.selector);
+        vm.expectRevert(AtlasErrors.InvalidLockState.selector);
         mockAtlas.transferUserERC20(
             WETH_ADDRESS, solverOneEOA, 10e18, userEOA, mockDAppControl, uint16(0), escrowKey.lockState
         );
@@ -113,7 +113,7 @@ contract Permit69Test is BaseTest {
 
     function testTransferDAppERC20RevertsIsCallerNotExecutionEnv() public {
         vm.prank(solverOneEOA);
-        vm.expectRevert(FastLaneErrorsEvents.EnvironmentMismatch.selector);
+        vm.expectRevert(AtlasErrors.EnvironmentMismatch.selector);
         mockAtlas.transferDAppERC20(
             WETH_ADDRESS, solverOneEOA, 10e18, userEOA, mockDAppControl, uint16(0), escrowKey.lockState
         );
@@ -126,7 +126,7 @@ contract Permit69Test is BaseTest {
         // Uninitialized
         escrowKey.lockState = uint16(1 << (mockAtlas.getExecutionPhaseOffset() + uint16(ExecutionPhase.Uninitialized)));
         mockAtlas.setEscrowKey(escrowKey);
-        vm.expectRevert(FastLaneErrorsEvents.InvalidLockState.selector);
+        vm.expectRevert(AtlasErrors.InvalidLockState.selector);
         mockAtlas.transferDAppERC20(
             WETH_ADDRESS, solverOneEOA, 10e18, userEOA, mockDAppControl, uint16(0), escrowKey.lockState
         );
@@ -134,7 +134,7 @@ contract Permit69Test is BaseTest {
         // UserOperation
         escrowKey.lockState = uint16(1 << (mockAtlas.getExecutionPhaseOffset() + uint16(ExecutionPhase.UserOperation)));
         mockAtlas.setEscrowKey(escrowKey);
-        vm.expectRevert(FastLaneErrorsEvents.InvalidLockState.selector);
+        vm.expectRevert(AtlasErrors.InvalidLockState.selector);
         mockAtlas.transferDAppERC20(
             WETH_ADDRESS, solverOneEOA, 10e18, userEOA, mockDAppControl, uint16(0), escrowKey.lockState
         );
@@ -143,7 +143,7 @@ contract Permit69Test is BaseTest {
         escrowKey.lockState =
             uint16(1 << (mockAtlas.getExecutionPhaseOffset() + uint16(ExecutionPhase.SolverOperations)));
         mockAtlas.setEscrowKey(escrowKey);
-        vm.expectRevert(FastLaneErrorsEvents.InvalidLockState.selector);
+        vm.expectRevert(AtlasErrors.InvalidLockState.selector);
         mockAtlas.transferDAppERC20(
             WETH_ADDRESS, solverOneEOA, 10e18, userEOA, mockDAppControl, uint16(0), escrowKey.lockState
         );
@@ -151,7 +151,7 @@ contract Permit69Test is BaseTest {
         // Releasing
         escrowKey.lockState = uint16(1 << (mockAtlas.getExecutionPhaseOffset() + uint16(ExecutionPhase.Releasing)));
         mockAtlas.setEscrowKey(escrowKey);
-        vm.expectRevert(FastLaneErrorsEvents.InvalidLockState.selector);
+        vm.expectRevert(AtlasErrors.InvalidLockState.selector);
         mockAtlas.transferDAppERC20(
             WETH_ADDRESS, solverOneEOA, 10e18, userEOA, mockDAppControl, uint16(0), escrowKey.lockState
         );
@@ -297,7 +297,7 @@ contract MockAtlasForPermit69Tests is Permit69 {
     // Overriding the virtual functions in Permit69
     function _verifyCallerIsExecutionEnv(address, address, uint32) internal view override {
         if (msg.sender != _environment) {
-            revert FastLaneErrorsEvents.EnvironmentMismatch();
+            revert AtlasErrors.EnvironmentMismatch();
         }
     }
 

--- a/test/SafetyLocks.t.sol
+++ b/test/SafetyLocks.t.sol
@@ -4,7 +4,8 @@ pragma solidity 0.8.22;
 import "forge-std/Test.sol";
 
 import { SafetyLocks } from "src/contracts/atlas/SafetyLocks.sol";
-import { FastLaneErrorsEvents } from "src/contracts/types/Emissions.sol";
+import { AtlasEvents } from "src/contracts/types/AtlasEvents.sol";
+import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 
 import "src/contracts/types/DAppApprovalTypes.sol";
 import "src/contracts/types/LockTypes.sol";
@@ -75,7 +76,7 @@ contract SafetyLocksTest is Test {
         uint256 msgValue = 444;
 
         safetyLocks.setLock(address(2));
-        vm.expectRevert(FastLaneErrorsEvents.AlreadyInitialized.selector);
+        vm.expectRevert(AtlasErrors.AlreadyInitialized.selector);
         safetyLocks.initializeEscrowLock{ value: msgValue }(executionEnvironment, gasMarker, userOpValue);
         safetyLocks.setLock(address(1)); // Reset to UNLOCKED
 
@@ -92,22 +93,22 @@ contract SafetyLocksTest is Test {
 
     function test_checkIfUnlocked() public {
         safetyLocks.setLock(address(2));
-        vm.expectRevert(FastLaneErrorsEvents.AlreadyInitialized.selector);
+        vm.expectRevert(AtlasErrors.AlreadyInitialized.selector);
         safetyLocks.checkIfUnlocked();
         safetyLocks.setLock(address(1)); // Reset to UNLOCKED
 
         safetyLocks.setClaims(1);
-        vm.expectRevert(FastLaneErrorsEvents.AlreadyInitialized.selector);
+        vm.expectRevert(AtlasErrors.AlreadyInitialized.selector);
         safetyLocks.checkIfUnlocked();
         safetyLocks.setClaims(type(uint256).max); // Reset
 
         safetyLocks.setWithdrawals(1);
-        vm.expectRevert(FastLaneErrorsEvents.AlreadyInitialized.selector);
+        vm.expectRevert(AtlasErrors.AlreadyInitialized.selector);
         safetyLocks.checkIfUnlocked();
         safetyLocks.setWithdrawals(type(uint256).max); // Reset
 
         safetyLocks.setDeposits(1);
-        vm.expectRevert(FastLaneErrorsEvents.AlreadyInitialized.selector);
+        vm.expectRevert(AtlasErrors.AlreadyInitialized.selector);
         safetyLocks.checkIfUnlocked();
         safetyLocks.setDeposits(type(uint256).max); // Reset
     }
@@ -115,7 +116,7 @@ contract SafetyLocksTest is Test {
     function test_buildEscrowLock() public {
         DAppConfig memory dConfig = DAppConfig({ to: address(10), callConfig: 0, bidToken: address(0) });
 
-        vm.expectRevert(FastLaneErrorsEvents.NotInitialized.selector);
+        vm.expectRevert(AtlasErrors.NotInitialized.selector);
         safetyLocks.buildEscrowLock(dConfig, executionEnvironment, 0, false);
 
         safetyLocks.initializeEscrowLock(executionEnvironment, 0, 0);
@@ -124,7 +125,7 @@ contract SafetyLocksTest is Test {
     }
 
     function test_releaseEscrowLock() public {
-        vm.expectRevert(FastLaneErrorsEvents.NotInitialized.selector);
+        vm.expectRevert(AtlasErrors.NotInitialized.selector);
         safetyLocks.releaseEscrowLock();
 
         safetyLocks.initializeEscrowLock(executionEnvironment, 0, 0);

--- a/test/Surcharge.t.sol
+++ b/test/Surcharge.t.sol
@@ -3,7 +3,8 @@ pragma solidity 0.8.22;
 
 import "forge-std/Test.sol";
 import { BaseTest } from "./base/BaseTest.t.sol";
-import { FastLaneErrorsEvents, AtlasEvents } from "src/contracts/types/Emissions.sol";
+import { AtlasEvents } from "src/contracts/types/AtlasEvents.sol";
+import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 
 contract SurchargeTest is BaseTest {
     using stdStorage for StdStorage;
@@ -14,7 +15,7 @@ contract SurchargeTest is BaseTest {
         assertEq(atlas.pendingSurchargeRecipient(), address(0), "pending surcharge recipient should be 0x0");
     
         // Check a random cant transfer the surcharge recipient
-        vm.expectRevert(FastLaneErrorsEvents.InvalidAccess.selector);
+        vm.expectRevert(AtlasErrors.InvalidAccess.selector);
         atlas.transferSurchargeRecipient(address(this));
 
         // Check the transfer process works as expected
@@ -26,7 +27,7 @@ contract SurchargeTest is BaseTest {
         assertEq(atlas.pendingSurchargeRecipient(), address(this), "pending surcharge recipient should now be address(this)");
 
         // Check that only correct recipient can accept the transfer
-        vm.expectRevert(FastLaneErrorsEvents.InvalidAccess.selector);
+        vm.expectRevert(AtlasErrors.InvalidAccess.selector);
         atlas.becomeSurchargeRecipient();
         vm.stopPrank();
 
@@ -40,7 +41,7 @@ contract SurchargeTest is BaseTest {
 
     function testSurchargeWithdraw() public {
         // Check a random cant withdraw
-        vm.expectRevert(FastLaneErrorsEvents.InvalidAccess.selector);
+        vm.expectRevert(AtlasErrors.InvalidAccess.selector);
         atlas.withdrawSurcharge();
 
         // Set surcharge for withdrawal


### PR DESCRIPTION
Split the original `Emissions.sol` file (which referred to FastLaneErrorsEvents) into 2 files, 1 for errors and 1 for events (now referred to as AtlasErrors and AtlasEvents)