### PR TITLE
Audit Chunk 1 Cleanup

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -146,15 +146,18 @@ Last updated: 2024-Jan-30
 
 ### Permit69.sol
 
+Effective Test Coverage: 100%
+
 Coverage as per coverage report:
 
 - Lines: 8/8 (100%)
 - Functions: 3/4 (75%)
 
-Work Needed:
+Notes:
 
-- Only missing function is the virtual `_verifyCallerIsExecutionEnv` function which gets overridden.
-- Double check Permit69.t.sol covers all edge cases
+- Coverage report shows internal virtual function `verifyCallerIsExecutionEnv` as not covered, but is covered in `Permit69.t.sol` in `testVerifyCallerIsExecutionEnv`.
+
+Last updated: 2024-Feb-05
 
 ### ExecutionBase.sol
 

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -91,25 +91,28 @@ Last updated: 2024-Jan-30
 
 ### AtlasVerification.sol
 
+Effective Test Coverage: 100%
+
 Coverage as per coverage report:
 
-- Lines: 146/151 (96.7%)
-- Functions: 18/19 (94.7%)
+- Lines: 147/151 (97.4%)
+- Functions: 19/19 (100%)
 
-Work Needed:
+Unreachable Code:
 
-- L278 return false if `dAppOp.control != dConfig.to`
-- L360 `_handleNonces` returns true at end. Probably a bug and already covered.
-- L381 `_incrementHighestFullAsyncBitmap` returns nonceTracker at end. Probably a bug and already covered.
-- L414 `getDomainSeparator` view function.
+- L278 Cannot be reached as `_verifyDApp` would return false before L278 if either dAppOp.control or dConfig.to are invalid, and if both are valid then this `return false` line would be bypassed.
 
 Coverage Bugs:
 
+- L360 `_handleNonces` last return line is covered as function is tested without revert.
+- L381 `_incrementHighestFullAsyncBitmap` last return line is covered as function is tested without revert.
 - L525 the `break` in `manuallyUpdateNonceTracker` is covered if the line above is covered, which it is.
 
-Last updated: 2024-Jan-30
+Last updated: 2024-Feb-06
 
 ### DAppIntegration.sol
+
+Effective Test Coverage: 100%
 
 Coverage as per coverage report:
 

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -93,17 +93,19 @@ Last updated: 2024-Jan-30
 
 Coverage as per coverage report:
 
-- Lines: 145/151 (96%)
+- Lines: 146/151 (96.7%)
 - Functions: 18/19 (94.7%)
 
 Work Needed:
 
-- L163 return with `ValidCallResult.NoSolverOp`
 - L278 return false if `dAppOp.control != dConfig.to`
 - L360 `_handleNonces` returns true at end. Probably a bug and already covered.
 - L381 `_incrementHighestFullAsyncBitmap` returns nonceTracker at end. Probably a bug and already covered.
 - L414 `getDomainSeparator` view function.
