### PR TITLE
Proper clean up of dAppSignatories when disabling a dApp

### DIFF
--- a/src/contracts/atlas/DAppIntegration.sol
+++ b/src/contracts/atlas/DAppIntegration.sol
@@ -117,19 +117,19 @@ contract DAppIntegration {
     }
 
     /// @notice Disables a dApp from the Atlas protocol.
-    /// @param dAppControl The address of the DAppControl contract.
-    function disableDApp(address dAppControl) external {
+    /// @param control The address of the DAppControl contract.
+    function disableDApp(address control) external {
         _checkAtlasIsUnlocked();
-        address dAppGov = IDAppControl(dAppControl).getDAppSignatory();
+        address dAppGov = IDAppControl(control).getDAppSignatory();
         if (msg.sender != dAppGov) revert AtlasErrors.OnlyGovernance();
 
-        bytes32 signatoryKey = keccak256(abi.encodePacked(dAppControl, dAppGov));
+        bytes32 signatoryKey = keccak256(abi.encodePacked(control, dAppGov));
         if (!signatories[signatoryKey]) revert AtlasErrors.DAppNotEnabled();
 
-        _removeSignatory(dAppControl, dAppGov);
+        _removeSignatory(control, dAppGov);
 
-        uint32 callConfig = IDAppControl(dAppControl).CALL_CONFIG();
-        emit AtlasEvents.DAppDisabled(dAppControl, dAppGov, callConfig);
+        uint32 callConfig = IDAppControl(control).CALL_CONFIG();
+        emit AtlasEvents.DAppDisabled(control, dAppGov, callConfig);
     }
 
     // ---------------------------------------------------- //

--- a/src/contracts/atlas/DAppIntegration.sol
+++ b/src/contracts/atlas/DAppIntegration.sol
@@ -122,8 +122,11 @@ contract DAppIntegration {
         _checkAtlasIsUnlocked();
         address dAppGov = IDAppControl(dAppControl).getDAppSignatory();
         if (msg.sender != dAppGov) revert AtlasErrors.OnlyGovernance();
+
         bytes32 signatoryKey = keccak256(abi.encodePacked(dAppControl, dAppGov));
-        signatories[signatoryKey] = false;
+        if (!signatories[signatoryKey]) revert AtlasErrors.DAppNotEnabled();
+
+        _removeSignatory(dAppControl, dAppGov);
 
         uint32 callConfig = IDAppControl(dAppControl).CALL_CONFIG();
         emit AtlasEvents.DAppDisabled(dAppControl, dAppGov, callConfig);


### PR DESCRIPTION
Resolves this audit issue: https://github.com/spearbit-audits/review-fastlane/issues/193

Cleanup the `dAppSignatories` map when disabling a dApp.
Add a check that the dApp is enabled before attempting to disable it.
Rename `dAppControl` to `control` to stay consistent across naming.