### PR TITLE
ChainlinkDAppControl Audit Fixes

### DIFF
--- a/src/contracts/examples/intents-example/SwapIntentDAppControl.sol
+++ b/src/contracts/examples/intents-example/SwapIntentDAppControl.sol
@@ -95,13 +95,14 @@ contract SwapIntentDAppControl is DAppControl {
             "SwapIntentDAppControl: SellFundsUnavailable"
         );
 
-        if (swapIntent.conditions.length > 0) {
-            require(swapIntent.conditions.length <= MAX_USER_CONDITIONS, "SwapIntentDAppControl: TooManyConditions");
+        uint256 conditionsLength = swapIntent.conditions.length;
+        if (conditionsLength > 0) {
+            require(conditionsLength <= MAX_USER_CONDITIONS, "SwapIntentDAppControl: TooManyConditions");
 
             bool valid;
             bytes memory conditionData;
 
-            for (uint256 i; i < swapIntent.conditions.length; ++i) {
+            for (uint256 i; i < conditionsLength; ++i) {
                 (valid, conditionData) = swapIntent.conditions[i].antecedent.staticcall{ gas: USER_CONDITION_GAS_LIMIT }(
                     swapIntent.conditions[i].context
                 );

--- a/src/contracts/examples/oev-example/ChainlinkAtlasWrapper.sol
+++ b/src/contracts/examples/oev-example/ChainlinkAtlasWrapper.sol
@@ -122,6 +122,11 @@ contract ChainlinkAtlasWrapper is Ownable, IChainlinkAtlasWrapper {
         }
     }
 
+    // TODO implement epoch and round logic to prevent outdated transmissions
+    function latestRound() external view override returns (uint256) {
+        return BASE_FEED.latestRound();
+    }
+
     // Fallback to base oracle's latestRoundData, unless this contract's latestTimestamp and latestAnswer are more
     // recent, in which case return those values as well as the other round data from the base oracle.
     function latestRoundData()
@@ -136,24 +141,40 @@ contract ChainlinkAtlasWrapper is Ownable, IChainlinkAtlasWrapper {
         }
     }
 
-    function latestRound() external view override returns (uint256) { }
+    // Pass-through call to base oracle's `getAnswer()` function
+    function getAnswer(uint256 roundId) external view override returns (int256) {
+        return BASE_FEED.getAnswer(roundId);
+    }
 
-    function getAnswer(uint256 roundId) external view override returns (int256) { }
+    // Pass-through call to base oracle's `getTimestamp()` function
+    function getTimestamp(uint256 roundId) external view override returns (uint256) {
+        return BASE_FEED.getTimestamp(roundId);
+    }
 
-    function getTimestamp(uint256 roundId) external view override returns (uint256) { }
-
-    function decimals() external view override returns (uint8) { }
-
-    function description() external view override returns (string memory) { }
-
-    function version() external view override returns (uint256) { }
-
+    // Pass-through call to base oracle's `getRoundData()` function
     function getRoundData(uint80 _roundId)
         external
         view
         override
         returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
-    { }
+    {
+        return BASE_FEED.getRoundData(_roundId);
+    }
+
+    // Pass-through calls to base oracle's `decimals()` functions
+    function decimals() external view override returns (uint8) {
+        return BASE_FEED.decimals();
+    }
+
+    // Pass-through calls to base oracle's `description()` functions
+    function description() external view override returns (string memory) {
+        return BASE_FEED.description();
+    }
+
+    // Pass-through calls to base oracle's `version()` functions
+    function version() external view override returns (uint256) {
+        return BASE_FEED.version();
+    }
 
     // ---------------------------------------------------- //
     //                     Owner Functions                  //
@@ -181,9 +202,9 @@ contract ChainlinkAtlasWrapper is Ownable, IChainlinkAtlasWrapper {
     receive() external payable { }
 }
 
-// -----------------------------------------------
-// Structs and interface for Chainlink Aggregator
-// -----------------------------------------------
+// ---------------------------------------------------- //
+//             Chainlink Aggregator Structs             //
+// ---------------------------------------------------- //
 
 struct ReportData {
     HotVars hotVars; // Only read from storage once

--- a/src/contracts/examples/oev-example/ChainlinkAtlasWrapper.sol
+++ b/src/contracts/examples/oev-example/ChainlinkAtlasWrapper.sol
@@ -9,8 +9,6 @@ import {
 } from "src/contracts/examples/oev-example/IChainlinkAtlasWrapper.sol";
 import { IChainlinkDAppControl } from "src/contracts/examples/oev-example/IChainlinkDAppControl.sol";
 
-import "forge-std/Test.sol"; //TODO remove
-
 // A wrapper contract for a specific Chainlink price feed, used by Atlas to capture Oracle Extractable Value (OEV).
 // Each MEV-generating protocol needs their own wrapper for each Chainlink price feed they use.
 contract ChainlinkAtlasWrapper is Ownable, IChainlinkAtlasWrapper {
@@ -127,8 +125,11 @@ contract ChainlinkAtlasWrapper is Ownable, IChainlinkAtlasWrapper {
         return BASE_FEED.latestRound();
     }
 
-    // Fallback to base oracle's latestRoundData, unless this contract's latestTimestamp and latestAnswer are more
+    // Fallback to base oracle's latestRoundData, unless this contract's `latestTimestamp` and `latestAnswer` are more
     // recent, in which case return those values as well as the other round data from the base oracle.
+    // NOTE: This may break some integrations as it implies a `roundId` has multiple answers (the canonical answer from
+    // the base feed, and the `atlasLatestAnswer` if more recent), which deviates from the expected behaviour of the
+    // base Chainlink feeds. Be aware of this tradeoff when integrating ChainlinkAtlasWrappers as your price feed.
     function latestRoundData()
         public
         view

--- a/src/contracts/examples/oev-example/IChainlinkAtlasWrapper.sol
+++ b/src/contracts/examples/oev-example/IChainlinkAtlasWrapper.sol
@@ -1,0 +1,50 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.22;
+
+import { IChainlinkDAppControl } from "./IChainlinkDAppControl.sol";
+
+interface AggregatorInterface {
+    function latestAnswer() external view returns (int256);
+    function latestTimestamp() external view returns (uint256);
+    function latestRound() external view returns (uint256);
+    function getAnswer(uint256 roundId) external view returns (int256);
+    function getTimestamp(uint256 roundId) external view returns (uint256);
+
+    event AnswerUpdated(int256 indexed current, uint256 indexed roundId, uint256 updatedAt);
+    event NewRound(uint256 indexed roundId, address indexed startedBy, uint256 startedAt);
+}
+
+interface AggregatorV3Interface {
+    function decimals() external view returns (uint8);
+    function description() external view returns (string memory);
+    function version() external view returns (uint256);
+
+    // getRoundData and latestRoundData should both raise "No data present"
+    // if they do not have data to report, instead of returning unset values
+    // which could be misinterpreted as actual reported values.
+    function getRoundData(uint80 _roundId)
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
+}
+
+interface AggregatorV2V3Interface is AggregatorInterface, AggregatorV3Interface { }
+
+interface IChainlinkAtlasWrapper is AggregatorV2V3Interface {
+    function transmit(
+        bytes calldata report,
+        bytes32[] calldata rs,
+        bytes32[] calldata ss,
+        bytes32 rawVs
+    )
+        external
+        returns (address);
+
+    function setTransmitterStatus(address transmitter, bool trusted) external;
+    function withdrawETH(address recipient) external;
+    function withdrawERC20(address token, address recipient) external;
+}

--- a/src/contracts/examples/oev-example/IChainlinkDAppControl.sol
+++ b/src/contracts/examples/oev-example/IChainlinkDAppControl.sol
@@ -1,0 +1,15 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.22;
+
+interface IChainlinkDAppControl {
+    function verifyTransmitSigners(
+        address baseChainlinkFeed,
+        bytes calldata report,
+        bytes32[] calldata rs,
+        bytes32[] calldata ss,
+        bytes32 rawVs
+    )
+        external
+        view
+        returns (bool verified);
+}

--- a/test/OEV.t.sol
+++ b/test/OEV.t.sol
@@ -119,6 +119,8 @@ contract OEVTest is BaseTest {
         atlas.bond(1e18);
         vm.stopPrank();
 
+        assertTrue(chainlinkDAppControl.isChainlinkWrapper(address(chainlinkAtlasWrapper)), "Wrapper should be registered on DAppControl - otherwise will revert in allocateValue");
+
         // Basic userOp created but excludes oracle price update data
         userOp = txBuilder.buildUserOperation({
             from: userEOA,

--- a/test/OEV.t.sol
+++ b/test/OEV.t.sol
@@ -305,6 +305,11 @@ contract OEVTest is BaseTest {
         chainlinkAtlasWrapper.transmit(transmitData.report, transmitData.rs, transmitData.ss, transmitData.rawVs);
 
         assertEq(uint(chainlinkAtlasWrapper.atlasLatestAnswer()), targetOracleAnswer, "Wrapper stored latestAnswer should be updated");
+
+        // Check that transmit reverts if called again with same data
+        vm.prank(executionEnvironment);
+        vm.expectRevert(ChainlinkAtlasWrapper.CannotReuseReport.selector);
+        chainlinkAtlasWrapper.transmit(transmitData.report, transmitData.rs, transmitData.ss, transmitData.rawVs);
     }
 
     function testChainlinkAtlasWrapperCanReceiveETH() public {


### PR DESCRIPTION
Resolves these audit issues:

- https://github.com/spearbit-audits/review-fastlane/issues/71
- https://github.com/spearbit-audits/review-fastlane/issues/79 (partial)
- https://github.com/spearbit-audits/review-fastlane/issues/129 (partial)
- https://github.com/spearbit-audits/review-fastlane/issues/176
- https://github.com/spearbit-audits/review-fastlane/issues/181

Acknowledged but did not fix this audit issue: 

- https://github.com/spearbit-audits/review-fastlane/issues/178

Notes:

- [Issue 79](https://github.com/spearbit-audits/review-fastlane/issues/79) is partially resolved because we can use `epochAndRound` from the `report` data to check that that specific ChainlinkAtlasWrapper contract is receiving data more recent than any `transmit()` payload it has previously accepted. However, due to the limitations of view functions and variables we can access on the base Chainlink feed, there doesn't seem to be a way to ensure, from the `transmit()` calldata, that it is not "stale" (there has been a more recent update on the base feed).
- [Issue 129](https://github.com/spearbit-audits/review-fastlane/issues/129) is partially resolved because there doesn't seem to be a good way to address the unexpected behaviour of `latestRoundData()`. See notes on the Spearbit issue.
- [Issue 178](https://github.com/spearbit-audits/review-fastlane/issues/178) is intentionally acknowledge but not fixed as recommended in the Spearbit issue. This is because changing the `report` data for security would require Chainlink nodes to run special code to sign Atlas-specific price observations. Additionally, both the Chainlink and Atlas versions of `transmit()` are permissioned functions, so there is a trust assumption to fall back on.