### PR TITLE
Add dAppOp.bundler to valid bundlers

### DIFF
--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -91,8 +91,9 @@ contract AtlasVerification is EIP712, DAppIntegration {
                 return (userOpHash, ValidCallsResult.InvalidAuctioneer);
             }
 
-            // msgSender must be userOp.from or userOp.sessionKey / dappOp.from
-            if (!(msgSender == dAppOp.from || msgSender == userOp.from) && !isSimulation) {
+            // msgSender (the bundler) must be userOp.from, userOp.sessionKey / dappOp.from, or dappOp.bundler
+            if (!(msgSender == dAppOp.from || msgSender == dAppOp.bundler || msgSender == userOp.from) && !isSimulation)
+            {
                 return (userOpHash, ValidCallsResult.InvalidBundler);
             }
         } else {


### PR DESCRIPTION
Changes:

 - In `allowsTrustedOpHash` mode, add `dAppOp.bundler` as a valid bundler. Previously, only `dAppOp.from`/`userOp.sessionKey` and `userOp.from` were the only valid bundler options in this config.

Reasoning for why it's safe to include `dAppOp.bundler` as a valid bundler:

 - The auctioneer still signs the `dAppOp` (which includes `dAppOp.bundler` so they are explicitly giving permission to a specific bundler) and this sig is still checked. And it's checked (unless signatory approval is bypassed) that the auctioneer was pre-approved as a signor by the dApp.