### PR TITLE
Use var already copied in stack instead of another storage read

### DIFF
--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -32,7 +32,7 @@ abstract contract GasAccounting is SafetyLocks {
             uint256 _deposits = deposits;
             // Check if locked.
             if (_deposits != type(uint256).max) {
-                fulfilled = deposits >= claims + withdrawals;
+                fulfilled = _deposits >= claims + withdrawals;
             }
         }
     }


### PR DESCRIPTION
Resolves this audit issue: https://github.com/spearbit-audits/review-fastlane/issues/47

Use var already copied in stack instead of another storage read