### PR TITLE
Bid find sorting fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,6 @@
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
 	branch = release-v4.8
+[submodule "lib/solady"]
+	path = lib/solady
+	url = https://github.com/vectorized/solady

--- a/remappings.txt
+++ b/remappings.txt
@@ -5,3 +5,4 @@ hardhat/=node_modules/hardhat/
 openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/
 openzeppelin-contracts/=lib/openzeppelin-contracts/
 solmate/=lib/solmate/src/
+solady/=lib/solady/src/

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -281,7 +281,7 @@ contract Atlas is Escrow, Factory {
                 // The array is filled with non-zero bids from the right. This causes all zero bids to be on the left -
                 // in their sorted position, so fewer operations are needed in the sorting step below.
                 bidsAndIndices[bidsAndIndicesLastIndex - (i - zeroBidCount)] =
-                    uint256(uint240(bidAmountFound) << BITS_FOR_INDEX | uint16(i));
+                    uint256(bidAmountFound << BITS_FOR_INDEX | uint16(i));
             }
         }
 

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.22;
 
 import { SafeTransferLib, ERC20 } from "solmate/utils/SafeTransferLib.sol";
+import { LibSort } from "solady/utils/LibSort.sol";
 
 import { IAtlasVerification } from "src/contracts/interfaces/IAtlasVerification.sol";
 
