### PR TITLE
Add Reputation Analytics Data

### DIFF
--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -106,9 +106,9 @@ abstract contract GasAccounting is SafetyLocks {
     // and increases transient solver deposits by this amount
     function _assign(address owner, uint256 amount) internal returns (bool isDeficit) {
         if (amount == 0) {
-            accessData[owner].lastAccessedBlock = uint128(block.number);
+            accessData[owner].lastAccessedBlock = uint32(block.number);
         } else {
-            uint128 amt = uint128(amount);
+            uint112 amt = uint112(amount);
 
             EscrowAccountAccessData memory aData = accessData[owner];
 
@@ -128,7 +128,7 @@ abstract contract GasAccounting is SafetyLocks {
                 aData.bonded -= amt;
             }
 
-            aData.lastAccessedBlock = uint128(block.number);
+            aData.lastAccessedBlock = uint32(block.number);
 
             accessData[owner] = aData;
 
@@ -139,11 +139,11 @@ abstract contract GasAccounting is SafetyLocks {
 
     // Increases owner's bonded balance by amount
     function _credit(address owner, uint256 amount) internal {
-        uint128 amt = uint128(amount);
+        uint112 amt = uint112(amount);
 
         EscrowAccountAccessData memory aData = accessData[owner];
 
-        aData.lastAccessedBlock = uint128(block.number);
+        aData.lastAccessedBlock = uint32(block.number);
         aData.bonded += amt;
 
         bondedTotalSupply += amount;

--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -11,7 +11,7 @@ import { SolverOperation } from "../types/SolverCallTypes.sol";
 
 import { EscrowBits } from "../libraries/EscrowBits.sol";
 
-//import "forge-std/Test.sol"; //TODO remove
+import "forge-std/Test.sol"; //TODO remove
 
 abstract contract GasAccounting is SafetyLocks {
     constructor(
@@ -108,6 +108,7 @@ abstract contract GasAccounting is SafetyLocks {
         if (amount == 0) {
             accessData[owner].lastAccessedBlock = uint32(block.number);
         } else {
+            if (amount > type(uint112).max) revert ValueTooLarge();
             uint112 amt = uint112(amount);
 
             EscrowAccountAccessData memory aData = accessData[owner];
@@ -139,6 +140,7 @@ abstract contract GasAccounting is SafetyLocks {
 
     // Increases owner's bonded balance by amount
     function _credit(address owner, uint256 amount) internal {
+        if (amount > type(uint112).max) revert ValueTooLarge();
         uint112 amt = uint112(amount);
 
         EscrowAccountAccessData memory aData = accessData[owner];

--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -138,7 +138,6 @@ abstract contract GasAccounting is SafetyLocks {
             } else {
                 aData.auctionFails++;
             }
-            // TODO maybe add event for analytics? Will be emitted for each solver win/fail
 
             accessData[owner] = aData;
 

--- a/src/contracts/atlas/Storage.sol
+++ b/src/contracts/atlas/Storage.sol
@@ -11,6 +11,7 @@ contract Storage is AtlasEvents, AtlasErrors {
     // Atlas constants
     uint256 internal constant _MAX_GAS = 1_500_000;
     uint256 internal constant LEDGER_LENGTH = 6; // type(Party).max = 6
+    uint256 internal constant GAS_USED_DECIMALS_TO_DROP = 1000;
     address internal constant UNLOCKED = address(1);
 
     uint256 public immutable ESCROW_DURATION;

--- a/src/contracts/types/AtlasErrors.sol
+++ b/src/contracts/types/AtlasErrors.sol
@@ -51,6 +51,7 @@ contract AtlasErrors {
     error InsufficientAvailableBalance(uint256 balance, uint256 requested);
     error InsufficientSurchargeBalance(uint256 balance, uint256 requested);
     error InsufficientBalanceForDeduction(uint256 balance, uint256 requested);
+    error ValueTooLarge();
 
     event Bond(address indexed owner, uint256 amount);
     event Unbond(address indexed owner, uint256 amount, uint256 earliestAvailable);

--- a/src/contracts/types/AtlasErrors.sol
+++ b/src/contracts/types/AtlasErrors.sol
@@ -53,12 +53,6 @@ contract AtlasErrors {
     error InsufficientBalanceForDeduction(uint256 balance, uint256 requested);
     error ValueTooLarge();
 
-    event Bond(address indexed owner, uint256 amount);
-    event Unbond(address indexed owner, uint256 amount, uint256 earliestAvailable);
-    event Redeem(address indexed owner, uint256 amount);
-    event Transfer(address indexed from, address indexed to, uint256 amount);
-    event Approval(address indexed owner, address indexed spender, uint256 amount);
-
     // DAppIntegration
     error OnlyGovernance();
     error OwnerActive();

--- a/src/contracts/types/AtlasEvents.sol
+++ b/src/contracts/types/AtlasEvents.sol
@@ -6,6 +6,13 @@ contract AtlasEvents {
     event MetacallResult(address indexed bundler, address indexed user, address indexed winningSolver);
     event SolverExecution(address indexed solver, uint256 index, bool isWin);
 
+    // AtlETH
+    event Bond(address indexed owner, uint256 amount);
+    event Unbond(address indexed owner, uint256 amount, uint256 earliestAvailable);
+    event Redeem(address indexed owner, uint256 amount);
+    event Transfer(address indexed from, address indexed to, uint256 amount);
+    event Approval(address indexed owner, address indexed spender, uint256 amount);
+
     // Escrow call step events
     event PreOpsCall(address environment, bool success, bytes returnData);
     event UserCall(address environment, bool success, bytes returnData);

--- a/src/contracts/types/EscrowTypes.sol
+++ b/src/contracts/types/EscrowTypes.sol
@@ -5,13 +5,16 @@ uint256 constant CALLDATA_LENGTH_PREMIUM = 32; // 16 (default) * 2
 
 // bonded = total - unbonding
 struct EscrowAccountBalance {
-    uint128 balance;
-    uint128 unbonding;
+    uint112 balance;
+    uint112 unbonding;
 }
 
 struct EscrowAccountAccessData {
-    uint128 bonded;
-    uint128 lastAccessedBlock;
+    uint112 bonded;
+    uint32 lastAccessedBlock;
+    uint24 auctionWins;
+    uint24 auctionFails;
+    uint64 totalGasUsed;
 }
 
 // NOTE: The order is very important here for balance reconciliation.

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -282,12 +282,12 @@ contract EscrowTest is AtlasBaseTest {
         executeSolverOperationCase(userOp, solverOps, false, false, 1 << uint256(SolverOutcome.PerBlockLimit), true);
     }
 
-    function test_executeSolverOperation_validateSolverOperation_insufficientEscrow() public {
-        vm.txGasPrice(1e50); // Set a gas price that will cause the solver to run out of escrow
+    // function test_executeSolverOperation_validateSolverOperation_insufficientEscrow() public {
+    //     vm.txGasPrice(1e50); // Set a gas price that will cause the solver to run out of escrow
 
-        (UserOperation memory userOp, SolverOperation[] memory solverOps) = executeSolverOperationInit(defaultCallConfig().build());
-        executeSolverOperationCase(userOp, solverOps, false, false, 1 << uint256(SolverOutcome.InsufficientEscrow), true);
-    }
+    //     (UserOperation memory userOp, SolverOperation[] memory solverOps) = executeSolverOperationInit(defaultCallConfig().build());
+    //     executeSolverOperationCase(userOp, solverOps, false, false, 1 << uint256(SolverOutcome.InsufficientEscrow), true);
+    // }
 
     function test_executeSolverOperation_validateSolverOperation_callValueTooHigh() public {
         (UserOperation memory userOp, SolverOperation[] memory solverOps) = executeSolverOperationInit(defaultCallConfig().build());

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -282,12 +282,13 @@ contract EscrowTest is AtlasBaseTest {
         executeSolverOperationCase(userOp, solverOps, false, false, 1 << uint256(SolverOutcome.PerBlockLimit), true);
     }
 
-    // function test_executeSolverOperation_validateSolverOperation_insufficientEscrow() public {
-    //     vm.txGasPrice(1e50); // Set a gas price that will cause the solver to run out of escrow
+    function test_executeSolverOperation_validateSolverOperation_insufficientEscrow() public {
+        // Solver only has 1 ETH escrowed
+        vm.txGasPrice(10e18); // Set a gas price that will cause the solver to run out of escrow
 
-    //     (UserOperation memory userOp, SolverOperation[] memory solverOps) = executeSolverOperationInit(defaultCallConfig().build());
-    //     executeSolverOperationCase(userOp, solverOps, false, false, 1 << uint256(SolverOutcome.InsufficientEscrow), true);
-    // }
+        (UserOperation memory userOp, SolverOperation[] memory solverOps) = executeSolverOperationInit(defaultCallConfig().build());
+        executeSolverOperationCase(userOp, solverOps, false, false, 1 << uint256(SolverOutcome.InsufficientEscrow), true);
+    }
 
     function test_executeSolverOperation_validateSolverOperation_callValueTooHigh() public {
         (UserOperation memory userOp, SolverOperation[] memory solverOps) = executeSolverOperationInit(defaultCallConfig().build());

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -22,7 +22,7 @@ contract MockGasAccounting is GasAccounting, Test {
         GasAccounting(_escrowDuration, _verification, _simulator, _surchargeRecipient)
     { }
 
-    function balanceOf(address account) external view returns (uint128, uint128) {
+    function balanceOf(address account) external view returns (uint112, uint112) {
         return (_balanceOf[account].balance, _balanceOf[account].unbonding);
     }
 
@@ -52,14 +52,14 @@ contract MockGasAccounting is GasAccounting, Test {
 
     function increaseBondedBalance(address account, uint256 amount) external {
         deal(address(this), amount);
-        accessData[account].bonded += uint128(amount);
-        bondedTotalSupply += uint128(amount);
+        accessData[account].bonded += uint112(amount);
+        bondedTotalSupply += amount;
     }
 
     function increaseUnbondingBalance(address account, uint256 amount) external {
         deal(address(this), amount);
-        _balanceOf[account].unbonding += uint128(amount);
-        bondedTotalSupply += uint128(amount);
+        _balanceOf[account].unbonding += uint112(amount);
+        bondedTotalSupply += amount;
     }
 }
 
@@ -167,14 +167,14 @@ contract GasAccountingTest is Test {
         uint256 assignedAmount = 1000;
         uint256 bondedTotalSupplyBefore;
         uint256 depositsBefore;
-        uint128 bonded;
-        uint128 unbonding;
-        uint128 lastAccessedBlock;
+        uint112 bonded;
+        uint112 unbonding;
+        uint32 lastAccessedBlock;
 
         bondedTotalSupplyBefore = mockGasAccounting.bondedTotalSupply();
         depositsBefore = mockGasAccounting.deposits();
         assertFalse(mockGasAccounting.assign(solverOp.from, 0));
-        (, lastAccessedBlock) = mockGasAccounting.accessData(solverOp.from);
+        (, lastAccessedBlock,,,) = mockGasAccounting.accessData(solverOp.from);
         assertEq(lastAccessedBlock, uint128(block.number));
         assertEq(mockGasAccounting.bondedTotalSupply(), bondedTotalSupplyBefore);
         assertEq(mockGasAccounting.deposits(), depositsBefore);
@@ -182,12 +182,12 @@ contract GasAccountingTest is Test {
         bondedTotalSupplyBefore = mockGasAccounting.bondedTotalSupply();
         depositsBefore = mockGasAccounting.deposits();
         assertTrue(mockGasAccounting.assign(solverOp.from, assignedAmount));
-        (, lastAccessedBlock) = mockGasAccounting.accessData(solverOp.from);
+        (, lastAccessedBlock,,,) = mockGasAccounting.accessData(solverOp.from);
         assertEq(lastAccessedBlock, uint128(block.number));
         assertEq(mockGasAccounting.bondedTotalSupply(), bondedTotalSupplyBefore);
         assertEq(mockGasAccounting.deposits(), depositsBefore);
         (, unbonding) = mockGasAccounting.balanceOf(solverOp.from);
-        (bonded,) = mockGasAccounting.accessData(solverOp.from);
+        (bonded,,,,) = mockGasAccounting.accessData(solverOp.from);
         assertEq(unbonding, 0);
         assertEq(bonded, 0);
 
@@ -196,12 +196,12 @@ contract GasAccountingTest is Test {
         bondedTotalSupplyBefore = mockGasAccounting.bondedTotalSupply();
         depositsBefore = mockGasAccounting.deposits();
         assertFalse(mockGasAccounting.assign(solverOp.from, assignedAmount));
-        (, lastAccessedBlock) = mockGasAccounting.accessData(solverOp.from);
+        (, lastAccessedBlock,,,) = mockGasAccounting.accessData(solverOp.from);
         assertEq(lastAccessedBlock, uint128(block.number));
         assertEq(mockGasAccounting.bondedTotalSupply(), bondedTotalSupplyBefore - assignedAmount);
         assertEq(mockGasAccounting.deposits(), depositsBefore + assignedAmount);
         (, unbonding) = mockGasAccounting.balanceOf(solverOp.from);
-        (bonded,) = mockGasAccounting.accessData(solverOp.from);
+        (bonded,,,,) = mockGasAccounting.accessData(solverOp.from);
         assertEq(unbonding, unbondingAmount + bonded - assignedAmount);
         assertEq(bonded, 0);
 
@@ -211,12 +211,12 @@ contract GasAccountingTest is Test {
         depositsBefore = mockGasAccounting.deposits();
         (, uint128 unbondingBefore) = mockGasAccounting.balanceOf(solverOp.from);
         assertFalse(mockGasAccounting.assign(solverOp.from, assignedAmount));
-        (, lastAccessedBlock) = mockGasAccounting.accessData(solverOp.from);
+        (, lastAccessedBlock,,,) = mockGasAccounting.accessData(solverOp.from);
         assertEq(lastAccessedBlock, uint128(block.number));
         assertEq(mockGasAccounting.bondedTotalSupply(), bondedTotalSupplyBefore - assignedAmount);
         assertEq(mockGasAccounting.deposits(), depositsBefore + assignedAmount);
         (, unbonding) = mockGasAccounting.balanceOf(solverOp.from);
-        (bonded,) = mockGasAccounting.accessData(solverOp.from);
+        (bonded,,,,) = mockGasAccounting.accessData(solverOp.from);
         assertEq(unbonding, unbondingBefore);
         assertEq(bonded, bondedAmount - assignedAmount);
 
@@ -241,22 +241,22 @@ contract GasAccountingTest is Test {
         uint256 lastAccessedBlock;
 
         uint256 bondedTotalSupplyBefore = mockGasAccounting.bondedTotalSupply();
-        (uint128 bondedBefore,) = mockGasAccounting.accessData(solverOp.from);
-        (, lastAccessedBlock) = mockGasAccounting.accessData(solverOp.from);
+        (uint112 bondedBefore,,,,) = mockGasAccounting.accessData(solverOp.from);
+        (, lastAccessedBlock,,,) = mockGasAccounting.accessData(solverOp.from);
         assertEq(lastAccessedBlock, 0);
 
         mockGasAccounting.credit(solverOp.from, creditedAmount);
 
-        (, lastAccessedBlock) = mockGasAccounting.accessData(solverOp.from);
-        (uint128 bondedAfter,) = mockGasAccounting.accessData(solverOp.from);
+        (, lastAccessedBlock,,,) = mockGasAccounting.accessData(solverOp.from);
+        (uint112 bondedAfter,,,,) = mockGasAccounting.accessData(solverOp.from);
 
-        assertEq(lastAccessedBlock, uint128(block.number));
+        assertEq(lastAccessedBlock, uint32(block.number));
         assertEq(mockGasAccounting.bondedTotalSupply(), bondedTotalSupplyBefore + creditedAmount);
-        assertEq(bondedAfter, bondedBefore + uint128(creditedAmount));
+        assertEq(bondedAfter, bondedBefore + uint112(creditedAmount));
 
-        // Testing uint128 boundary values for casting from uint256 to uint128 in _credit()
+        // Testing uint112 boundary values for casting from uint256 to uint112 in _credit()
         vm.expectRevert(stdError.arithmeticError);
-        mockGasAccounting.credit(solverOp.from, type(uint128).max + 1);
+        mockGasAccounting.credit(solverOp.from, type(uint112).max + 1);
     }
 
     function test_trySolverLock() public {
@@ -271,8 +271,8 @@ contract GasAccountingTest is Test {
         uint256 calldataCost = (solverOp.data.length * CALLDATA_LENGTH_PREMIUM) + 1;
         uint256 gasWaterMark = gasleft() + 5000;
         uint256 maxGasUsed;
-        uint128 bondedBefore;
-        uint128 bondedAfter;
+        uint112 bondedBefore;
+        uint112 bondedAfter;
         uint256 result;
 
         // FULL_REFUND
@@ -281,9 +281,9 @@ contract GasAccountingTest is Test {
         maxGasUsed = (maxGasUsed + ((maxGasUsed * mockGasAccounting.SURCHARGE()) / mockGasAccounting.SURCHARGE_BASE()))
             * tx.gasprice;
         mockGasAccounting.increaseBondedBalance(solverOp.from, maxGasUsed);
-        (bondedBefore,) = mockGasAccounting.accessData(solverOp.from);
+        (bondedBefore,,,,) = mockGasAccounting.accessData(solverOp.from);
         mockGasAccounting.releaseSolverLock(solverOp, gasWaterMark, result);
-        (bondedAfter,) = mockGasAccounting.accessData(solverOp.from);
+        (bondedAfter,,,,) = mockGasAccounting.accessData(solverOp.from);
         assertGt(
             bondedBefore - bondedAfter,
             (calldataCost + ((calldataCost * mockGasAccounting.SURCHARGE()) / mockGasAccounting.SURCHARGE_BASE()))
@@ -297,16 +297,16 @@ contract GasAccountingTest is Test {
             calldataCost + ((calldataCost * mockGasAccounting.SURCHARGE()) / mockGasAccounting.SURCHARGE_BASE())
         ) * tx.gasprice;
         mockGasAccounting.increaseBondedBalance(solverOp.from, maxGasUsed);
-        (bondedBefore,) = mockGasAccounting.accessData(solverOp.from);
+        (bondedBefore,,,,) = mockGasAccounting.accessData(solverOp.from);
         mockGasAccounting.releaseSolverLock(solverOp, gasWaterMark, result);
-        (bondedAfter,) = mockGasAccounting.accessData(solverOp.from);
+        (bondedAfter,,,,) = mockGasAccounting.accessData(solverOp.from);
         assertEq(bondedBefore - bondedAfter, maxGasUsed);
 
         // NO_USER_REFUND
         result = 1 << uint256(SolverOutcome.InvalidTo);
-        (bondedBefore,) = mockGasAccounting.accessData(solverOp.from);
+        (bondedBefore,,,,) = mockGasAccounting.accessData(solverOp.from);
         mockGasAccounting.releaseSolverLock(solverOp, gasWaterMark, result);
-        (bondedAfter,) = mockGasAccounting.accessData(solverOp.from);
+        (bondedAfter,,,,) = mockGasAccounting.accessData(solverOp.from);
         assertEq(bondedBefore, bondedAfter);
 
         // UncoveredResult
@@ -317,8 +317,8 @@ contract GasAccountingTest is Test {
 
     function test_settle() public {
         address bundler = makeAddr("bundler");
-        uint128 bondedBefore;
-        uint128 bondedAfter;
+        uint112 bondedBefore;
+        uint112 bondedAfter;
 
         vm.expectRevert();
         // This reverts with AtlasErrors.InsufficientTotalBalance(shortfall).
@@ -329,22 +329,22 @@ contract GasAccountingTest is Test {
 
         // Deficit, but solver has enough balance to cover it
         mockGasAccounting.increaseBondedBalance(solverOp.from, initialClaims);
-        (bondedBefore,) = mockGasAccounting.accessData(solverOp.from);
+        (bondedBefore,,,,) = mockGasAccounting.accessData(solverOp.from);
         vm.expectEmit(true, true, true, false);
         emit AtlasEvents.GasRefundSettled(bundler, 0);
         mockGasAccounting.settle(solverOp.from, bundler);
-        (bondedAfter,) = mockGasAccounting.accessData(solverOp.from);
+        (bondedAfter,,,,) = mockGasAccounting.accessData(solverOp.from);
         assertLt(bondedAfter, bondedBefore);
 
         // Surplus, credited to solver's bonded balance
         deal(executionEnvironment, initialClaims);
         vm.prank(executionEnvironment);
         mockGasAccounting.contribute{ value: initialClaims }();
-        (bondedBefore,) = mockGasAccounting.accessData(solverOp.from);
+        (bondedBefore,,,,) = mockGasAccounting.accessData(solverOp.from);
         vm.expectEmit(true, true, true, false);
         emit AtlasEvents.GasRefundSettled(bundler, 0);
         mockGasAccounting.settle(solverOp.from, bundler);
-        (bondedAfter,) = mockGasAccounting.accessData(solverOp.from);
+        (bondedAfter,,,,) = mockGasAccounting.accessData(solverOp.from);
         assertGt(bondedAfter, bondedBefore);
     }
 }

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -30,8 +30,8 @@ contract MockGasAccounting is GasAccounting, Test {
         _initializeEscrowLock(executionEnvironment, gasMarker, userOpValue);
     }
 
-    function assign(address owner, uint256 value) external returns (bool) {
-        return _assign(owner, value);
+    function assign(address owner, uint256 value, bool solverWon) external returns (bool) {
+        return _assign(owner, value, solverWon);
     }
 
     function credit(address owner, uint256 value) external {
@@ -173,7 +173,7 @@ contract GasAccountingTest is Test {
 
         bondedTotalSupplyBefore = mockGasAccounting.bondedTotalSupply();
         depositsBefore = mockGasAccounting.deposits();
-        assertFalse(mockGasAccounting.assign(solverOp.from, 0));
+        assertFalse(mockGasAccounting.assign(solverOp.from, 0, true));
         (, lastAccessedBlock,,,) = mockGasAccounting.accessData(solverOp.from);
         assertEq(lastAccessedBlock, uint32(block.number));
         assertEq(mockGasAccounting.bondedTotalSupply(), bondedTotalSupplyBefore);
@@ -181,7 +181,7 @@ contract GasAccountingTest is Test {
 
         bondedTotalSupplyBefore = mockGasAccounting.bondedTotalSupply();
         depositsBefore = mockGasAccounting.deposits();
-        assertTrue(mockGasAccounting.assign(solverOp.from, assignedAmount));
+        assertTrue(mockGasAccounting.assign(solverOp.from, assignedAmount, true));
         (, lastAccessedBlock,,,) = mockGasAccounting.accessData(solverOp.from);
         assertEq(lastAccessedBlock, uint32(block.number));
         assertEq(mockGasAccounting.bondedTotalSupply(), bondedTotalSupplyBefore);
@@ -195,7 +195,7 @@ contract GasAccountingTest is Test {
         mockGasAccounting.increaseUnbondingBalance(solverOp.from, unbondingAmount);
         bondedTotalSupplyBefore = mockGasAccounting.bondedTotalSupply();
         depositsBefore = mockGasAccounting.deposits();
-        assertFalse(mockGasAccounting.assign(solverOp.from, assignedAmount));
+        assertFalse(mockGasAccounting.assign(solverOp.from, assignedAmount, true));
         (, lastAccessedBlock,,,) = mockGasAccounting.accessData(solverOp.from);
         assertEq(lastAccessedBlock, uint32(block.number));
         assertEq(mockGasAccounting.bondedTotalSupply(), bondedTotalSupplyBefore - assignedAmount);
@@ -210,7 +210,7 @@ contract GasAccountingTest is Test {
         bondedTotalSupplyBefore = mockGasAccounting.bondedTotalSupply();
         depositsBefore = mockGasAccounting.deposits();
         (, uint112 unbondingBefore) = mockGasAccounting.balanceOf(solverOp.from);
-        assertFalse(mockGasAccounting.assign(solverOp.from, assignedAmount));
+        assertFalse(mockGasAccounting.assign(solverOp.from, assignedAmount, true));
         (, lastAccessedBlock,,,) = mockGasAccounting.accessData(solverOp.from);
         assertEq(lastAccessedBlock, uint32(block.number));
         assertEq(mockGasAccounting.bondedTotalSupply(), bondedTotalSupplyBefore - assignedAmount);
@@ -228,7 +228,7 @@ contract GasAccountingTest is Test {
         depositsBefore = mockGasAccounting.deposits();
         (, unbondingBefore) = mockGasAccounting.balanceOf(solverOp.from);
         vm.expectRevert(AtlasErrors.ValueTooLarge.selector);
-        mockGasAccounting.assign(solverOp.from, assignedAmount);
+        mockGasAccounting.assign(solverOp.from, assignedAmount, true);
         // Check assign reverted with overflow, and accounting values did not change
         assertEq(mockGasAccounting.bondedTotalSupply(), bondedTotalSupplyBefore);
         assertEq(mockGasAccounting.deposits(), depositsBefore);


### PR DESCRIPTION
TODO:
- Extra tests for changes to GasAccounting where analytics data is stored
- Decide if we emit an event in `_assign` in addition to storing data for each solver win/fail
- Decide if we use the last 32 bits in `EscrowAccountBalance` struct for something. Can also just leave as is.


Note: We need to be extra careful with the `uint112` values. Before, with `uint128`, Solidity would catch overflows and revert automatically. Now it looks like it's not catching those overflows with `uint112` so we have to explicitly check and revert with `ValueTooLarge`.