### PR TITLE
Enforce smart wallet validation in simulation mode

### DIFF
--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -567,7 +567,7 @@ contract AtlasVerification is EIP712, DAppIntegration {
             }
             bool validSmartWallet =
                 IAccount(userOp.from).validateUserOp{ gas: 30_000 }(userOp, _getUserOpHash(userOp), 0) == 0;
-            return (isSimulation || validSmartWallet);
+            return validSmartWallet;
         }
 
         bool bypassSignature = msgSender == userOp.from || (isSimulation && userOp.signature.length == 0);


### PR DESCRIPTION
Resolves this audit issue: https://github.com/spearbit-audits/review-fastlane/issues/74

Enforce smart wallet validation, even in simulation mode, to avoid false positives and potentially have the bundler waste gas.