-- L525 `manuallyUpdateNonceTracker` breaks if `nonceBitmap.bitmap == FULL_BITMAP` in loop. Probably a bug and already covered.
+
+Coverage Bugs:
+
+- L525 the `break` in `manuallyUpdateNonceTracker` is covered if the line above is covered, which it is.
 
 Last updated: 2024-Jan-30
 

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -275,6 +275,7 @@ contract AtlasVerification is EIP712, DAppIntegration {
         }
 
         if (dAppOp.control != dConfig.to) {
+            // This should be unreachable but returning false just in case.
             return false;
         }
 

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -41,7 +41,7 @@ contract AtlasVerification is EIP712, DAppIntegration {
 
     error InvalidCaller();
 
-    constructor(address _atlas) EIP712("ProtoCallHandler", "0.0.1") DAppIntegration(_atlas) { }
+    constructor(address _atlas) EIP712("AtlasVerification", "0.0.1") DAppIntegration(_atlas) { }
 
     function validCalls(
         DAppConfig calldata dConfig,

--- a/src/contracts/atlas/Storage.sol
+++ b/src/contracts/atlas/Storage.sol
@@ -67,6 +67,7 @@ contract Storage {
         INITIAL_DOMAIN_SEPARATOR = _computeDomainSeparator();
 
         // Gas Accounting
+        // Initialized with msg.value to seed flash loan liquidity
         surcharge = msg.value;
         surchargeRecipient = _surchargeRecipient;
 

--- a/test/AtlasVerification.t.sol
+++ b/test/AtlasVerification.t.sol
@@ -1382,4 +1382,16 @@ contract AtlasVerificationTest is AtlasVerificationBase {
             userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
         ), ValidCallsResult.NoSolverOp);
     }
+
+    function testGetDomainSeparatorInAtlasVerification() public {
+        bytes32 hashedName = keccak256(bytes("AtlasVerification"));
+        bytes32 hashedVersion = keccak256(bytes("0.0.1"));
+        bytes32 typeHash = keccak256(
+            "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+        );
+        bytes32 predictedDomainSeparator = keccak256(abi.encode(typeHash, hashedName, hashedVersion, block.chainid, address(atlasVerification)));
+        bytes32 domainSeparator = atlasVerification.getDomainSeparator();
+
+        assertEq(predictedDomainSeparator, domainSeparator);
+    }
 }

--- a/test/AtlasVerification.t.sol
+++ b/test/AtlasVerification.t.sol
@@ -1360,11 +1360,23 @@ contract AtlasVerificationTest is AtlasVerificationBase {
     // because all solver ops are pruned
     //
     function test_validCalls_NoSolverOps_ZeroSolverSet_NoSolverOp() public {
-        defaultAtlasWithCallConfig(defaultCallConfig().withRequireFulfillment(true).build());
+        // Should return NoSolverOp in the `if (!dConfig.callConfig.allowsZeroSolvers())` branch
+        defaultAtlasWithCallConfig(defaultCallConfig().withRequireFulfillment(true).withZeroSolvers(false).build());
 
         UserOperation memory userOp = validUserOperation().build();
         SolverOperation[] memory solverOps = new SolverOperation[](0);
         DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).build();
+
+        callAndAssert(ValidCallsCall({
+            userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
+        ), ValidCallsResult.NoSolverOp);
+
+        // Should return NoSolverOp in the `if (dConfig.callConfig.needsFulfillment())` branch
+        defaultAtlasWithCallConfig(defaultCallConfig().withRequireFulfillment(true).withZeroSolvers(true).build());
+
+        userOp = validUserOperation().build();
+        solverOps = new SolverOperation[](0);
+        dappOp = validDAppOperation(userOp, solverOps).build();
 
         callAndAssert(ValidCallsCall({
             userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}

--- a/test/Permit69.t.sol
+++ b/test/Permit69.t.sol
@@ -255,7 +255,13 @@ contract Permit69Test is BaseTest {
     }
 
     function testVerifyCallerIsExecutionEnv() public {
-        // TODO Implement to complete Permit69 coverage
+        vm.prank(solverOneEOA);
+        vm.expectRevert(AtlasErrors.EnvironmentMismatch.selector);
+        mockAtlas.verifyCallerIsExecutionEnv(solverOneEOA, userEOA, 0);
+
+        vm.prank(mockExecutionEnvAddress);
+        bool res = mockAtlas.verifyCallerIsExecutionEnv(solverOneEOA, userEOA, 0);
+        assertTrue(res, "Should return true and not revert");
     }
 }
 
@@ -302,6 +308,12 @@ contract MockAtlasForPermit69Tests is Permit69 {
         if (msg.sender != _environment) {
             revert AtlasErrors.EnvironmentMismatch();
         }
+    }
+
+    // Exposing above overridden function for testing and Permit69 coverage
+    function verifyCallerIsExecutionEnv(address user, address controller, uint32 callConfig) public returns (bool) {
+        _verifyCallerIsExecutionEnv(user, controller, callConfig);
+        return true; // Added to test lack of revert
     }
 
     // Implemented in Factory.sol in the canonical Atlas system

--- a/test/Permit69.t.sol
+++ b/test/Permit69.t.sol
@@ -253,9 +253,12 @@ contract Permit69Test is BaseTest {
             "Binary string form of bit map not as expected"
         );
     }
+
+    function testVerifyCallerIsExecutionEnv() public {
+        // TODO Implement to complete Permit69 coverage
+    }
 }
 
-// TODO probably refactor some of this stuff to a shared folder of standard implementations
 // Mock Atlas with standard implementations of Permit69's virtual functions
 contract MockAtlasForPermit69Tests is Permit69 {
     constructor(


### PR DESCRIPTION
Audit Chunk 1:

- Permit69.sol module of Atlas
- AtlasVerification.sol + DAppIntegration.sol standalone contract
- Brief overview of other Atlas stuff

Permit69, AtlasVerification, and DAppIntegration are 100% tested with full coverage. There are notes in `COVERAGE.md` explaining any lines not showing up in the coverage report as either unreachable or a coverage bug.