### PR TITLE
Use internal function instead of direct mapping access

### DIFF
--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -371,13 +371,13 @@ contract AtlasVerification is EIP712, DAppIntegration {
         // Check actual bundler matches the dApp's intended `dAppOp.bundler`
         // If bundler and auctioneer are the same address, this check is skipped
         if (dAppOp.bundler != address(0) && msgSender != dAppOp.bundler) {
-            if (!skipDAppOpChecks && !signatories[keccak256(abi.encodePacked(dAppOp.control, msgSender))]) {
+            if (!skipDAppOpChecks && !_isDAppSignatory(dAppOp.control, msgSender)) {
                 return (false, ValidCallsResult.InvalidBundler);
             }
         }
 
         // Make sure the signer is currently enabled by dapp owner
-        if (!skipDAppOpChecks && !signatories[keccak256(abi.encodePacked(dAppOp.control, dAppOp.from))]) {
+        if (!skipDAppOpChecks && !_isDAppSignatory(dAppOp.control, dAppOp.from)) {
             return (false, ValidCallsResult.DAppSignatureInvalid);
         }
 

--- a/src/contracts/atlas/DAppIntegration.sol
+++ b/src/contracts/atlas/DAppIntegration.sol
@@ -133,6 +133,16 @@ contract DAppIntegration {
     //                   Internal Functions                 //
     // ---------------------------------------------------- //
 
+    /// @notice Returns whether a specified address is a signatory for a specified DAppControl contract.
+    /// @param dAppControl The address of the DAppControl contract.
+    /// @param signatory The address to check.
+    /// @return A boolean indicating whether the specified address is a signatory for the specified DAppControl
+    /// contract.
+    function _isDAppSignatory(address dAppControl, address signatory) internal view returns (bool) {
+        bytes32 signatoryKey = keccak256(abi.encodePacked(dAppControl, signatory));
+        return signatories[signatoryKey];
+    }
+
     /// @notice Adds a new signatory to a dApp's list of approved signatories.
     /// @param control The address of the DAppControl contract.
     /// @param signatory The address of the new signatory.
@@ -183,8 +193,7 @@ contract DAppIntegration {
     /// @return A boolean indicating whether the specified address is a signatory for the specified DAppControl
     /// contract.
     function isDAppSignatory(address dAppControl, address signatory) external view returns (bool) {
-        bytes32 signatoryKey = keccak256(abi.encodePacked(dAppControl, signatory));
-        return signatories[signatoryKey];
+        return _isDAppSignatory(dAppControl, signatory);
     }
 
     /// @notice Returns an array of signatories for a specified DAppControl contract.


### PR DESCRIPTION
Resolves this audit issue: https://github.com/spearbit-audits/review-fastlane/issues/59

Use an internal function instead of accessing inherited mapping values.