### PR TITLE
Optimize sortBids by avoiding double calculation

### DIFF
--- a/src/contracts/helpers/Sorter.sol
+++ b/src/contracts/helpers/Sorter.sol
@@ -41,9 +41,9 @@ contract Sorter {
 
         uint256[] memory sorted = _sort(sortingData, count, invalid);
 
-        SolverOperation[] memory solverOpsSorted = new SolverOperation[](count - invalid);
-
         count -= invalid;
+        SolverOperation[] memory solverOpsSorted = new SolverOperation[](count);
+
         uint256 i = 0;
 
         for (; i < count; ++i) {


### PR DESCRIPTION
Resolves this audit issue: https://github.com/spearbit-audits/review-fastlane/issues/168

Avoid double calculation.