### PR TITLE
Minor safety stuff

### DIFF
--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -396,6 +396,9 @@ abstract contract Escrow is AtlETH {
             return 1 << uint256(SolverOutcome.BidNotPaid);
         } else if (errorSwitch == BalanceNotReconciled.selector) {
             return 1 << uint256(SolverOutcome.BalanceNotReconciled);
+        } else if (errorSwitch == InvalidEntry.selector) {
+            // DAppControl is attacking solver contract - treat as AlteredControl
+            return 1 << uint256(SolverOutcome.AlteredControl);
         } else {
             return 1 << uint256(SolverOutcome.EVMError);
         }

--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -399,6 +399,8 @@ abstract contract Escrow is AtlETH {
         } else if (errorSwitch == InvalidEntry.selector) {
             // DAppControl is attacking solver contract - treat as AlteredControl
             return 1 << uint256(SolverOutcome.AlteredControl);
+        } else if (errorSwitch == CallbackNotCalled.selector) {
+            return 1 << uint256(SolverOutcome.SolverOpReverted);
         } else {
             return 1 << uint256(SolverOutcome.EVMError);
         }

--- a/src/contracts/atlas/ExecutionEnvironment.sol
+++ b/src/contracts/atlas/ExecutionEnvironment.sol
@@ -260,8 +260,7 @@ contract ExecutionEnvironment is Base {
             }
 
             // Verify payback
-            bool calledBack;
-            (calledBack, success) = IEscrow(atlas).validateBalances();
+            (, success) = IEscrow(atlas).validateBalances();
             if (!success) revert AtlasErrors.BalanceNotReconciled();
 
             // Solver bid was successful, revert with highest amount.

--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -11,7 +11,7 @@ import { SolverOperation } from "../types/SolverCallTypes.sol";
 
 import { EscrowBits } from "../libraries/EscrowBits.sol";
 
-// import "forge-std/Test.sol"; //TODO remove
+import "forge-std/Test.sol"; //TODO remove
 
 abstract contract GasAccounting is SafetyLocks {
     using EscrowBits for uint256;
@@ -33,7 +33,11 @@ abstract contract GasAccounting is SafetyLocks {
     function validateBalances() external view returns (bool calledBack, bool fulfilled) {
         (, calledBack, fulfilled) = solverLockData();
         if (!fulfilled) {
-            fulfilled = deposits >= claims + withdrawals;
+            uint256 _deposits = deposits;
+            // Check if locked. 
+            if (_deposits != type(uint256).max) {
+                fulfilled = deposits >= claims + withdrawals;
+            }
         }
     }
 

--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -34,7 +34,7 @@ abstract contract GasAccounting is SafetyLocks {
         (, calledBack, fulfilled) = solverLockData();
         if (!fulfilled) {
             uint256 _deposits = deposits;
-            // Check if locked. 
+            // Check if locked.
             if (_deposits != type(uint256).max) {
                 fulfilled = deposits >= claims + withdrawals;
             }

--- a/src/contracts/interfaces/IEscrow.sol
+++ b/src/contracts/interfaces/IEscrow.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.22;
 
 interface IEscrow {
-    function validateBalances() external view returns (bool valid);
+    function validateBalances() external view returns (bool calledBack, bool fulfilled);
     function reconcile(
         address environment,
         address solverFrom,
@@ -14,4 +14,5 @@ interface IEscrow {
     function contribute() external payable;
     function borrow(uint256 amount) external payable;
     function shortfall() external view returns (uint256);
+    function solverLockData() external view returns (address currentSolver, bool calledBack, bool fulfilled);
 }

--- a/src/contracts/types/AtlasErrors.sol
+++ b/src/contracts/types/AtlasErrors.sol
@@ -23,6 +23,7 @@ contract AtlasErrors {
     error BalanceNotReconciled();
     error SolverOperationReverted();
     error AlteredControl();
+    error InvalidEntry();
     error IntentUnfulfilled();
     error PreSolverFailed();
     error PostSolverFailed();
@@ -77,6 +78,7 @@ contract AtlasErrors {
     error InsufficientFunds();
     error NoUnfilledRequests();
     error SolverMustReconcile();
+    error DoubleReconcile();
     error InvalidExecutionEnvironment(address correctEnvironment);
     error InvalidSolverFrom(address solverFrom);
     error InsufficientSolverBalance(uint256 actual, uint256 msgValue, uint256 holds, uint256 needed);

--- a/src/contracts/types/AtlasErrors.sol
+++ b/src/contracts/types/AtlasErrors.sol
@@ -24,6 +24,7 @@ contract AtlasErrors {
     error SolverOperationReverted();
     error AlteredControl();
     error InvalidEntry();
+    error CallbackNotCalled();
     error IntentUnfulfilled();
     error PreSolverFailed();
     error PostSolverFailed();

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -90,12 +90,16 @@ contract GasAccountingTest is Test {
     }
 
     function test_validateBalances() public {
-        assertFalse(mockGasAccounting.validateBalances());
+        (bool calledBack, bool fulfilled) = mockGasAccounting.validateBalances();
+        assertFalse(calledBack);
+        assertFalse(fulfilled);
 
         mockGasAccounting.trySolverLock(solverOp);
         mockGasAccounting.reconcile{ value: initialClaims }(executionEnvironment, solverOp.from, 0);
 
-        assertTrue(mockGasAccounting.validateBalances());
+        (calledBack, fulfilled) = mockGasAccounting.validateBalances();
+        assertTrue(calledBack);
+        assertTrue(fulfilled);
     }
 
     function test_contribute() public {

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -153,7 +153,7 @@ contract GasAccountingTest is Test {
         assertEq(mockGasAccounting.shortfall(), 0);
     }
 
-    function test_reconcile() public {
+    function test_reconcileFail() public {
         vm.expectRevert(
             abi.encodeWithSelector(AtlasErrors.InvalidExecutionEnvironment.selector, executionEnvironment)
         );
@@ -164,8 +164,10 @@ contract GasAccountingTest is Test {
         mockGasAccounting.reconcile(executionEnvironment, makeAddr("wrongSolver"), 0);
 
         assertTrue(mockGasAccounting.reconcile(executionEnvironment, solverOp.from, 0) > 0);
+    }
 
-        assertEq(mockGasAccounting.solver(), solverOp.from);
+    function test_reconcile() public {
+        mockGasAccounting.trySolverLock(solverOp);
         assertTrue(mockGasAccounting.reconcile{ value: initialClaims }(executionEnvironment, solverOp.from, 0) == 0);
         (address currentSolver, bool verified, bool fulfilled) = mockGasAccounting.solverLockData();
         assertTrue(verified && fulfilled);


### PR DESCRIPTION
Adds a check on the ``reconcile()`` function called by Solvers so that a solver can only call it once.  This blocks the PreOps call and the PostOps call from tricking the Solver into thinking they're the real call and potentially modifying the solver's calldata (assuming that the dappcontrol module is upgradeable and malicious) since two calls into the solver contract will now force two calls of reconcile, which will throw a revert. 