### PR TITLE
Cleanup unused Safetybits constants, restore test

### DIFF
--- a/src/contracts/common/Permit69.sol
+++ b/src/contracts/common/Permit69.sol
@@ -8,12 +8,7 @@ import { GasAccounting } from "../atlas/GasAccounting.sol";
 import "../types/LockTypes.sol";
 import "../types/EscrowTypes.sol";
 
-import {
-    EXECUTION_PHASE_OFFSET,
-    SAFE_USER_TRANSFER,
-    SAFE_DAPP_TRANSFER,
-    SAFE_GAS_TRANSFER
-} from "../libraries/SafetyBits.sol";
+import { SAFE_USER_TRANSFER, SAFE_DAPP_TRANSFER } from "../libraries/SafetyBits.sol";
 
 // NOTE: IPermit69 only works inside of the Atlas environment - specifically
 // inside of the custom ExecutionEnvironments that each user deploys when

--- a/src/contracts/examples/v4-example/UniV4Hook.sol
+++ b/src/contracts/examples/v4-example/UniV4Hook.sol
@@ -84,7 +84,7 @@ contract UniV4Hook is V4DAppControl {
 
             // Verify that the pool is valid for the user to trade in.
             require(keccak256(abi.encode(key, sender)) == hashLock, "ERR-H02 InvalidSwapper");
-        } else if (escrowKey.lockState == SafetyBits._LOCKED_X_SOLVERS_X_VERIFIED) {
+        } else if (escrowKey.lockState == SafetyBits._LOCKED_X_SOLVERS_X_REQUESTED) {
             // Case: Solver call
             // Sender = Solver contract
             // NOTE: This lockState verifies that the user's transaction has already

--- a/src/contracts/libraries/SafetyBits.sol
+++ b/src/contracts/libraries/SafetyBits.sol
@@ -12,8 +12,6 @@ import "../types/LockTypes.sol";
 
 uint16 constant EXECUTION_PHASE_OFFSET = uint16(type(BaseLock).max) + 1;
 
-uint16 constant ONLY_EXECUTION_PHASE_MASK = uint16(4080); // 0000 1111 1111 0000
-
 // NOTE: No user transfers allowed during HandlingPayments
 uint16 constant SAFE_USER_TRANSFER = uint16(
     1 << (EXECUTION_PHASE_OFFSET + uint16(ExecutionPhase.PreOps))
@@ -31,24 +29,12 @@ uint16 constant SAFE_DAPP_TRANSFER = uint16(
         | 1 << (EXECUTION_PHASE_OFFSET + uint16(ExecutionPhase.PostOps))
 );
 
-uint16 constant SAFE_GAS_TRANSFER = uint16(
-    1 << (EXECUTION_PHASE_OFFSET + uint16(ExecutionPhase.PreOps))
-        | 1 << (EXECUTION_PHASE_OFFSET + uint16(ExecutionPhase.UserOperation))
-        | 1 << (EXECUTION_PHASE_OFFSET + uint16(ExecutionPhase.PreSolver))
-);
-
 library SafetyBits {
     uint16 internal constant _LOCKED_X_SOLVERS_X_REQUESTED =
         uint16(1 << uint16(BaseLock.Locked) | 1 << (EXECUTION_PHASE_OFFSET + uint16(ExecutionPhase.SolverOperations)));
 
-    uint16 internal constant _LOCKED_X_SOLVERS_X_VERIFIED =
-        uint16(1 << uint16(BaseLock.Locked) | 1 << (EXECUTION_PHASE_OFFSET + uint16(ExecutionPhase.SolverOperations)));
-
     uint16 internal constant _ACTIVE_X_PRE_OPS_X_UNSET =
         uint16(1 << uint16(BaseLock.Active) | 1 << (EXECUTION_PHASE_OFFSET + uint16(ExecutionPhase.PreOps)));
-
-    uint16 internal constant _PENDING_X_RELEASING_X_UNSET =
-        uint16(1 << uint16(BaseLock.Pending) | 1 << (EXECUTION_PHASE_OFFSET + uint16(ExecutionPhase.Releasing)));
 
     uint16 internal constant _LOCKED_X_PRE_OPS_X_UNSET =
         uint16(1 << uint16(BaseLock.Locked) | 1 << (EXECUTION_PHASE_OFFSET + uint16(ExecutionPhase.PreOps)));
@@ -59,17 +45,8 @@ library SafetyBits {
     uint16 internal constant _LOCKED_X_USER_X_UNSET =
         uint16(1 << uint16(BaseLock.Locked) | 1 << (EXECUTION_PHASE_OFFSET + uint16(ExecutionPhase.UserOperation)));
 
-    uint16 internal constant _PENDING_X_SOLVER_X_UNSET =
-        uint16(1 << uint16(BaseLock.Pending) | 1 << (EXECUTION_PHASE_OFFSET + uint16(ExecutionPhase.SolverOperations)));
-
-    uint16 internal constant _ACTIVE_X_SOLVER_X_UNSET =
-        uint16(1 << uint16(BaseLock.Active) | 1 << (EXECUTION_PHASE_OFFSET + uint16(ExecutionPhase.SolverOperations)));
-
     uint16 internal constant _LOCK_PAYMENTS =
         uint16(1 << uint16(BaseLock.Locked) | 1 << (EXECUTION_PHASE_OFFSET + uint16(ExecutionPhase.HandlingPayments)));
-
-    uint16 internal constant _NO_SOLVER_SUCCESS =
-        uint16(1 << uint16(BaseLock.Active) | 1 << (EXECUTION_PHASE_OFFSET + uint16(ExecutionPhase.PostOps)));
 
     uint16 internal constant _LOCKED_X_VERIFICATION_X_UNSET =
         uint16(1 << uint16(BaseLock.Locked) | 1 << (EXECUTION_PHASE_OFFSET + uint16(ExecutionPhase.PostOps)));

--- a/test/libraries/SafetyBits.t.sol
+++ b/test/libraries/SafetyBits.t.sol
@@ -15,91 +15,55 @@ contract SafetyBitsTest is Test {
     }
 
     // TODO Let's fix the constants test last.
-    /*
+
     function testConstants() public {
-        string memory expectedBitMapString = "0010000010001000";
+        string memory expectedBitMapString = "0000000100001000";
         assertEq(
             TestUtils.uint16ToBinaryString(SafetyBits._LOCKED_X_SOLVERS_X_REQUESTED),
             expectedBitMapString,
             "_LOCKED_X_SOLVERS_X_REQUESTED incorrect"
         );
 
-        expectedBitMapString = "0100000010001000";
-        assertEq(
-            TestUtils.uint16ToBinaryString(SafetyBits._LOCKED_X_SOLVERS_X_VERIFIED),
-            expectedBitMapString,
-            "_LOCKED_X_SOLVERS_X_VERIFIED incorrect"
-        );
-
-        expectedBitMapString = "0001000000100100";
+        expectedBitMapString = "0000000000100100";
         assertEq(
             TestUtils.uint16ToBinaryString(SafetyBits._ACTIVE_X_PRE_OPS_X_UNSET),
             expectedBitMapString,
             "_ACTIVE_X_PRE_OPS_X_UNSET incorrect"
         );
 
-        expectedBitMapString = "0001100000000010";
-        assertEq(
-            TestUtils.uint16ToBinaryString(SafetyBits._PENDING_X_RELEASING_X_UNSET),
-            expectedBitMapString,
-            "_PENDING_X_RELEASING_X_UNSET incorrect"
-        );
-
-        expectedBitMapString = "0001000000101000";
+        expectedBitMapString = "0000000000101000";
         assertEq(
             TestUtils.uint16ToBinaryString(SafetyBits._LOCKED_X_PRE_OPS_X_UNSET),
             expectedBitMapString,
             "_LOCKED_X_PRE_OPS_X_UNSET incorrect"
         );
 
-        expectedBitMapString = "0001000001000100";
+        expectedBitMapString = "0000000001000100";
         assertEq(
             TestUtils.uint16ToBinaryString(SafetyBits._ACTIVE_X_USER_X_UNSET),
             expectedBitMapString,
             "_ACTIVE_X_USER_X_UNSET incorrect"
         );
 
-        expectedBitMapString = "0001000001001000";
+        expectedBitMapString = "0000000001001000";
         assertEq(
             TestUtils.uint16ToBinaryString(SafetyBits._LOCKED_X_USER_X_UNSET),
             expectedBitMapString,
             "_LOCKED_X_USER_X_UNSET incorrect"
         );
 
-        expectedBitMapString = "0001000010000010";
+        expectedBitMapString = "0000010000001000";
         assertEq(
-            TestUtils.uint16ToBinaryString(SafetyBits._PENDING_X_SOLVER_X_UNSET),
-            expectedBitMapString,
-            "_PENDING_X_SOLVER_X_UNSET incorrect"
+            TestUtils.uint16ToBinaryString(SafetyBits._LOCK_PAYMENTS), expectedBitMapString, "_LOCK_PAYMENTS incorrect"
         );
 
-        expectedBitMapString = "0001000010000010";
-        assertEq(
-            TestUtils.uint16ToBinaryString(SafetyBits._ACTIVE_X_SOLVER_X_UNSET),
-            expectedBitMapString,
-            "_ACTIVE_X_SOLVER_X_UNSET incorrect"
-        );
-
-        expectedBitMapString = "0001000100001000";
-        assertEq(
-    TestUtils.uint16ToBinaryString(SafetyBits._LOCK_PAYMENTS), expectedBitMapString, "_LOCK_PAYMENTS incorrect"
-        );
-
-        expectedBitMapString = "0001010000000100";
-        assertEq(
-            TestUtils.uint16ToBinaryString(SafetyBits._NO_SOLVER_SUCCESS),
-            expectedBitMapString,
-            "_NO_SOLVER_SUCCESS incorrect"
-        );
-
-        expectedBitMapString = "0001010000001000";
+        expectedBitMapString = "0000100000001000";
         assertEq(
             TestUtils.uint16ToBinaryString(SafetyBits._LOCKED_X_VERIFICATION_X_UNSET),
             expectedBitMapString,
             "_LOCKED_X_VERIFICATION_X_UNSET incorrect"
         );
     }
-    */
 
     function testInitializeEscrowLock() public {
         EscrowKey memory key = initializeEscrowLock();
@@ -129,7 +93,7 @@ contract SafetyBitsTest is Test {
         assertTrue(key.lockState == SafetyBits._LOCKED_X_VERIFICATION_X_UNSET);
         assertFalse(key.addressPointer == address(1));
         assertTrue(key.callIndex == 3);
-      
+
         EscrowKey memory newKey = initializeEscrowLock();
         newKey.addressPointer = address(1);
         newKey.solverSuccessful = true;

--- a/test/libraries/SafetyBits.t.sol
+++ b/test/libraries/SafetyBits.t.sol
@@ -14,8 +14,6 @@ contract SafetyBitsTest is Test {
         key = key.initializeEscrowLock(true, 1, address(0), false);
     }
 
-    // TODO Let's fix the constants test last.
-
     function testConstants() public {
         string memory expectedBitMapString = "0000000100001000";
         assertEq(


### PR DESCRIPTION
Proposal to remove all unused constants from SafetyBits and restore the corresponding test.
Although those constants aren't used anywhere in the project, I am not exactly sure we should get rid of all of it, technically I think the dAppControls could use them to check phases.

Note that the base branch is [lock-update](https://github.com/FastLane-Labs/atlas/pull/121).