### PR TITLE
Remove useless assignment

### DIFF
--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -132,7 +132,7 @@ abstract contract Escrow is AtlETH {
 
                 // Execute the solver call
                 // _solverOpsWrapper returns a SolverOutcome enum value
-                result |= _solverOpWrapper(
+                result = _solverOpWrapper(
                     bidAmount, gasLimit, key.executionEnvironment, solverOp, dAppReturnData, key.pack()
                 );
 
@@ -272,7 +272,7 @@ abstract contract Escrow is AtlETH {
             solverOp.value
                 > address(this).balance - (gasLimit * tx.gasprice > address(this).balance ? 0 : gasLimit * tx.gasprice)
         ) {
-            return (result |= 1 << uint256(SolverOutcome.CallValueTooHigh), gasLimit);
+            return (result | 1 << uint256(SolverOutcome.CallValueTooHigh), gasLimit);
         }
 
         // subtract out the gas buffer since the solver's metaTx won't use it


### PR DESCRIPTION
Resolves this audit issue: https://github.com/spearbit-audits/review-fastlane/issues/107

Remove `OR` assignment when not useful.