### PR TITLE
Fix parameter naming in solver type hash

### DIFF
--- a/src/contracts/types/SolverCallTypes.sol
+++ b/src/contracts/types/SolverCallTypes.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.22;
 
 bytes32 constant SOLVER_TYPEHASH = keccak256(
-    "SolverOperation(address from,address to,uint256 value,uint256 gas,uint256 maxFeePerGas,uint256 deadline,address dapp,address control,bytes32 userOpHash,address bidToken,uint256 bidAmount,bytes32 data)"
+    "SolverOperation(address from,address to,uint256 value,uint256 gas,uint256 maxFeePerGas,uint256 deadline,address solver,address control,bytes32 userOpHash,address bidToken,uint256 bidAmount,bytes32 data)"
 );
 
 // NOTE: The calldata length of this SolverOperation struct is 608 bytes when the `data` field is excluded. This value


### PR DESCRIPTION
Resolves this audit issue: https://github.com/spearbit-audits/review-fastlane/issues/162

Typo fix: the parameter `dapp` was wrong, and replaced with `solver`.