### PR TITLE
Move statement to avoid double assignment

### DIFF
--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -136,8 +136,6 @@ abstract contract Escrow is AtlETH {
                     bidAmount, gasLimit, key.executionEnvironment, solverOp, dAppReturnData, key.pack()
                 );
 
-                key.solverOutcome = uint24(result);
-
                 if (result.executionSuccessful()) {
                     // first successful solver call that paid what it bid
 
@@ -145,6 +143,8 @@ abstract contract Escrow is AtlETH {
 
                     key.solverSuccessful = true;
                     // auctionWon = true
+
+                    key.solverOutcome = uint24(result);
                     return (true, key);
                 }
             }


### PR DESCRIPTION
Resolves this audit issue: https://github.com/spearbit-audits/review-fastlane/issues/108

Move the `key.solverOutcome = uint24(result)` statement to avoid having it executing twice in certain conditions.