### PR TITLE
Remove useless reverting fallback function

### DIFF
--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -481,8 +481,4 @@ abstract contract Escrow is AtlETH {
     }
 
     receive() external payable { }
-
-    fallback() external payable {
-        revert();
-    }
 }


### PR DESCRIPTION
Resolves this audit issue: https://github.com/spearbit-audits/review-fastlane/issues/122

Remove the `fallback` function from `Escrow` contract.
Having only a `revert()` in `fallback()` is same as not having a `fallback()` at all.