### PR TITLE
Remove test inheritance from SolverBase

### DIFF
--- a/src/contracts/solver/SolverBase.sol
+++ b/src/contracts/solver/SolverBase.sol
@@ -8,14 +8,12 @@ import { IEscrow } from "src/contracts/interfaces/IEscrow.sol";
 
 import "../types/SolverCallTypes.sol";
 
-import "forge-std/Test.sol";
-
 interface IWETH9 {
     function deposit() external payable;
     function withdraw(uint256 wad) external payable;
 }
 
-contract SolverBase is Test {
+contract SolverBase {
     address public immutable WETH_ADDRESS;
     address internal immutable _owner;
     address internal immutable _atlas;


### PR DESCRIPTION
Resolves this audit issue: https://github.com/spearbit-audits/review-fastlane/issues/203

Remove leftover `Test` inheritance.