### PR TITLE
Remove redundant escrow address var in tests

### DIFF
--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -65,7 +65,8 @@ contract Atlas is Escrow, Factory {
             dConfig, userOp, solverOps, dAppOp, msg.value, msg.sender, isSimulation
         );
         if (validCallsResult != ValidCallsResult.Valid) {
-            if (isSimulation) revert VerificationSimFail();
+            // TODO group lines below into single revert line?
+            if (isSimulation) revert VerificationSimFail(uint256(validCallsResult));
             else revert ValidCalls(validCallsResult);
         }
 

--- a/src/contracts/helpers/Simulator.sol
+++ b/src/contracts/helpers/Simulator.sol
@@ -38,7 +38,7 @@ contract Simulator is AtlasErrors {
     }
 
     function setAtlas(address _atlas) external {
-        require(msg.sender == deployer, "err - invalid sender");
+        if (msg.sender != deployer) revert Unauthorized();
         atlas = _atlas;
     }
 
@@ -127,7 +127,7 @@ contract Simulator is AtlasErrors {
         external
         payable
     {
-        require(msg.sender == address(this), "invalid entry func");
+        if (msg.sender != address(this)) revert InvalidEntryFunction();
         if (!IAtlas(atlas).metacall(userOp, solverOps, dAppOp)) {
             revert NoAuctionWinner(); // should be unreachable
         }
@@ -135,6 +135,5 @@ contract Simulator is AtlasErrors {
     }
 
     receive() external payable { }
-
     fallback() external payable { }
 }

--- a/src/contracts/types/AtlasErrors.sol
+++ b/src/contracts/types/AtlasErrors.sol
@@ -24,7 +24,7 @@ contract AtlasErrors {
     error PreSolverFailed();
     error PostSolverFailed();
 
-    error VerificationSimFail();
+    error VerificationSimFail(uint256 validCallsResult);
     error PreOpsSimFail();
     error UserOpSimFail();
     error SolverSimFail();

--- a/src/contracts/types/AtlasErrors.sol
+++ b/src/contracts/types/AtlasErrors.sol
@@ -4,9 +4,17 @@ pragma solidity 0.8.22;
 import "../types/ValidCallsTypes.sol";
 
 contract AtlasErrors {
+    // Simulator
+    error Unauthorized();
+    error Unreachable();
+    error NoAuctionWinner();
+    error InvalidEntryFunction();
+    error SimulationPassed();
+
     error UserSimulationFailed();
     error UserSimulationSucceeded();
     error UserUnexpectedSuccess();
+    error UserNotFulfilled();
 
     error SolverBidUnpaid();
     error BalanceNotReconciled();
@@ -16,15 +24,11 @@ contract AtlasErrors {
     error PreSolverFailed();
     error PostSolverFailed();
 
-    error UserNotFulfilled();
-    error NoAuctionWinner();
-
     error VerificationSimFail();
     error PreOpsSimFail();
     error UserOpSimFail();
     error SolverSimFail();
     error PostOpsSimFail();
-    error SimulationPassed();
     error ValidCalls(ValidCallsResult);
 
     // Atlas

--- a/test/Accounting.t.sol
+++ b/test/Accounting.t.sol
@@ -22,6 +22,7 @@ import { SolverBase } from "src/contracts/solver/SolverBase.sol";
 
 import { IEscrow } from "src/contracts/interfaces/IEscrow.sol";
 
+// TODO Check if this is tested in more contract-specific tests, then delete this if true.
 contract AccountingTest is BaseTest {
     SwapIntentController public swapIntentController;
     TxBuilder public txBuilder;
@@ -49,7 +50,7 @@ contract AccountingTest is BaseTest {
 
         // Deploy new SwapIntent Controller from new gov and initialize in Atlas
         vm.startPrank(governanceEOA);
-        swapIntentController = new SwapIntentController(address(escrow));
+        swapIntentController = new SwapIntentController(address(atlas));
         atlasVerification.initializeGovernance(address(swapIntentController));
         vm.stopPrank();
 
@@ -211,7 +212,8 @@ contract AccountingTest is BaseTest {
 
         vm.startPrank(userEOA);
 
-        assertFalse(simulator.simUserOperation(userOp), "metasimUserOperationcall tested true a");
+        (bool simResult, ) = simulator.simUserOperation(userOp);
+        assertFalse(simResult, "metasimUserOperationcall tested true a");
 
         WETH.approve(address(atlas), swapIntent.amountUserSells);
 

--- a/test/ExecutionEnvironment.t.sol
+++ b/test/ExecutionEnvironment.t.sol
@@ -59,7 +59,7 @@ contract ExecutionEnvironmentTest is BaseTest {
 
     function setupDAppControl(CallConfig memory customCallConfig) internal {
         vm.startPrank(governance);
-        dAppControl = new MockDAppControl(escrow, governance, customCallConfig);
+        dAppControl = new MockDAppControl(address(atlas), governance, customCallConfig);
         atlasVerification.initializeGovernance(address(dAppControl));
         vm.stopPrank();
 
@@ -669,7 +669,7 @@ contract ExecutionEnvironmentTest is BaseTest {
     }
 
     function test_getEscrow() public {
-        assertEq(executionEnvironment.getEscrow(), escrow);
+        assertEq(executionEnvironment.getEscrow(), address(atlas));
     }
 }
 

--- a/test/FlashLoan.t.sol
+++ b/test/FlashLoan.t.sol
@@ -46,14 +46,14 @@ contract FlashLoanTest is BaseTest {
         // Deploy
         vm.startPrank(governanceEOA);
 
-        controller = new DummyDAppControlBuilder(address(escrow), WETH_ADDRESS);
+        controller = new DummyDAppControlBuilder(address(atlas), WETH_ADDRESS);
         atlasVerification.initializeGovernance(address(controller));
         vm.stopPrank();
     }
 
     function testFlashLoan() public {
         vm.startPrank(solverOneEOA);
-        SimpleSolver solver = new SimpleSolver(WETH_ADDRESS, escrow);
+        SimpleSolver solver = new SimpleSolver(WETH_ADDRESS, address(atlas));
         deal(WETH_ADDRESS, address(solver), 1e18); // 1 WETH to solver to pay bid
         atlas.bond(1 ether); // gas for solver to pay
         vm.stopPrank();

--- a/test/MainTest.t.sol
+++ b/test/MainTest.t.sol
@@ -390,11 +390,14 @@ contract MainTest is BaseTest {
         atlas.createExecutionEnvironment(userOp.control);
 
         // Failure case, user hasn't approved Atlas for TOKEN_ONE, operation must fail
-        assertFalse(simulator.simUserOperation(userOp), "UserOperation tested true");
+        (bool simResult, ) = simulator.simUserOperation(userOp);
+        assertFalse(simResult, "metasimUserOperationcall tested true");
 
         // Success case
         ERC20(TOKEN_ONE).approve(address(atlas), type(uint256).max);
-        assertTrue(simulator.simUserOperation(userOp), "UserOperation tested false");
+
+        (simResult,) = simulator.simUserOperation(userOp);
+        assertTrue(simResult, "metasimUserOperationcall tested false");
 
         vm.stopPrank();
     }

--- a/test/Simulator.t.sol
+++ b/test/Simulator.t.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.22;
+
+import "forge-std/Test.sol";
+
+import { DAppConfig, DAppOperation, CallConfig } from "src/contracts/types/DAppApprovalTypes.sol";
+import { UserOperation } from "src/contracts/types/UserCallTypes.sol";
+import { SolverOperation } from "src/contracts/types/SolverCallTypes.sol";
+import { AtlasEvents } from "src/contracts/types/AtlasEvents.sol";
+import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
+
+import { BaseTest } from "./base/BaseTest.t.sol";
+import { UserOperationBuilder } from "./base/builders/UserOperationBuilder.sol";
+import { SolverOperationBuilder } from "./base/builders/SolverOperationBuilder.sol";
+import { DAppOperationBuilder } from "./base/builders/DAppOperationBuilder.sol";
+import { CallConfigBuilder } from "./helpers/CallConfigBuilder.sol";
+import { DummyDAppControlBuilder } from "./helpers/DummyDAppControlBuilder.sol";
+
+import { DummyDAppControl } from "./base/DummyDAppControl.sol";
+
+
+contract SimulatorTest is BaseTest {
+
+    DummyDAppControl dAppControl;
+
+    struct ValidCallsCall {
+        UserOperation userOp;
+        SolverOperation[] solverOps;
+        DAppOperation dAppOp;
+        uint256 msgValue;
+        address msgSender;
+        bool isSimulation;
+    }
+
+    function defaultCallConfig() public returns (CallConfigBuilder) {
+        return new CallConfigBuilder();
+    }
+
+    function defaultDAppControl() public returns (DummyDAppControlBuilder) {
+        return new DummyDAppControlBuilder()
+            .withEscrow(address(atlas))
+            .withGovernance(governanceEOA)
+            .withCallConfig(defaultCallConfig().build());
+    }
+
+    function validUserOperation() public returns (UserOperationBuilder) {
+        return new UserOperationBuilder()
+            .withFrom(userEOA)
+            .withTo(address(atlas))
+            .withValue(0)
+            .withGas(1_000_000)
+            .withMaxFeePerGas(tx.gasprice + 1)
+            .withNonce(address(atlasVerification), userEOA)
+            .withDeadline(block.number + 2)
+            .withControl(address(dAppControl))
+            .withSessionKey(address(0))
+            .withData("")
+            .sign(address(atlasVerification), userPK);
+    }
+
+    function setUp() public override {
+        BaseTest.setUp();
+        dAppControl = defaultDAppControl().buildAndIntegrate(atlasVerification);
+    }
+
+    function test_sim_temp() public {
+        
+        // Fail in VERIFICATION.validateCalls with userSignatureInvalid
+
+        UserOperation memory userOp = validUserOperation().build();
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(userPK, "wrong data");
+        userOp.signature = abi.encodePacked(r, s, v);
+
+        simulator.simUserOperation(userOp);
+    }
+
+}

--- a/test/SwapIntent.t.sol
+++ b/test/SwapIntent.t.sol
@@ -50,7 +50,7 @@ contract SwapIntentTest is BaseTest {
 
         // Deploy new SwapIntent Controller from new gov and initialize in Atlas
         vm.startPrank(governanceEOA);
-        swapIntentController = new SwapIntentController(address(escrow));
+        swapIntentController = new SwapIntentController(address(atlas));
         atlasVerification.initializeGovernance(address(swapIntentController));
         vm.stopPrank();
 
@@ -177,11 +177,13 @@ contract SwapIntentTest is BaseTest {
 
         vm.startPrank(userEOA);
 
-        assertFalse(simulator.simUserOperation(userOp), "metasimUserOperationcall tested true a");
+        (bool simResult, ) = simulator.simUserOperation(userOp);
+        assertFalse(simResult, "metasimUserOperationcall tested true a");
 
         WETH.approve(address(atlas), swapIntent.amountUserSells);
 
-        assertTrue(simulator.simUserOperation(userOp), "metasimUserOperationcall tested false c");
+        (simResult,) = simulator.simUserOperation(userOp);
+        assertTrue(simResult, "metasimUserOperationcall tested false c");
 
         atlas.metacall({ userOp: userOp, solverOps: solverOps, dAppOp: dAppOp });
         vm.stopPrank();
@@ -297,11 +299,13 @@ contract SwapIntentTest is BaseTest {
 
         vm.startPrank(userEOA);
 
-        assertFalse(simulator.simUserOperation(userOp), "metasimUserOperationcall tested true");
+        (bool simResult, ) = simulator.simUserOperation(userOp);
+        assertFalse(simResult, "metasimUserOperationcall tested true a");
 
         WETH.approve(address(atlas), swapIntent.amountUserSells);
 
-        assertTrue(simulator.simUserOperation(userOp), "metasimUserOperationcall tested false");
+        (simResult,) = simulator.simUserOperation(userOp);
+        assertTrue(simResult, "metasimUserOperationcall tested false c");
 
         // Check solver does NOT have DAI - it must use Uniswap to get it during metacall
         assertEq(DAI.balanceOf(address(uniswapSolver)), 0, "Solver has DAI before metacall");

--- a/test/base/AtlasBaseTest.t.sol
+++ b/test/base/AtlasBaseTest.t.sol
@@ -45,8 +45,6 @@ contract AtlasBaseTest is Test, TestConstants {
     Simulator public simulator;
     Sorter public sorter;
 
-    address public escrow;
-
     Utilities public u;
 
     // Fork stuff
@@ -83,8 +81,6 @@ contract AtlasBaseTest is Test, TestConstants {
         atlasVerification = new AtlasVerification(address(atlas));
 
         simulator.setAtlas(address(atlas));
-
-        escrow = address(atlas);
         sorter = new Sorter(address(atlas));
 
         vm.stopPrank();
@@ -93,7 +89,6 @@ contract AtlasBaseTest is Test, TestConstants {
         vm.label(governanceEOA, "GOVERNANCE");
         vm.label(solverOneEOA, "SOLVER_ONE");
         vm.label(solverTwoEOA, "SOLVER_TWO");
-        vm.label(escrow, "ESCROW");
         vm.label(address(atlas), "ATLAS");
     }
 }

--- a/test/base/BaseTest.t.sol
+++ b/test/base/BaseTest.t.sol
@@ -45,8 +45,6 @@ contract BaseTest is Test, TestConstants {
     Simulator public simulator;
     Sorter public sorter;
 
-    address public escrow;
-
     Solver public solverOne;
     Solver public solverTwo;
 
@@ -99,14 +97,12 @@ contract BaseTest is Test, TestConstants {
         console.log("verification expected:", expectedAtlasVerificationAddr);
 
         simulator.setAtlas(address(atlas));
-
-        escrow = address(atlas);
         sorter = new Sorter(address(atlas));
 
         vm.stopPrank();
         vm.startPrank(governanceEOA);
 
-        control = new V2DAppControl(escrow);
+        control = new V2DAppControl(address(atlas));
         atlasVerification.initializeGovernance(address(control));
 
         vm.stopPrank();
@@ -115,7 +111,7 @@ contract BaseTest is Test, TestConstants {
 
         vm.startPrank(solverOneEOA);
 
-        solverOne = new Solver(WETH_ADDRESS, escrow, solverOneEOA);
+        solverOne = new Solver(WETH_ADDRESS, address(atlas), solverOneEOA);
         atlas.deposit{ value: 1e18 }();
 
         deal(TOKEN_ZERO, address(solverOne), 10e24);
@@ -125,7 +121,7 @@ contract BaseTest is Test, TestConstants {
 
         vm.startPrank(solverTwoEOA);
 
-        solverTwo = new Solver(WETH_ADDRESS, escrow, solverTwoEOA);
+        solverTwo = new Solver(WETH_ADDRESS, address(atlas), solverTwoEOA);
         atlas.deposit{ value: 1e18 }();
 
         vm.stopPrank();
@@ -140,7 +136,6 @@ contract BaseTest is Test, TestConstants {
         deal(TOKEN_ONE, address(atlas), 1);
 
         vm.label(userEOA, "USER");
-        vm.label(escrow, "ESCROW");
         vm.label(address(atlas), "ATLAS");
         vm.label(address(control), "DAPP CONTROL");
     }


### PR DESCRIPTION
Escrow is now the same contract at Atlas, so no need for the separate `address escrow` variable in tests.
Removed and standardized on using the `atlas` variable whenever referring to the Atlas contract.