### PR TITLE
Add `callConfig` to userOp for safety

### DIFF
--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -630,6 +630,7 @@ contract AtlasVerification is EIP712, DAppIntegration {
                 userOp.deadline,
                 userOp.dapp,
                 userOp.control,
+                userOp.callConfig,
                 userOp.sessionKey,
                 keccak256(userOp.data)
             )

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -154,6 +154,11 @@ contract AtlasVerification is EIP712, DAppIntegration {
             if (msgValue < userOp.value) {
                 return (userOpHash, ValidCallsResult.TxValueLowerThanCallValue);
             }
+
+            // Check the call config read at the start of the metacall is same as user expected (as set in userOp)
+            if (dConfig.callConfig != userOp.callConfig) {
+                return (userOpHash, ValidCallsResult.CallConfigMismatch);
+            }
         }
 
         // Some checks are only needed when call is not a simulation

--- a/src/contracts/helpers/TxBuilder.sol
+++ b/src/contracts/helpers/TxBuilder.sol
@@ -77,6 +77,7 @@ contract TxBuilder {
             deadline: deadline,
             dapp: to,
             control: control,
+            callConfig: IDAppControl(control).CALL_CONFIG(),
             sessionKey: address(0),
             data: data,
             signature: new bytes(0)

--- a/src/contracts/libraries/CallVerification.sol
+++ b/src/contracts/libraries/CallVerification.sol
@@ -1,11 +1,11 @@
 //SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
-import { IDAppControl } from "../interfaces/IDAppControl.sol";
+import { IDAppControl } from "src/contracts/interfaces/IDAppControl.sol";
 
-import "../types/SolverCallTypes.sol";
-import "../types/UserCallTypes.sol";
-import "../types/DAppApprovalTypes.sol";
+import "src/contracts/types/SolverCallTypes.sol";
+import "src/contracts/types/UserCallTypes.sol";
+import "src/contracts/types/DAppApprovalTypes.sol";
 
 library CallVerification {
     function getUserOperationHash(UserOperation memory userOp) internal pure returns (bytes32 userOpHash) {
@@ -13,7 +13,9 @@ library CallVerification {
     }
 
     function getAltOperationHash(UserOperation memory userOp) internal pure returns (bytes32 altOpHash) {
-        altOpHash = keccak256(abi.encodePacked(userOp.from, userOp.to, userOp.dapp, userOp.control, userOp.sessionKey));
+        altOpHash = keccak256(
+            abi.encodePacked(userOp.from, userOp.to, userOp.dapp, userOp.control, userOp.callConfig, userOp.sessionKey)
+        );
     }
 
     function getCallChainHash(

--- a/src/contracts/types/UserCallTypes.sol
+++ b/src/contracts/types/UserCallTypes.sol
@@ -15,6 +15,7 @@ struct UserOperation {
     uint256 deadline;
     address dapp; // nested "to" for user's call
     address control; // address for preOps / validation funcs
+    uint32 callConfig;
     address sessionKey;
     bytes data;
     bytes signature;

--- a/src/contracts/types/UserCallTypes.sol
+++ b/src/contracts/types/UserCallTypes.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.22;
 
 bytes32 constant USER_TYPEHASH = keccak256(
-    "UserOperation(address from,address to,uint256 value,uint256 gas,uint256 maxFeePerGas,uint256 nonce,uint256 deadline,address dapp,address control,address sessionKey,bytes32 data)"
+    "UserOperation(address from,address to,uint256 value,uint256 gas,uint256 maxFeePerGas,uint256 nonce,uint256 deadline,address dapp,address control,uint32 callConfig,address sessionKey,bytes32 data)"
 );
 
 struct UserOperation {

--- a/src/contracts/types/ValidCallsTypes.sol
+++ b/src/contracts/types/ValidCallsTypes.sol
@@ -20,5 +20,6 @@ enum ValidCallsResult {
     DeadlineMismatch,
     InvalidControl,
     InvalidSolverGasLimit,
-    InvalidDAppNonce
+    InvalidDAppNonce,
+    CallConfigMismatch
 }

--- a/test/AtlasVerification.t.sol
+++ b/test/AtlasVerification.t.sol
@@ -59,6 +59,7 @@ contract AtlasVerificationBase is AtlasBaseTest {
             .withNonce(address(atlasVerification), userEOA)
             .withDeadline(block.number + 2)
             .withControl(address(dAppControl))
+            .withCallConfig(dAppControl.CALL_CONFIG())
             .withSessionKey(address(0))
             .withData("")
             .sign(address(atlasVerification), userPK);
@@ -163,6 +164,11 @@ contract AtlasVerificationBase is AtlasBaseTest {
 
 contract AtlasVerificationVerifySolverOpTest is AtlasVerificationBase {
     using CallVerification for UserOperation;
+
+    function setUp() public override {
+        AtlasBaseTest.setUp();
+        dAppControl = defaultDAppControl().buildAndIntegrate(atlasVerification);
+    }
 
     function test_verifySolverOp_InvalidSignature() public {
         UserOperation memory userOp = validUserOperation().build();

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -65,6 +65,7 @@ contract EscrowTest is AtlasBaseTest {
             .withDeadline(block.number + 2)
             .withDapp(address(dAppControl))
             .withControl(address(dAppControl))
+            .withCallConfig(dAppControl.CALL_CONFIG())
             .withSessionKey(address(0))
             .withData("")
             .sign(address(atlasVerification), userPK);

--- a/test/ExPost.t.sol
+++ b/test/ExPost.t.sol
@@ -56,6 +56,7 @@ contract ExPostTest is BaseTest {
 
         UserOperation memory userOp = helper.buildUserOperation(POOL_ONE, POOL_TWO, userEOA, TOKEN_ONE);
         userOp.control = address(v2ExPost);
+        userOp.callConfig = v2ExPost.CALL_CONFIG();
 
         // user does not sign their own operation when bundling
         // (v, r, s) = vm.sign(userPK, atlasVerification.getUserOperationPayload(userOp));
@@ -283,6 +284,7 @@ contract ExPostTest is BaseTest {
         uint256 NUM_SOLVE_OPS = 3;
         UserOperation memory userOp = helper.buildUserOperation(POOL_ONE, POOL_TWO, userEOA, TOKEN_ONE);
         userOp.control = address(v2ExPost);
+        userOp.callConfig = v2ExPost.CALL_CONFIG();
         SolverOperation[] memory solverOps = new SolverOperation[](NUM_SOLVE_OPS);
         bytes memory solverOpData;
         address[] memory solverEOAs = new address[](NUM_SOLVE_OPS);

--- a/test/FlashLoan.t.sol
+++ b/test/FlashLoan.t.sol
@@ -73,6 +73,7 @@ contract FlashLoanTest is BaseTest {
             .withNonce(address(atlasVerification))
             .withDapp(address(control))
             .withControl(address(control))
+            .withCallConfig(control.CALL_CONFIG())
             .withDeadline(block.number + 2)
             .withData(new bytes(0))
             .build();

--- a/test/base/builders/UserOperationBuilder.sol
+++ b/test/base/builders/UserOperationBuilder.sol
@@ -4,10 +4,14 @@ pragma solidity 0.8.22;
 import "forge-std/Test.sol";
 
 import { UserOperation } from "src/contracts/types/UserCallTypes.sol";
+import { CallConfig } from "src/contracts/types/DAppApprovalTypes.sol";
+import { CallBits } from "src/contracts/libraries/CallBits.sol";
 
 import { IAtlasVerification } from "src/contracts/interfaces/IAtlasVerification.sol";
 
 contract UserOperationBuilder is Test {
+    using CallBits for uint32;
+
     UserOperation userOperation;
 
     function withFrom(address from) public returns (UserOperationBuilder) {
@@ -81,6 +85,16 @@ contract UserOperationBuilder is Test {
 
     function withControl(address control) public returns (UserOperationBuilder) {
         userOperation.control = control;
+        return this;
+    }
+
+    function withCallConfig(CallConfig memory callConfig) public returns (UserOperationBuilder) {
+        userOperation.callConfig = CallBits.encodeCallConfig(callConfig);
+        return this;
+    }
+
+    function withCallConfig(uint32 callConfig) public returns (UserOperationBuilder) {
+        userOperation.callConfig = callConfig;
         return this;
     }
 

--- a/test/libraries/CallVerification.t.sol
+++ b/test/libraries/CallVerification.t.sol
@@ -21,6 +21,7 @@ contract CallVerificationTest is Test {
             value: 90,
             dapp: address(0x2),
             control: address(0x3),
+            callConfig: 321,
             sessionKey: address(0),
             data: "data",
             signature: "signature"


### PR DESCRIPTION
Resolves this audit issue: https://github.com/spearbit-audits/review-fastlane/issues/154

Added `uint32 callConfig` as a field on the `UserOperation` struct. This enables a user to "agree" to an explicit CallConfig state, which can just be read off the DAppControl contract. Then, if a DAppControl for changes their CallConfig settings between the user creating the userOp and reading the modified CallConfig at the beginning of `metacall()`, the transaction will fail in `validateCalls()` in AtlasVerification with `ValidCallsResult.CallConfigMismatch`.

Considering the solvers and dapp signer need to see the userOp in order to create their `SolverOperation`/`DAppOperation` calldata, by just including `callConfig` in the userOpHash used by the other parties, they are also implicitly agreeing on the user's `callConfig` state.

This `callConfig` field is included in both types of `userOpHash` (when `allowsTrustedOpHash == true` and `allowsTrustedOpHash == false`).