### PR TITLE
Allow DAppControl to define solver gas limit

### DIFF
--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -364,6 +364,10 @@ contract AtlasVerification is EIP712, DAppIntegration {
             return (false, ValidCallsResult.InvalidControl);
         }
 
+        if (dConfig.solverGasLimit >= block.gaslimit) {
+            return (false, ValidCallsResult.InvalidSolverGasLimit);
+        }
+
         // If dAppOp.from is left blank and sim = true,
         // implies a simUserOp call, so dapp nonce check is skipped.
         if (dAppOp.from == address(0) && isSimulation) {

--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -193,7 +193,7 @@ abstract contract Escrow is AtlETH {
         view
         returns (uint256, uint256 gasLimit)
     {
-        if (gasWaterMark < EscrowBits.VALIDATION_GAS_LIMIT + EscrowBits.SOLVER_GAS_LIMIT) {
+        if (gasWaterMark < EscrowBits.VALIDATION_GAS_LIMIT + dConfig.solverGasLimit) {
             // Make sure to leave enough gas for dApp validation calls
             return (result | 1 << uint256(SolverOutcome.UserOutOfGas), gasLimit);
         }
@@ -211,7 +211,7 @@ abstract contract Escrow is AtlETH {
             );
         }
 
-        gasLimit = (100) * (solverOp.gas < EscrowBits.SOLVER_GAS_LIMIT ? solverOp.gas : EscrowBits.SOLVER_GAS_LIMIT)
+        gasLimit = (100) * (solverOp.gas < dConfig.solverGasLimit ? solverOp.gas : dConfig.solverGasLimit)
             / (100 + EscrowBits.SOLVER_GAS_BUFFER) + EscrowBits.FASTLANE_GAS_BUFFER;
 
         uint256 gasCost = (tx.gasprice * gasLimit) + (solverOp.data.length * CALLDATA_LENGTH_PREMIUM * tx.gasprice);

--- a/src/contracts/dapp/ControlTemplate.sol
+++ b/src/contracts/dapp/ControlTemplate.sol
@@ -9,6 +9,8 @@ import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 import "forge-std/Test.sol";
 
 abstract contract DAppControlTemplate {
+    uint32 internal constant DEFAULT_SOLVER_GAS_LIMIT = 1_000_000;
+
     constructor() { }
 
     // Virtual functions to be overridden by participating dApp governance
@@ -132,4 +134,8 @@ abstract contract DAppControlTemplate {
     function getBidFormat(UserOperation calldata userOp) public view virtual returns (address bidToken);
 
     function getBidValue(SolverOperation calldata solverOp) public view virtual returns (uint256);
+
+    function getSolverGasLimit() public view virtual returns (uint32) {
+        return DEFAULT_SOLVER_GAS_LIMIT;
+    }
 }

--- a/src/contracts/dapp/DAppControl.sol
+++ b/src/contracts/dapp/DAppControl.sol
@@ -133,7 +133,12 @@ abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
         mustBeCalled
         returns (DAppConfig memory dConfig)
     {
-        dConfig = DAppConfig({ to: address(this), callConfig: CALL_CONFIG, bidToken: getBidFormat(userOp) });
+        dConfig = DAppConfig({
+            to: address(this),
+            callConfig: CALL_CONFIG,
+            bidToken: getBidFormat(userOp),
+            solverGasLimit: getSolverGasLimit()
+        });
     }
 
     function getCallConfig() external view returns (CallConfig memory) {

--- a/src/contracts/libraries/EscrowBits.sol
+++ b/src/contracts/libraries/EscrowBits.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.22;
 import "../types/EscrowTypes.sol";
 
 library EscrowBits {
-    uint256 public constant SOLVER_GAS_LIMIT = 1_000_000;
     uint256 public constant VALIDATION_GAS_LIMIT = 500_000;
     uint256 public constant SOLVER_GAS_BUFFER = 5; // out of 100
     uint256 public constant FASTLANE_GAS_BUFFER = 125_000; // integer amount

--- a/src/contracts/types/DAppApprovalTypes.sol
+++ b/src/contracts/types/DAppApprovalTypes.sol
@@ -23,6 +23,7 @@ struct DAppConfig {
     address to;
     uint32 callConfig;
     address bidToken;
+    uint32 solverGasLimit;
 }
 
 struct CallConfig {

--- a/src/contracts/types/ValidCallsTypes.sol
+++ b/src/contracts/types/ValidCallsTypes.sol
@@ -19,5 +19,6 @@ enum ValidCallsResult {
     OpHashMismatch,
     DeadlineMismatch,
     InvalidControl,
+    InvalidSolverGasLimit,
     InvalidDAppNonce
 }

--- a/test/AtlasVerification.t.sol
+++ b/test/AtlasVerification.t.sol
@@ -905,7 +905,7 @@ contract AtlasVerificationValidCallsTest is AtlasVerificationBase {
     //
     function test_validCalls_InvalidUserOpControl_UserSignatureInvalid() public {
         defaultAtlasEnvironment();
-        DAppConfig memory config = DAppConfig({ to: address(dAppControl), callConfig: CallBits.encodeCallConfig(defaultCallConfig().build()), bidToken: address(0) });
+        DAppConfig memory config = DAppConfig({ to: address(dAppControl), callConfig: CallBits.encodeCallConfig(defaultCallConfig().build()), bidToken: address(0), solverGasLimit: 1_000_000 });
 
         UserOperation memory userOp = validUserOperation().withControl(address(0)).build();
         SolverOperation[] memory solverOps = validSolverOperations(userOp);

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -300,7 +300,8 @@ contract EscrowTest is AtlasBaseTest {
 
     function test_executeSolverOperation_validateSolverOperation_userOutOfGas() public {
         (UserOperation memory userOp, SolverOperation[] memory solverOps) = executeSolverOperationInit(defaultCallConfig().build());
-        this.executeSolverOperationCase{gas: EscrowBits.VALIDATION_GAS_LIMIT + EscrowBits.SOLVER_GAS_LIMIT + 1_000_000}(
+        // First 1_000_000 is the default solver gas limit defined in a DAppControl contract
+        this.executeSolverOperationCase{gas: EscrowBits.VALIDATION_GAS_LIMIT + 1_000_000 + 1_000_000}(
             userOp, solverOps, false, false, 1 << uint256(SolverOutcome.UserOutOfGas), true
         );
     }

--- a/test/SafetyLocks.t.sol
+++ b/test/SafetyLocks.t.sol
@@ -114,7 +114,7 @@ contract SafetyLocksTest is Test {
     }
 
     function test_buildEscrowLock() public {
-        DAppConfig memory dConfig = DAppConfig({ to: address(10), callConfig: 0, bidToken: address(0) });
+        DAppConfig memory dConfig = DAppConfig({ to: address(10), callConfig: 0, bidToken: address(0), solverGasLimit: 1_000_000});
 
         vm.expectRevert(AtlasErrors.NotInitialized.selector);
         safetyLocks.buildEscrowLock(dConfig, executionEnvironment, 0, false);

--- a/test/libraries/CallVerification.t.sol
+++ b/test/libraries/CallVerification.t.sol
@@ -54,7 +54,7 @@ contract CallVerificationTest is Test {
     }
 
     function testGetCallChainHash() public {
-        DAppConfig memory dConfig = DAppConfig({ to: address(0x1), callConfig: 1, bidToken: address(0) });
+        DAppConfig memory dConfig = DAppConfig({ to: address(0x1), callConfig: 1, bidToken: address(0), solverGasLimit: 1_000_000 });
         UserOperation memory userOp = buildUserOperation();
         SolverOperation[] memory solverOps = new SolverOperation[](2);
         solverOps[0] = builderSolverOperation();


### PR DESCRIPTION
The `solverGasLimit` var used in `Escrow.sol` is now read from the `DAppControl` contract and passed to Atlas inside the `DAppConfig struct`, instead of hardcoded in `EscrowBits` library.

This allows DAppControl contracts to define their own gas limits for each solverOp.

Currently its stored as a `uint32` so it has a max value of 4.2 billion, but the variable could be larger if we think we may ever need more.