@@ -246,47 +247,68 @@ contract Atlas is Escrow, Factory {
     {
         key.bidFind = true;
 
-        uint256[] memory sortedOps = new uint256[](solverOps.length);
-        uint256[] memory bidAmounts = new uint256[](solverOps.length);
-        uint256 j;
-        uint256 bidPlaceholder;
+        uint256[] memory bidsAndIndices = new uint256[](solverOps.length);
+        uint256 zeroBidCount;
+        uint256 bidAmountFound;
+        uint256 bidsAndIndicesLastIndex = bidsAndIndices.length - 1; // computed once for efficiency
 
-        for (uint256 i; i < solverOps.length; i++) {
-            bidPlaceholder = _getBidAmount(dConfig, userOp, solverOps[i], returnData, key);
+        // First, get all bid amounts. Bids of zero are ignored by only storing non-zero bids in the array, from right
+        // to left. If there are any zero bids they will end up on the left as uint(0) values - in their sorted
+        // position. This reduces operations needed later when sorting the array in ascending order.
+        // Each non-zero bid amount is packed with its original solverOps array index, to fit into a uint256 value. The
+        // order of bidAmount and index is important - with bidAmount using the most significant bits, and considering
+        // we do not store zero bids in the array, the index values within the uint256 should not impact the sorting.
 
-            if (bidPlaceholder == 0) {
+        // |<------------------------- uint256 (256 bits) ------------------------->|
+        // |                                                                        |
+        // |<------------------ uint240 ----------------->|<-------- uint16 ------->|
+        // |                                              |                         |
+        // |                    bidAmount                 |          index          |
+        // |                                              |                         |
+        // |<------------------ 240 bits ---------------->|<------- 16 bits ------->|
+
+        for (uint256 i; i < solverOps.length; ++i) {
+            bidAmountFound = _getBidAmount(dConfig, userOp, solverOps[i], returnData, key);
+
+            if (bidAmountFound == 0) {
+                // Zero bids are ignored: increment zeroBidCount offset
                 unchecked {
-                    ++j;
+                    ++zeroBidCount;
                 }
-                continue;
             } else {
-                bidAmounts[i] = bidPlaceholder;
+                if (bidAmountFound > type(uint240).max) revert BidTooHigh(i, bidAmountFound);
 
-                for (uint256 k = i - j + 1; k > 0; k--) {
-                    if (bidPlaceholder > bidAmounts[sortedOps[k - 1]]) {
-                        sortedOps[k] = sortedOps[k - 1];
-                        sortedOps[k - 1] = i;
-                    } else {
-                        sortedOps[k] = i;
-                        break;
-                    }
-                }
+                // Non-zero bids are packed with their original solverOps index.
+                // The array is filled with non-zero bids from the right. This causes all zero bids to be on the left -
+                // in their sorted position, so fewer operations are needed in the sorting step below.
+                bidsAndIndices[bidsAndIndicesLastIndex - (i - zeroBidCount)] =
+                    uint256(uint240(bidAmountFound) << BITS_FOR_INDEX | uint16(i));
             }
         }
 
-        key.bidFind = false;
-        j = solverOps.length - j;
+        // Then, sorts the uint256 array in-place, in ascending order.
+        LibSort.insertionSort(bidsAndIndices);
 
-        for (uint256 i; i < j; i++) {
-            bidPlaceholder = sortedOps[i];
+        key.bidFind = false;
+
+        // Finally, iterate through sorted bidsAndIndices array in descending order of bidAmount.
+        for (uint256 i = bidsAndIndices.length - 1; i >= 0; --i) {
+            // Isolate the bidAmount from the packed uint256 value
+            bidAmountFound = (bidsAndIndices[i] >> BITS_FOR_INDEX) & FIRST_240_BITS_MASK;
+
+            // If we reach the zero bids on the left of array, break as all valid bids already checked.
+            if (bidAmountFound == 0) break;
+
+            // Isolate the original solverOps index from the packed uint256 value
+            uint256 solverOpsIndex = bidsAndIndices[i] & FIRST_16_BITS_MASK;
 
             (auctionWon, key) = _executeSolverOperation(
-                dConfig, userOp, solverOps[bidPlaceholder], returnData, bidAmounts[bidPlaceholder], true, key
+                dConfig, userOp, solverOps[solverOpsIndex], returnData, bidAmountFound, true, key
             );
 
             if (auctionWon) {
-                key = _allocateValue(dConfig, solverOps[bidPlaceholder], bidAmounts[bidPlaceholder], returnData, key);
-                key.solverOutcome = uint24(bidPlaceholder);
+                key = _allocateValue(dConfig, solverOps[solverOpsIndex], bidAmountFound, returnData, key);
+                key.solverOutcome = uint24(solverOpsIndex);
                 return (auctionWon, key);
             }
         }

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -245,6 +245,9 @@ contract Atlas is Escrow, Factory {
         internal
         returns (bool auctionWon, EscrowKey memory)
     {
+        // Return early if no solverOps (e.g. in simUserOperation)
+        if (solverOps.length == 0) return (false, key);
+
         key.bidFind = true;
 
         uint256[] memory bidsAndIndices = new uint256[](solverOps.length);
@@ -291,7 +294,7 @@ contract Atlas is Escrow, Factory {
         key.bidFind = false;
 
         // Finally, iterate through sorted bidsAndIndices array in descending order of bidAmount.
-        for (uint256 i = bidsAndIndices.length - 1; i >= 0; --i) {
+        for (uint256 i = bidsAndIndicesLastIndex; i >= 0; --i) {
             // Isolate the bidAmount from the packed uint256 value
             bidAmountFound = (bidsAndIndices[i] >> BITS_FOR_INDEX) & FIRST_240_BITS_MASK;
 
@@ -310,6 +313,8 @@ contract Atlas is Escrow, Factory {
                 key.solverOutcome = uint24(solverOpsIndex);
                 return (auctionWon, key);
             }
+
+            if (i == 0) break; // break to prevent underflow in next loop
         }
 
         return (auctionWon, key);

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -270,14 +270,13 @@ contract Atlas is Escrow, Factory {
         for (uint256 i; i < solverOps.length; ++i) {
             bidAmountFound = _getBidAmount(dConfig, userOp, solverOps[i], returnData, key);
 
-            if (bidAmountFound == 0) {
+            if (bidAmountFound == 0 || bidAmountFound > type(uint240).max) {
                 // Zero bids are ignored: increment zeroBidCount offset
+                // Bids that would cause an overflow are also ignored
                 unchecked {
                     ++zeroBidCount;
                 }
             } else {
-                if (bidAmountFound > type(uint240).max) revert BidTooHigh(i, bidAmountFound);
-
                 // Non-zero bids are packed with their original solverOps index.
                 // The array is filled with non-zero bids from the right. This causes all zero bids to be on the left -
                 // in their sorted position, so fewer operations are needed in the sorting step below.

--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -138,7 +138,7 @@ abstract contract GasAccounting is SafetyLocks {
     /// @param owner The address of the owner from whom AtlETH is taken.
     /// @param amount The amount of AtlETH to be taken.
     /// @param solverWon A boolean indicating whether the solver won the bid.
-    /// @param bidFind A boolean indicating whether the bid was found.
+    /// @param bidFind Indicates if called in the context of `_getBidAmount` in Escrow.sol (true) or not (false).
     /// @return isDeficit A boolean indicating whether there is a deficit after the assignment.
     function _assign(address owner, uint256 amount, bool solverWon, bool bidFind) internal returns (bool isDeficit) {
         if (amount == 0) {
@@ -220,7 +220,7 @@ abstract contract GasAccounting is SafetyLocks {
     /// @param solverOp The current SovlerOperation for which to account
     /// @param gasWaterMark The `gasleft()` watermark taken at the start of executing the SolverOperation.
     /// @param result The result bitmap of the SolverOperation execution.
-    /// @param bidFind Indicates if called in the context of `_getBidAmount` in Escrow.sol.
+    /// @param bidFind Indicates if called in the context of `_getBidAmount` in Escrow.sol (true) or not (false).
     /// @param includeCalldata Whether to include calldata cost in the gas calculation.
     function _releaseSolverLock(
         SolverOperation calldata solverOp,

--- a/src/contracts/atlas/Storage.sol
+++ b/src/contracts/atlas/Storage.sol
@@ -15,6 +15,12 @@ contract Storage is AtlasEvents, AtlasErrors {
     address internal constant UNLOCKED = address(1);
     uint256 internal constant _UNLOCKED_UINT = 1;
 
+    // Atlas constants used in `_bidFindingIteration()`
+    uint256 internal constant BITS_FOR_INDEX = 16;
+    uint256 internal constant FIRST_16_BITS_MASK = uint256(0xFFFF);
+    uint256 internal constant FIRST_240_BITS_MASK =
+        uint256(0x0000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
+
     uint256 public immutable ESCROW_DURATION;
     address public immutable VERIFICATION;
     address public immutable SIMULATOR;

--- a/src/contracts/examples/v4-example/V4DAppControl.sol
+++ b/src/contracts/examples/v4-example/V4DAppControl.sol
@@ -121,7 +121,7 @@ contract V4DAppControl is DAppControl {
                 params.zeroForOne
                     ? IPoolManager.Currency.unwrap(key.currency0)
                     : IPoolManager.Currency.unwrap(key.currency1)
-                ),
+            ),
             poolKey: key
         });
 

--- a/src/contracts/types/AtlasErrors.sol
+++ b/src/contracts/types/AtlasErrors.sol
@@ -57,6 +57,7 @@ contract AtlasErrors {
     error InsufficientSurchargeBalance(uint256 balance, uint256 requested);
     error InsufficientBalanceForDeduction(uint256 balance, uint256 requested);
     error ValueTooLarge();
+    error BidTooHigh(uint256 indexInSolverOps, uint256 bidAmount);
 
     // DAppIntegration
     error OnlyGovernance();

--- a/test/Atlas.t.sol
+++ b/test/Atlas.t.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.22;
+
+import "forge-std/Test.sol";
+
+import { BaseTest } from "test/base/BaseTest.t.sol";
+import { TxBuilder } from "src/contracts/helpers/TxBuilder.sol";
+import { UserOperationBuilder } from "test/base/builders/UserOperationBuilder.sol";
+
+import { Atlas } from "src/contracts/atlas/Atlas.sol";
+import { AtlasVerification } from "src/contracts/atlas/AtlasVerification.sol";
+import { ExecutionEnvironment } from "src/contracts/atlas/ExecutionEnvironment.sol";
+import { Sorter } from "src/contracts/helpers/Sorter.sol";
+import { Simulator } from "src/contracts/helpers/Simulator.sol";
+import { SolverOperation } from "src/contracts/types/SolverCallTypes.sol";
+import { UserOperation } from "src/contracts/types/UserCallTypes.sol";
+import { DAppOperation, DAppConfig } from "src/contracts/types/DAppApprovalTypes.sol";
+import "src/contracts/types/LockTypes.sol";
+
+import { LibSort } from "solady/utils/LibSort.sol";
+
+// These tests focus on the functions found in the Atlas.sol file
+contract AtlasTest is BaseTest {
+
+    function setUp_bidFindingIteration() public {
+        // super.setUp();
+
+        // vm.startPrank(payee);
+        // simulator = new Simulator();
+
+        // // Computes the addresses at which AtlasVerification will be deployed
+        // address expectedAtlasAddr = vm.computeCreateAddress(payee, vm.getNonce(payee) + 1);
+        // address expectedAtlasVerificationAddr = vm.computeCreateAddress(payee, vm.getNonce(payee) + 2);
+        // bytes32 salt = keccak256(abi.encodePacked(block.chainid, expectedAtlasAddr, "AtlasFactory 1.0"));
+        // ExecutionEnvironment execEnvTemplate = new ExecutionEnvironment{ salt: salt }(expectedAtlasAddr);
+
+        // atlas = new MockAtlas({
+        //     _escrowDuration: 64,
+        //     _verification: expectedAtlasVerificationAddr,
+        //     _simulator: address(simulator),
+        //     _executionTemplate: address(execEnvTemplate),
+        //     _surchargeRecipient: payee
+        // });
+        // atlasVerification = new AtlasVerification(address(atlas));
+        // simulator.setAtlas(address(atlas));
+        // sorter = new Sorter(address(atlas));
+        // vm.stopPrank();
+    }
+
+    function test_bidFindingIteration_sortingOrder() public {
+        // Test order of bidsAndIndices after insertionSort
+
+        // 3 items. [200, 0, 100] --> [0, 100, 200] 
+        uint256[] memory bidsAndIndices = new uint256[](3);
+        bidsAndIndices[0] = 100;
+        bidsAndIndices[1] = 0;
+        bidsAndIndices[2] = 300;
+
+        LibSort.insertionSort(bidsAndIndices);
+        assertEq(bidsAndIndices[0], 0);
+        assertEq(bidsAndIndices[1], 100);
+        assertEq(bidsAndIndices[2], 300);
+
+        // 1 item. [100] --> [100]
+        bidsAndIndices = new uint256[](1);
+        bidsAndIndices[0] = 100;
+
+        LibSort.insertionSort(bidsAndIndices);
+        assertEq(bidsAndIndices[0], 100);
+
+        // 2 items. [100, 0] --> [0, 100]
+        bidsAndIndices = new uint256[](2);
+        bidsAndIndices[0] = 100;
+        bidsAndIndices[1] = 0;
+
+        LibSort.insertionSort(bidsAndIndices);
+        assertEq(bidsAndIndices[0], 0);
+        assertEq(bidsAndIndices[1], 100);
+    }
+
+    function test_bidFindingIteration_packBidAndIndex() public {
+        uint256 bid = 12345;
+        uint256 index = 2;
+
+        uint256 packed = _packBidAndIndex(bid, index);
+        (uint256 unpackedBid, uint256 unpackedIndex) = _unpackBidAndIndex(packed);
+        assertEq(unpackedBid, bid);
+        assertEq(unpackedIndex, index);
+
+        bid = type(uint240).max - 1;
+        index = 7;
+
+        packed = _packBidAndIndex(bid, index);
+        (unpackedBid, unpackedIndex) = _unpackBidAndIndex(packed);
+        assertEq(unpackedBid, bid);
+        assertEq(unpackedIndex, index);
+
+        bid = 0;
+        index = 1;
+
+        packed = _packBidAndIndex(bid, index);
+        (unpackedBid, unpackedIndex) = _unpackBidAndIndex(packed);
+        assertEq(unpackedBid, bid);
+        assertEq(unpackedIndex, index);
+
+        bid = 1;
+        index = 0;
+
+        packed = _packBidAndIndex(bid, index);
+        (unpackedBid, unpackedIndex) = _unpackBidAndIndex(packed);
+        assertEq(unpackedBid, bid);
+        assertEq(unpackedIndex, index);
+    }
+
+
+    // Packs bid and index into a single uint256, replicates logic used in `_bidFindingIteration()`
+    function _packBidAndIndex(uint256 bid, uint256 index) internal pure returns (uint256) {
+        return uint256(bid << 16 | uint16(index));
+    }
+
+    // Unpacks bid and index from a single uint256, replicates logic used in `_bidFindingIteration()`
+    function _unpackBidAndIndex(uint256 packed) internal pure returns (uint256 bid, uint256 index) {
+        // bidAmountFound = (bidsAndIndices[i] >> BITS_FOR_INDEX) & FIRST_240_BITS_MASK;
+        bid = (packed >> 16) & uint256(0x0000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
+
+        // uint256 solverOpsIndex = bidsAndIndices[i] & FIRST_16_BITS_MASK;
+        index = packed & uint256(0xFFFF);
+    }
+}
+
+// MockAtlas exposes Atlas' internal functions for testing
+contract MockAtlas is Atlas {
+    constructor(
+        uint256 _escrowDuration,
+        address _verification,
+        address _simulator,
+        address _surchargeRecipient,
+        address _executionTemplate
+    ) 
+        Atlas(_escrowDuration, _verification, _simulator, _surchargeRecipient, _executionTemplate) 
+    { }
+
+    function bidFindingIteration(
+        DAppConfig calldata dConfig,
+        UserOperation calldata userOp,
+        SolverOperation[] calldata solverOps,
+        bytes memory returnData,
+        EscrowKey memory key
+    ) public returns (bool auctionWon, EscrowKey memory) {
+        return _bidFindingIteration(dConfig, userOp, solverOps, returnData, key);
+    }
+}

--- a/test/ExPost.t.sol
+++ b/test/ExPost.t.sol
@@ -8,6 +8,8 @@ import { IExecutionEnvironment } from "src/contracts/interfaces/IExecutionEnviro
 
 import { Atlas } from "src/contracts/atlas/Atlas.sol";
 
+import { Result } from "src/contracts/helpers/Simulator.sol";
+
 import { V2ExPost } from "src/contracts/examples/ex-post-mev-example/V2ExPost.sol";
 
 import { SolverExPost } from "src/contracts/solver/src/TestSolverExPost.sol";
@@ -117,6 +119,16 @@ contract ExPostTest is BaseTest {
         ERC20(TOKEN_ONE).approve(address(atlas), type(uint256).max);
 
         vm.stopPrank();
+
+        // Check in simulator that UserOp is valid
+        (bool simSuccess, Result simResult,) = simulator.simUserOperation(userOp);
+        assertTrue(simSuccess, "userOp fails in simulator");
+
+        (simSuccess, simResult,) = simulator.simSolverCall(userOp, solverOps[0], dAppOp);
+        // assertTrue(simSuccess, "solverOp[0] fails in simulator"); // TODO this fails - should it?
+
+        (simSuccess, simResult,) = simulator.simSolverCall(userOp, solverOps[1], dAppOp);
+        assertTrue(simSuccess, "solverOp[1] fails in simulator");
 
         // address bundler = userEOA;
         vm.startPrank(userEOA);

--- a/test/ExPost.t.sol
+++ b/test/ExPost.t.sol
@@ -122,13 +122,13 @@ contract ExPostTest is BaseTest {
 
         // Check in simulator that UserOp is valid
         (bool simSuccess, Result simResult,) = simulator.simUserOperation(userOp);
-        assertTrue(simSuccess, "userOp fails in simulator");
+        // assertTrue(simSuccess, "userOp fails in simulator"); // TODO fix this failing
 
         (simSuccess, simResult,) = simulator.simSolverCall(userOp, solverOps[0], dAppOp);
-        // assertTrue(simSuccess, "solverOp[0] fails in simulator"); // TODO this fails - should it?
+        assertTrue(simSuccess, "solverOp[0] fails in simulator"); // TODO this fails - should it?
 
         (simSuccess, simResult,) = simulator.simSolverCall(userOp, solverOps[1], dAppOp);
-        assertTrue(simSuccess, "solverOp[1] fails in simulator");
+        assertTrue(simSuccess, "solverOp[1] fails in simulator"); // TODO this fails - should it?
 
         // address bundler = userEOA;
         vm.startPrank(userEOA);

--- a/test/ExPost.t.sol
+++ b/test/ExPost.t.sol
@@ -122,13 +122,13 @@ contract ExPostTest is BaseTest {
 
         // Check in simulator that UserOp is valid
         (bool simSuccess, Result simResult,) = simulator.simUserOperation(userOp);
-        // assertTrue(simSuccess, "userOp fails in simulator"); // TODO fix this failing
+        // assertTrue(simSuccess, "userOp fails in simulator"); // TODO fix - failing
 
         (simSuccess, simResult,) = simulator.simSolverCall(userOp, solverOps[0], dAppOp);
-        assertTrue(simSuccess, "solverOp[0] fails in simulator"); // TODO this fails - should it?
+        // assertTrue(simSuccess, "solverOp[0] fails in simulator"); // TODO fix - failing
 
         (simSuccess, simResult,) = simulator.simSolverCall(userOp, solverOps[1], dAppOp);
-        assertTrue(simSuccess, "solverOp[1] fails in simulator"); // TODO this fails - should it?
+        // assertTrue(simSuccess, "solverOp[1] fails in simulator"); // TODO fix - failing
 
         // address bundler = userEOA;
         vm.startPrank(userEOA);

--- a/test/ExPost.t.sol
+++ b/test/ExPost.t.sol
@@ -27,6 +27,11 @@ import { AtlasEvents } from "src/contracts/types/AtlasEvents.sol";
 import "forge-std/Test.sol";
 
 contract ExPostTest is BaseTest {
+    struct Sig {
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+    }
 
     V2ExPost public v2ExPost;
     /// forge-config: default.gas_price = 15000000000
@@ -47,9 +52,7 @@ contract ExPostTest is BaseTest {
 
     function test_ExPostMEV() public {
 
-        uint8 v;
-        bytes32 r;
-        bytes32 s;
+        Sig memory sig;
 
         UserOperation memory userOp = helper.buildUserOperation(POOL_ONE, POOL_TWO, userEOA, TOKEN_ONE);
         userOp.control = address(v2ExPost);
@@ -76,8 +79,8 @@ contract ExPostTest is BaseTest {
             userOp, solverOpData, solverOneEOA, address(solverOneXP), 0, 0
         );
 
-        (v, r, s) = vm.sign(solverOnePK, atlasVerification.getSolverPayload(solverOps[1]));
-        solverOps[1].signature = abi.encodePacked(r, s, v);
+        (sig.v, sig.r, sig.s) = vm.sign(solverOnePK, atlasVerification.getSolverPayload(solverOps[1]));
+        solverOps[1].signature = abi.encodePacked(sig.r, sig.s, sig.v);
 
         console.log("solverTwoEOA WETH:", WETH.balanceOf(address(solverTwoEOA)));
         console.log("solverTwoXP  WETH:", WETH.balanceOf(address(solverTwoXP)));
@@ -88,8 +91,8 @@ contract ExPostTest is BaseTest {
             userOp, solverOpData, solverTwoEOA, address(solverTwoXP), 0, 0
         );
 
-        (v, r, s) = vm.sign(solverTwoPK, atlasVerification.getSolverPayload(solverOps[0]));
-        solverOps[0].signature = abi.encodePacked(r, s, v);
+        (sig.v, sig.r, sig.s) = vm.sign(solverTwoPK, atlasVerification.getSolverPayload(solverOps[0]));
+        solverOps[0].signature = abi.encodePacked(sig.r, sig.s, sig.v);
 
         console.log("topBid before sorting", solverOps[0].bidAmount);
 
@@ -100,9 +103,9 @@ contract ExPostTest is BaseTest {
         // DAppOperation call
         DAppOperation memory dAppOp = helper.buildDAppOperation(governanceEOA, userOp, solverOps);
 
-        (v, r, s) = vm.sign(governancePK, atlasVerification.getDAppOperationPayload(dAppOp));
+        (sig.v, sig.r, sig.s) = vm.sign(governancePK, atlasVerification.getDAppOperationPayload(dAppOp));
 
-        dAppOp.signature = abi.encodePacked(r, s, v);
+        dAppOp.signature = abi.encodePacked(sig.r, sig.s, sig.v);
 
         vm.startPrank(userEOA);
 
@@ -111,7 +114,7 @@ contract ExPostTest is BaseTest {
 
         console.log("userEOA", userEOA);
         console.log("atlas", address(atlas));
-        console.log("control", address(control));
+        console.log("control", address(v2ExPost));
         console.log("executionEnvironment", executionEnvironment);
 
         // User must approve Atlas
@@ -120,33 +123,51 @@ contract ExPostTest is BaseTest {
 
         vm.stopPrank();
 
-        // Check in simulator that UserOp is valid
+        // Simulate the UserOp
         (bool simSuccess, Result simResult,) = simulator.simUserOperation(userOp);
-        // assertTrue(simSuccess, "userOp fails in simulator"); // TODO fix - failing
+        assertTrue(simSuccess, "userOp should succeed in simulator");
 
+        // Simulate the first SolverOp
+        SolverOperation[] memory tempSolverOps = new SolverOperation[](1);
+        tempSolverOps[0] = solverOps[0];
+        dAppOp = helper.buildDAppOperation(governanceEOA, userOp, tempSolverOps);
+        (sig.v, sig.r, sig.s) = vm.sign(governancePK, atlasVerification.getDAppOperationPayload(dAppOp));
+        dAppOp.signature = abi.encodePacked(sig.r, sig.s, sig.v);
         (simSuccess, simResult,) = simulator.simSolverCall(userOp, solverOps[0], dAppOp);
-        // assertTrue(simSuccess, "solverOp[0] fails in simulator"); // TODO fix - failing
+        assertTrue(simSuccess, "solverOps[0] should succeed in simulator");
 
+        // Simulate the second SolverOp
+        tempSolverOps[0] = solverOps[1];
+        dAppOp = helper.buildDAppOperation(governanceEOA, userOp, tempSolverOps);
+        (sig.v, sig.r, sig.s) = vm.sign(governancePK, atlasVerification.getDAppOperationPayload(dAppOp));
+        dAppOp.signature = abi.encodePacked(sig.r, sig.s, sig.v);
         (simSuccess, simResult,) = simulator.simSolverCall(userOp, solverOps[1], dAppOp);
-        // assertTrue(simSuccess, "solverOp[1] fails in simulator"); // TODO fix - failing
+        assertEq(simSuccess, false, "solverOps[1] should fail in sim due to swap path");
+
+        // Simulate all SolverOps together
+        dAppOp = helper.buildDAppOperation(governanceEOA, userOp, solverOps);
+        (sig.v, sig.r, sig.s) = vm.sign(governancePK, atlasVerification.getDAppOperationPayload(dAppOp));
+        dAppOp.signature = abi.encodePacked(sig.r, sig.s, sig.v);
+        (simSuccess, simResult,) = simulator.simSolverCalls(userOp, solverOps, dAppOp);
+        assertTrue(simSuccess, "all solverOps together should succeed in simulator");
 
         // address bundler = userEOA;
         vm.startPrank(userEOA);
 
-        uint256 userEOABalance = userEOA.balance;
-        uint256 userAtlEthBalance = atlas.balanceOf(userEOA);
+        // uint256 userEOABalance = userEOA.balance;
+        // uint256 userAtlEthBalance = atlas.balanceOf(userEOA);
 
         // uint256 bundlerEOABalance = bundler.balance;
         // uint256 bundlerAtlEthBalance = atlas.balanceOf(bundler);
 
-        uint256 solverOneEOABalance = solverOneEOA.balance;
-        uint256 solverOneAtlEthBalance = atlas.balanceOf(solverOneEOA);
+        // uint256 solverOneEOABalance = solverOneEOA.balance;
+        // uint256 solverOneAtlEthBalance = atlas.balanceOf(solverOneEOA);
 
-        uint256 solverTwoEOABalance = solverTwoEOA.balance;
-        uint256 solverTwoAtlEthBalance = atlas.balanceOf(solverTwoEOA);
+        // uint256 solverTwoEOABalance = solverTwoEOA.balance;
+        // uint256 solverTwoAtlEthBalance = atlas.balanceOf(solverTwoEOA);
 
         (bool success,) =
-            address(atlas).call(abi.encodeWithSelector(atlas.metacall.selector, userOp, solverOps, dAppOp));
+            address(atlas).call(abi.encodeCall(atlas.metacall, (userOp, solverOps, dAppOp)));
 
         if (success) {
             console.log("success!");
@@ -184,76 +205,135 @@ contract ExPostTest is BaseTest {
         }
         */
 
-        console.log("--");
-        console.log("USER:");
+        // console.log("--");
+        // console.log("USER:");
 
-        uint256 newUserBalance = userEOA.balance + atlas.balanceOf(userEOA);
-        uint256 userTotalBalance = userEOABalance + userAtlEthBalance;
+        // uint256 newUserBalance = userEOA.balance + atlas.balanceOf(userEOA);
+        // uint256 userTotalBalance = userEOABalance + userAtlEthBalance;
 
-        if (userEOA.balance >= userEOABalance) {
-            console.log("user eoa balance delta   : +", userEOA.balance - userEOABalance);
-        } else {
-            console.log("user eoa balance delta   : -", userEOABalance - userEOA.balance);
+        // if (userEOA.balance >= userEOABalance) {
+        //     console.log("user eoa balance delta   : +", userEOA.balance - userEOABalance);
+        // } else {
+        //     console.log("user eoa balance delta   : -", userEOABalance - userEOA.balance);
+        // }
+
+        // if (atlas.balanceOf(userEOA) >= userAtlEthBalance) {
+        //     console.log("user atlETH balance delta: +", atlas.balanceOf(userEOA) - userAtlEthBalance);
+        // } else {
+        //     console.log("user atlETH balance delta: -", userAtlEthBalance - atlas.balanceOf(userEOA));
+        // }
+
+        // if (newUserBalance >= userTotalBalance) {
+        //     console.log("user total balance delta : +", newUserBalance - userTotalBalance);
+        // } else {
+        //     console.log("user total balance delta : -", userTotalBalance - newUserBalance);
+        // }
+
+        // console.log("--");
+        // console.log("SOLVER ONE:");
+
+        // uint256 newSolverOneBalance = solverOneEOA.balance + atlas.balanceOf(solverOneEOA);
+        // uint256 solverOneTotalBalance = solverOneEOABalance + solverOneAtlEthBalance;
+
+        // if (solverOneEOA.balance >= solverOneEOABalance) {
+        //     console.log("solverOne eoa balance delta   : +", solverOneEOA.balance - solverOneEOABalance);
+        // } else {
+        //     console.log("solverOne eoa balance delta   : -", solverOneEOABalance - solverOneEOA.balance);
+        // }
+
+        // if (atlas.balanceOf(solverOneEOA) >= solverOneAtlEthBalance) {
+        //     console.log("solverOne atlETH balance delta: +", atlas.balanceOf(solverOneEOA) - solverOneAtlEthBalance);
+        // } else {
+        //     console.log("solverOne atlETH balance delta: -", solverOneAtlEthBalance - atlas.balanceOf(solverOneEOA));
+        // }
+
+        // if (newSolverOneBalance >= solverOneTotalBalance) {
+        //     console.log("solverOne total balance delta : +", newSolverOneBalance - solverOneTotalBalance);
+        // } else {
+        //     console.log("solverOne total balance delta : -", solverOneTotalBalance - newSolverOneBalance);
+        // }
+
+        // console.log("--");
+        // console.log("SOLVER TWO:");
+
+        // uint256 newSolverTwoBalance = solverTwoEOA.balance + atlas.balanceOf(solverTwoEOA);
+        // uint256 solverTwoTotalBalance = solverTwoEOABalance + solverTwoAtlEthBalance;
+
+        // if (solverTwoEOA.balance >= solverTwoEOABalance) {
+        //     console.log("solverTwo eoa balance delta   : +", solverTwoEOA.balance - solverTwoEOABalance);
+        // } else {
+        //     console.log("solverTwo eoa balance delta   : -", solverTwoEOABalance - solverTwoEOA.balance);
+        // }
+
+        // if (atlas.balanceOf(solverTwoEOA) >= solverTwoAtlEthBalance) {
+        //     console.log("solverTwo atlETH balance delta: +", atlas.balanceOf(solverTwoEOA) - solverTwoAtlEthBalance);
+        // } else {
+        //     console.log("solverTwo atlETH balance delta: -", solverTwoAtlEthBalance - atlas.balanceOf(solverTwoEOA));
+        // }
+
+        // if (newSolverTwoBalance >= solverTwoTotalBalance) {
+        //     console.log("solverTwo total balance delta : +", newSolverTwoBalance - solverTwoTotalBalance);
+        // } else {
+        //     console.log("solverTwo total balance delta : -", solverTwoTotalBalance - newSolverTwoBalance);
+        // }
+    }
+
+    // Shoutout to rholterhus for the test
+    function test_ExPostOrdering() public {
+        uint256 NUM_SOLVE_OPS = 3;
+        UserOperation memory userOp = helper.buildUserOperation(POOL_ONE, POOL_TWO, userEOA, TOKEN_ONE);
+        userOp.control = address(v2ExPost);
+        SolverOperation[] memory solverOps = new SolverOperation[](NUM_SOLVE_OPS);
+        bytes memory solverOpData;
+        address[] memory solverEOAs = new address[](NUM_SOLVE_OPS);
+        address[] memory solverXPs = new address[](NUM_SOLVE_OPS);
+        uint256[] memory solverPKs = new uint256[](NUM_SOLVE_OPS);
+        for (uint256 i; i < NUM_SOLVE_OPS; ++i) {
+            (solverEOAs[i], solverPKs[i]) = makeAddrAndKey(string(abi.encodePacked("SOLVER", i)));
+            solverXPs[i] = address(new SolverExPost(WETH_ADDRESS, address(atlas), solverEOAs[i], 60 + i));
+            vm.deal(solverEOAs[i], 100e18);
+            deal(TOKEN_ZERO, address(solverXPs[i]), 10e24);
+            deal(TOKEN_ONE, address(solverXPs[i]), 10e24);
+            vm.startPrank(address(solverEOAs[i]));
+            atlas.deposit{ value: 1e18 }();
+            atlas.bond(1 ether);
+            vm.stopPrank();
         }
-
-        if (atlas.balanceOf(userEOA) >= userAtlEthBalance) {
-            console.log("user atlETH balance delta: +", atlas.balanceOf(userEOA) - userAtlEthBalance);
-        } else {
-            console.log("user atlETH balance delta: -", userAtlEthBalance - atlas.balanceOf(userEOA));
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+        for (uint256 i; i < NUM_SOLVE_OPS; ++i) {
+            solverOpData = helper.buildV2SolverOperationData(POOL_TWO, POOL_ONE);
+            solverOps[i] = helper.buildSolverOperation(userOp, solverOpData, solverEOAs[i], address(solverXPs[i]), 0, 0);
+            (v, r, s) = vm.sign(solverPKs[i], atlasVerification.getSolverPayload(solverOps[i]));
+            solverOps[i].signature = abi.encodePacked(r, s, v);
         }
+        solverOps = sorter.sortBids(userOp, solverOps);
+        // DAppOperation call
+        DAppOperation memory dAppOp = helper.buildDAppOperation(governanceEOA, userOp, solverOps);
+        (v, r, s) = vm.sign(governancePK, atlasVerification.getDAppOperationPayload(dAppOp));
+        dAppOp.signature = abi.encodePacked(r, s, v);
+        vm.startPrank(userEOA);
+        address executionEnvironment = atlas.createExecutionEnvironment(userOp.control);
+        // User must approve Atlas
+        ERC20(TOKEN_ZERO).approve(address(atlas), type(uint256).max);
+        ERC20(TOKEN_ONE).approve(address(atlas), type(uint256).max);
+        vm.stopPrank();
 
-        if (newUserBalance >= userTotalBalance) {
-            console.log("user total balance delta : +", newUserBalance - userTotalBalance);
-        } else {
-            console.log("user total balance delta : -", userTotalBalance - newUserBalance);
-        }
+        // Simulate the UserOp
+        (bool simSuccess, Result simResult,) = simulator.simUserOperation(userOp);
+        assertTrue(simSuccess, "userOp fails in simulator");
 
-        console.log("--");
-        console.log("SOLVER ONE:");
+        // Simulate the SolverOps
+        (simSuccess, simResult,) = simulator.simSolverCalls(userOp, solverOps, dAppOp);
+        assertTrue(simSuccess, "solverOps fail in simulator");
 
-        uint256 newSolverOneBalance = solverOneEOA.balance + atlas.balanceOf(solverOneEOA);
-        uint256 solverOneTotalBalance = solverOneEOABalance + solverOneAtlEthBalance;
-
-        if (solverOneEOA.balance >= solverOneEOABalance) {
-            console.log("solverOne eoa balance delta   : +", solverOneEOA.balance - solverOneEOABalance);
-        } else {
-            console.log("solverOne eoa balance delta   : -", solverOneEOABalance - solverOneEOA.balance);
-        }
-
-        if (atlas.balanceOf(solverOneEOA) >= solverOneAtlEthBalance) {
-            console.log("solverOne atlETH balance delta: +", atlas.balanceOf(solverOneEOA) - solverOneAtlEthBalance);
-        } else {
-            console.log("solverOne atlETH balance delta: -", solverOneAtlEthBalance - atlas.balanceOf(solverOneEOA));
-        }
-
-        if (newSolverOneBalance >= solverOneTotalBalance) {
-            console.log("solverOne total balance delta : +", newSolverOneBalance - solverOneTotalBalance);
-        } else {
-            console.log("solverOne total balance delta : -", solverOneTotalBalance - newSolverOneBalance);
-        }
-
-        console.log("--");
-        console.log("SOLVER TWO:");
-
-        uint256 newSolverTwoBalance = solverTwoEOA.balance + atlas.balanceOf(solverTwoEOA);
-        uint256 solverTwoTotalBalance = solverTwoEOABalance + solverTwoAtlEthBalance;
-
-        if (solverTwoEOA.balance >= solverTwoEOABalance) {
-            console.log("solverTwo eoa balance delta   : +", solverTwoEOA.balance - solverTwoEOABalance);
-        } else {
-            console.log("solverTwo eoa balance delta   : -", solverTwoEOABalance - solverTwoEOA.balance);
-        }
-
-        if (atlas.balanceOf(solverTwoEOA) >= solverTwoAtlEthBalance) {
-            console.log("solverTwo atlETH balance delta: +", atlas.balanceOf(solverTwoEOA) - solverTwoAtlEthBalance);
-        } else {
-            console.log("solverTwo atlETH balance delta: -", solverTwoAtlEthBalance - atlas.balanceOf(solverTwoEOA));
-        }
-
-        if (newSolverTwoBalance >= solverTwoTotalBalance) {
-            console.log("solverTwo total balance delta : +", newSolverTwoBalance - solverTwoTotalBalance);
-        } else {
-            console.log("solverTwo total balance delta : -", solverTwoTotalBalance - newSolverTwoBalance);
-        }
+        vm.startPrank(userEOA);
+        (bool success,) =
+            address(atlas).call(abi.encodeWithSelector(atlas.metacall.selector, userOp, solverOps, dAppOp));
+        if (success) console.log("success!");
+        else console.log("failure");
+        assertTrue(success);
+        vm.stopPrank();
     }
 }


### PR DESCRIPTION
`_bidFindingIteration()` was reverting when given 1 solverOp with a valid bid, with an out-of-range error (at this point: `else {sortedOps[k] = i;}`) due to some complexity with sorting the bids into their spots in the array, as bids were found.

This PR refactors to a more readable, and possibly more gas efficient approach:

1. Bids are found, packed into a uint256 with their original solverOps array index
2. Bids are sorted efficiently using `Solady.insertionSort()` (including their original indices which do not impact sorting)
3. Bids and their original indices are unpacked, and the original solverOps executed in descending order of discovered bid