### PR TITLE
Restore 'data' as bytes in user and solver type hashes

### DIFF
--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -311,7 +311,7 @@ contract AtlasVerification is EIP712, DAppIntegration {
                 solverOp.userOpHash,
                 solverOp.bidToken,
                 solverOp.bidAmount,
-                keccak256(solverOp.data)
+                solverOp.data
             )
         );
     }
@@ -632,7 +632,7 @@ contract AtlasVerification is EIP712, DAppIntegration {
                 userOp.control,
                 userOp.callConfig,
                 userOp.sessionKey,
-                keccak256(userOp.data)
+                userOp.data
             )
         );
     }

--- a/src/contracts/types/SolverCallTypes.sol
+++ b/src/contracts/types/SolverCallTypes.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.22;
 
 bytes32 constant SOLVER_TYPEHASH = keccak256(
-    "SolverOperation(address from,address to,uint256 value,uint256 gas,uint256 maxFeePerGas,uint256 deadline,address dapp,address control,bytes32 userOpHash,address bidToken,uint256 bidAmount,bytes32 data)"
+    "SolverOperation(address from,address to,uint256 value,uint256 gas,uint256 maxFeePerGas,uint256 deadline,address dapp,address control,bytes32 userOpHash,address bidToken,uint256 bidAmount,bytes data)"
 );
 
 // NOTE: The calldata length of this SolverOperation struct is 608 bytes when the `data` field is excluded. This value

--- a/src/contracts/types/UserCallTypes.sol
+++ b/src/contracts/types/UserCallTypes.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.22;
 
 bytes32 constant USER_TYPEHASH = keccak256(
-    "UserOperation(address from,address to,uint256 value,uint256 gas,uint256 maxFeePerGas,uint256 nonce,uint256 deadline,address dapp,address control,uint32 callConfig,address sessionKey,bytes32 data)"
+    "UserOperation(address from,address to,uint256 value,uint256 gas,uint256 maxFeePerGas,uint256 nonce,uint256 deadline,address dapp,address control,uint32 callConfig,address sessionKey,bytes data)"
 );
 
 struct UserOperation {


### PR DESCRIPTION
Resolves this audit issue: https://github.com/spearbit-audits/review-fastlane/issues/163

The `data` field of user and solver type hashes was defined as a `bytes32` when it is in fact `bytes`.
Switched it back to the correct `bytes` type in the user and solver type hashes, and updated the `_getUserOpHash` and `_getSolverOpHash` functions in `AtlasVerification.sol` to ***not*** `keccak256` the `data` field anymore.