### PR TITLE
DAppControl Clean Up

### DIFF
--- a/src/contracts/atlas/AtlETH.sol
+++ b/src/contracts/atlas/AtlETH.sol
@@ -6,8 +6,6 @@ import { SafeTransferLib } from "solmate/utils/SafeTransferLib.sol";
 import "../types/EscrowTypes.sol";
 import { Permit69 } from "../common/Permit69.sol";
 
-// TODO split out events and errors to share with AtlasEscrow
-
 /// @notice Modified Solmate ERC20 with some Atlas-specific modifications.
 /// @author FastLane Labs
 /// @author Modified from Solmate (https://github.com/transmissions11/solmate/blob/main/src/tokens/ERC20.sol)

--- a/src/contracts/common/ExecutionBase.sol
+++ b/src/contracts/common/ExecutionBase.sol
@@ -220,17 +220,17 @@ contract ExecutionBase is Base {
     }
 
     function _availableFundsERC20(
-        address token,
-        address source,
-        uint256 amount,
+        address _token,
+        address _source,
+        uint256 _amount,
         ExecutionPhase phase
     )
         internal
         view
         returns (bool available)
     {
-        uint256 balance = ERC20(token).balanceOf(source);
-        if (balance < amount) {
+        uint256 balance = ERC20(_token).balanceOf(_source);
+        if (balance < _amount) {
             return false;
         }
 
@@ -238,19 +238,19 @@ contract ExecutionBase is Base {
         address user = _user();
         address dapp = _control();
 
-        if (source == user) {
+        if (_source == user) {
             if (shiftedPhase & SAFE_USER_TRANSFER == 0) {
                 return false;
             }
-            if (ERC20(token).allowance(user, atlas) < amount) {
+            if (ERC20(_token).allowance(user, atlas) < _amount) {
                 return false;
             }
             return true;
-        } else if (source == dapp) {
+        } else if (_source == dapp) {
             if (shiftedPhase & SAFE_DAPP_TRANSFER == 0) {
                 return false;
             }
-            if (ERC20(token).allowance(dapp, atlas) < amount) {
+            if (ERC20(_token).allowance(dapp, atlas) < _amount) {
                 return false;
             }
             return true;

--- a/src/contracts/dapp/ControlTemplate.sol
+++ b/src/contracts/dapp/ControlTemplate.sol
@@ -8,11 +8,7 @@ import "../types/DAppApprovalTypes.sol";
 import "forge-std/Test.sol";
 
 abstract contract DAppControlTemplate {
-    address internal immutable _executionBase;
-
-    constructor() {
-        _executionBase = address(this);
-    }
+    constructor() { }
 
     string internal constant _NOT_IMPLEMENTED = "NOT IMPLEMENTED";
     // Virtual functions to be overridden by participating dApp governance

--- a/src/contracts/dapp/DAppControl.sol
+++ b/src/contracts/dapp/DAppControl.sol
@@ -19,21 +19,19 @@ import "forge-std/Test.sol";
 // TODO: Check payable is appropriate in pre/post ops and solver calls. Needed to send ETH if necessary (even when
 // delegatecalled)
 
-abstract contract DAppControl is Test, DAppControlTemplate, ExecutionBase {
-    address public immutable escrow;
+abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
     address public immutable governance;
     address public immutable control;
     uint32 public immutable callConfig;
 
     uint8 private constant _CONTROL_DEPTH = 1 << 2;
 
-    constructor(address _escrow, address _governance, CallConfig memory _callConfig) ExecutionBase(_escrow) {
+    constructor(address _atlas, address _governance, CallConfig memory _callConfig) ExecutionBase(_atlas) {
         if (_callConfig.userNoncesSequenced && _callConfig.dappNoncesSequenced) {
             revert("DAPP AND USER CANT BOTH BE SEQ"); // TODO convert to custom errors
         }
 
         control = address(this);
-        escrow = _escrow;
         governance = _governance;
         callConfig = CallBits.encodeCallConfig(_callConfig);
     }

--- a/src/contracts/examples/intents-example/SwapIntent.sol
+++ b/src/contracts/examples/intents-example/SwapIntent.sol
@@ -53,9 +53,9 @@ contract SwapIntentController is DAppControl {
 
     uint256 public constant EXPECTED_GAS_USAGE_EX_SOLVER = 200_000;
 
-    constructor(address _escrow)
+    constructor(address _atlas)
         DAppControl(
-            _escrow,
+            _atlas,
             msg.sender,
             CallConfig({
                 userNoncesSequenced: false,
@@ -86,7 +86,7 @@ contract SwapIntentController is DAppControl {
 
     // swap() selector = 0x98434997
     function swap(SwapIntent calldata swapIntent) external payable returns (SwapData memory) {
-        require(msg.sender == escrow, "ERR-PI002 InvalidSender");
+        require(msg.sender == atlas, "ERR-PI002 InvalidSender");
         require(_addressPointer() == control, "ERR-PI003 InvalidLockState");
         require(address(this) != control, "ERR-PI004 MustBeDelegated");
 
@@ -169,7 +169,7 @@ contract SwapIntentController is DAppControl {
 
     function _preSolverCall(bytes calldata data) internal override returns (bool) {
         (address solverTo,, bytes memory returnData) = abi.decode(data, (address, uint256, bytes));
-        if (solverTo == address(this) || solverTo == _control() || solverTo == escrow) {
+        if (solverTo == address(this) || solverTo == _control() || solverTo == atlas) {
             return false;
         }
 

--- a/src/contracts/examples/intents-example/V4SwapIntent.sol
+++ b/src/contracts/examples/intents-example/V4SwapIntent.sol
@@ -34,11 +34,11 @@ contract V4SwapIntentController is DAppControl {
     uint256 startingBalance; // Balance tracked for the v4 pool
 
     constructor(
-        address _escrow,
+        address _atlas,
         address poolManager
     )
         DAppControl(
-            _escrow,
+            _atlas,
             msg.sender,
             CallConfig({
                 userNoncesSequenced: false,
@@ -70,7 +70,7 @@ contract V4SwapIntentController is DAppControl {
     //////////////////////////////////
 
     modifier verifyCall(address tokenIn, address tokenOut, uint256 amount) {
-        require(msg.sender == escrow, "ERR-PI002 InvalidSender");
+        require(msg.sender == atlas, "ERR-PI002 InvalidSender");
         require(_addressPointer() == control, "ERR-PI003 InvalidLockState");
         require(address(this) != control, "ERR-PI004 MustBeDelegated");
 
@@ -153,7 +153,7 @@ contract V4SwapIntentController is DAppControl {
 
     function _preSolverCall(bytes calldata data) internal override returns (bool) {
         (address solverTo, uint256 solverBid, bytes memory returnData) = abi.decode(data, (address, uint256, bytes));
-        if (solverTo == address(this) || solverTo == _control() || solverTo == escrow) {
+        if (solverTo == address(this) || solverTo == _control() || solverTo == atlas) {
             return false;
         }
 
@@ -233,7 +233,7 @@ contract V4SwapIntentController is DAppControl {
     function _allocateValueCall(address bidToken, uint256 bidAmount, bytes calldata) internal override {
         // This function is delegatecalled
         // address(this) = ExecutionEnvironment
-        // msg.sender = Escrow
+        // msg.sender = Atlas
         if (bidToken != address(0)) {
             ERC20(bidToken).safeTransfer(_user(), bidAmount);
         } else {

--- a/src/contracts/examples/v2-example/V2DAppControl.sol
+++ b/src/contracts/examples/v2-example/V2DAppControl.sol
@@ -47,9 +47,9 @@ contract V2DAppControl is DAppControl {
 
     event GiftedGovernanceToken(address indexed user, address indexed token, uint256 amount);
 
-    constructor(address _escrow)
+    constructor(address _atlas)
         DAppControl(
-            _escrow,
+            _atlas,
             msg.sender,
             CallConfig({
                 userNoncesSequenced: false,

--- a/src/contracts/examples/v4-example/UniV4Hook.sol
+++ b/src/contracts/examples/v4-example/UniV4Hook.sol
@@ -29,7 +29,7 @@ import "../../types/LockTypes.sol";
 /////////////////////////////////////////////////////////
 
 contract UniV4Hook is V4DAppControl {
-    constructor(address _escrow, address _v4Singleton) V4DAppControl(_escrow, _v4Singleton) { }
+    constructor(address _atlas, address _v4Singleton) V4DAppControl(_atlas, _v4Singleton) { }
 
     function getHooksCalls() public pure returns (IHooks.Calls memory) {
         // override
@@ -76,7 +76,7 @@ contract UniV4Hook is V4DAppControl {
         require(address(this) == hook, "ERR-H00 InvalidCallee");
         require(msg.sender == v4Singleton, "ERR-H01 InvalidCaller"); // TODO: Confirm this
 
-        EscrowKey memory escrowKey = ISafetyLocks(escrow).getLockState();
+        EscrowKey memory escrowKey = ISafetyLocks(atlas).getLockState();
 
         if (escrowKey.lockState == SafetyBits._LOCKED_X_USER_X_UNSET) {
             // Case: User call

--- a/src/contracts/examples/v4-example/V4DAppControl.sol
+++ b/src/contracts/examples/v4-example/V4DAppControl.sol
@@ -48,11 +48,11 @@ contract V4DAppControl is DAppControl {
     PoolKey internal _currentKey; // TODO: Transient storage <-
 
     constructor(
-        address _escrow,
+        address _atlas,
         address _v4Singleton
     )
         DAppControl(
-            _escrow,
+            _atlas,
             msg.sender,
             CallConfig({
                 userNoncesSequenced: false,
@@ -98,7 +98,7 @@ contract V4DAppControl is DAppControl {
 
         // Verify that the swapper went through the FastLane Atlas MEV Auction
         // and that DAppControl supplied a valid signature
-        require(msg.sender == escrow, "ERR-H00 InvalidCaller");
+        require(msg.sender == atlas, "ERR-H00 InvalidCaller");
 
         (IPoolManager.PoolKey memory key, IPoolManager.SwapParams memory params) =
             abi.decode(userOp.data[4:], (IPoolManager.PoolKey, IPoolManager.SwapParams));
@@ -201,7 +201,7 @@ contract V4DAppControl is DAppControl {
         // address(this) = hook
         // msg.sender = ExecutionEnvironment
 
-        EscrowKey memory escrowKey = ISafetyLocks(escrow).getLockState();
+        EscrowKey memory escrowKey = ISafetyLocks(atlas).getLockState();
 
         // Verify that the swapper went through the FastLane Atlas MEV Auction
         // and that DAppControl supplied a valid signature
@@ -219,7 +219,7 @@ contract V4DAppControl is DAppControl {
         // address(this) = hook
         // msg.sender = ExecutionEnvironment
 
-        EscrowKey memory escrowKey = ISafetyLocks(escrow).getLockState();
+        EscrowKey memory escrowKey = ISafetyLocks(atlas).getLockState();
 
         // Verify that the swapper went through the FastLane Atlas MEV Auction
         // and that DAppControl supplied a valid signature

--- a/src/contracts/solver/SolverBase.sol
+++ b/src/contracts/solver/SolverBase.sol
@@ -20,12 +20,12 @@ contract SolverBase is Test {
 
     // TODO consider making these accessible (internal) for solvers which may want to use them
     address private immutable _owner;
-    address private immutable _escrow;
+    address private immutable _atlas;
 
-    constructor(address weth, address atlasEscrow, address owner) {
+    constructor(address weth, address atlas, address owner) {
         WETH_ADDRESS = weth;
         _owner = owner;
-        _escrow = atlasEscrow;
+        _atlas = atlas;
     }
 
     function atlasSolverCall(
@@ -53,12 +53,12 @@ contract SolverBase is Test {
 
         _;
 
-        uint256 shortfall = IEscrow(_escrow).shortfall();
+        uint256 shortfall = IEscrow(_atlas).shortfall();
 
         if (shortfall < msg.value) shortfall = 0;
         else shortfall -= msg.value;
 
-        IEscrow(_escrow).reconcile{ value: msg.value }(msg.sender, sender, shortfall);
+        IEscrow(_atlas).reconcile{ value: msg.value }(msg.sender, sender, shortfall);
     }
 
     modifier payBids(address bidToken, uint256 bidAmount) {

--- a/test/ExecutionEnvironment.t.sol
+++ b/test/ExecutionEnvironment.t.sol
@@ -675,11 +675,11 @@ contract ExecutionEnvironmentTest is BaseTest {
 
 contract MockDAppControl is DAppControl {
     constructor(
-        address _escrow,
+        address _atlas,
         address _governance,
         CallConfig memory _callConfig
     )
-        DAppControl(_escrow, _governance, _callConfig)
+        DAppControl(_atlas, _governance, _callConfig)
     { }
 
     /*//////////////////////////////////////////////////////////////
@@ -735,11 +735,11 @@ contract MockDAppControl is DAppControl {
 
 contract MockSolverContract {
     address public immutable WETH_ADDRESS;
-    address private immutable _escrow;
+    address private immutable _atlas;
 
-    constructor(address weth, address atlasEscrow) {
+    constructor(address weth, address atlas) {
         WETH_ADDRESS = weth;
-        _escrow = atlasEscrow;
+        _atlas = atlas;
     }
 
     function atlasSolverCall(

--- a/test/FlashLoan.t.sol
+++ b/test/FlashLoan.t.sol
@@ -242,11 +242,11 @@ contract DummyDAppControlBuilder is DAppControl {
     address immutable weth;
 
     constructor(
-        address _escrow,
+        address _atlas,
         address _weth
     )
         DAppControl(
-            _escrow,
+            _atlas,
             msg.sender,
             CallConfig({
                 userNoncesSequenced: false,
@@ -295,11 +295,11 @@ contract DummyDAppControlBuilder is DAppControl {
 contract SimpleSolver {
     address weth;
     address msgSender;
-    address escrow;
+    address atlas;
 
-    constructor(address _weth, address _escrow) {
+    constructor(address _weth, address _atlas) {
         weth = _weth;
-        escrow = _escrow;
+        atlas = _atlas;
     }
 
     function atlasSolverCall(
@@ -317,12 +317,12 @@ contract SimpleSolver {
         (success, data) = address(this).call{ value: msg.value }(solverOpData);
 
         if (bytes4(solverOpData[:4]) == SimpleSolver.payback.selector) {
-            uint256 shortfall = IEscrow(escrow).shortfall();
+            uint256 shortfall = IEscrow(atlas).shortfall();
 
             if (shortfall < msg.value) shortfall = 0;
             else shortfall -= msg.value;
 
-            IEscrow(escrow).reconcile{ value: msg.value }(msg.sender, sender, shortfall);
+            IEscrow(atlas).reconcile{ value: msg.value }(msg.sender, sender, shortfall);
         }
     }
 

--- a/test/base/DummyDAppControl.sol
+++ b/test/base/DummyDAppControl.sol
@@ -15,11 +15,11 @@ contract DummyDAppControl is DAppControl {
     event MEVPaymentSuccess(address bidToken, uint256 bidAmount);
 
     constructor(
-        address _escrow,
+        address _atlas,
         address _governance,
         CallConfig memory _callConfig
     )
-        DAppControl(_escrow, _governance, _callConfig)
+        DAppControl(_atlas, _governance, _callConfig)
     { }
 
     // ****************************************

--- a/test/helpers/DummyDAppControlBuilder.sol
+++ b/test/helpers/DummyDAppControlBuilder.sol
@@ -8,12 +8,12 @@ import { AtlasVerification } from "src/contracts/atlas/AtlasVerification.sol";
 import "forge-std/Test.sol";
 
 contract DummyDAppControlBuilder is Test {
-    address public escrow;
+    address public atlas;
     address public governance;
     CallConfig callConfig;
 
-    function withEscrow(address _escrow) public returns (DummyDAppControlBuilder) {
-        escrow = _escrow;
+    function withEscrow(address _atlas) public returns (DummyDAppControlBuilder) {
+        atlas = _atlas;
         return this;
     }
 
@@ -28,7 +28,7 @@ contract DummyDAppControlBuilder is Test {
     }
 
     function build() public returns (DummyDAppControl) {
-        return new DummyDAppControl(escrow, governance, callConfig);
+        return new DummyDAppControl(atlas, governance, callConfig);
     }
 
     /*


### PR DESCRIPTION
Just some small clean up items for DAppControl in this PR:

- Now DAppControl only stores the `atlas` address var, and not the `escrow` address which points to the same contract
- Now DAppControl only stores its own address as `source` var, and not also as `_executionBase` as well.
- The `source` var was being shadowed by param with same name in `_availableFundsERC20`, changed param to be `_source`