### PR TITLE
Fix solverOutcome StackTooDeep in test coverage

### DIFF
--- a/src/contracts/helpers/Simulator.sol
+++ b/src/contracts/helpers/Simulator.sol
@@ -112,9 +112,9 @@ contract Simulator is AtlasErrors {
                 // revertData in form [bytes4, uint256] but reverts on abi.decode
                 // This decodes the uint256 error code portion of the revertData
                 uint256 validCallsResult;
-                uint256 startIndex = revertData.length - 32;
                 assembly {
-                    validCallsResult := mload(add(add(revertData, 0x20), startIndex))
+                    let dataLocation := add(revertData, 0x20)
+                    validCallsResult := mload(add(dataLocation, sub(mload(revertData), 32)))
                 }
                 result = Result.VerificationSimFail;
                 additionalErrorCode = validCallsResult;
@@ -129,9 +129,9 @@ contract Simulator is AtlasErrors {
             } else if (errorSwitch == SolverSimFail.selector) {
                 // Expects revertData in form [bytes4, uint256]
                 uint256 solverOutcomeResult;
-                uint256 startIndex = revertData.length - 32;
                 assembly {
-                    solverOutcomeResult := mload(add(add(revertData, 0x20), startIndex))
+                    let dataLocation := add(revertData, 0x20)
+                    solverOutcomeResult := mload(add(dataLocation, sub(mload(revertData), 32)))
                 }
                 result = Result.SolverSimFail;
                 additionalErrorCode = solverOutcomeResult;

--- a/src/contracts/types/LockTypes.sol
+++ b/src/contracts/types/LockTypes.sol
@@ -7,10 +7,11 @@ struct EscrowKey {
     bool paymentsSuccessful;
     uint8 callIndex;
     uint8 callCount;
-    uint16 lockState; // bitwise
+    uint16 lockState; // bitmap
     uint32 gasRefund;
     bool isSimulation;
     uint8 callDepth;
+    uint256 solverOutcome; // TODO this could be 24 bits but not sure we can improve packing
 }
 
 enum BaseLock {

--- a/test/Permit69.t.sol
+++ b/test/Permit69.t.sol
@@ -39,7 +39,8 @@ contract Permit69Test is BaseTest {
             lockState: EXEC_PHASE_PRE_OPS,
             gasRefund: 0,
             isSimulation: false,
-            callDepth: 0
+            callDepth: 0,
+            solverOutcome: 0
         });
 
         mockAtlas = new MockAtlasForPermit69Tests(10, address(0), address(0), address(0));


### PR DESCRIPTION
When merging #134 we introduced an issue where tests run except during test coverage as that's compiled using via-IR. The additional `uint256 solverOutcome` bitmap variable used to deliver more solverOp failure context to the simulator was causing a Stack Too Deep error.

This PR moves that `solverOutcome` variable into the `EscrowKey memory key` struct.

Test coverage should be fixed with this.