### PR TITLE
Move stats update in separate function, add stats update in _credit

### DIFF
--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -169,13 +169,7 @@ abstract contract GasAccounting is SafetyLocks {
                 aData.lastAccessedBlock = uint32(block.number);
             }
 
-            // Reputation Analytics: Track total gas used, solver wins, and failures
-            aData.totalGasUsed += uint64(amount / _GAS_USED_DECIMALS_TO_DROP);
-            if (solverWon) {
-                aData.auctionWins++;
-            } else if (!bidFind) {
-                aData.auctionFails++;
-            }
+            _updateAnalytics(aData, amount, solverWon, bidFind);
 
             accessData[owner] = aData;
 
@@ -197,6 +191,8 @@ abstract contract GasAccounting is SafetyLocks {
         aData.bonded += amt;
 
         bondedTotalSupply += amount;
+
+        _updateAnalytics(aData, 0, true, false);
 
         accessData[owner] = aData;
     }
@@ -305,5 +301,28 @@ abstract contract GasAccounting is SafetyLocks {
 
         // _SOLVER_OP_BASE_CALLDATA = SolverOperation calldata length excluding solverOp.data
         calldataCost = (calldataLength + _SOLVER_OP_BASE_CALLDATA) * _CALLDATA_LENGTH_PREMIUM * tx.gasprice;
+    }
+
+    /// @notice Reputation Analytics: Track total gas used, solver wins, and failures.
+    /// @dev The aData struct is passed by reference. The calling function is responsible for updating the storage.
+    /// @param aData The EscrowAccountAccessData for the solver.
+    /// @param gasUsed The gas charged to the solver.
+    /// @param solverWon A boolean indicating whether the solver won the auction.
+    /// @param bidFind Indicates if called in the context of `_getBidAmount` in Escrow.sol (true) or not (false).
+    function _updateAnalytics(
+        EscrowAccountAccessData memory aData,
+        uint256 gasUsed,
+        bool solverWon,
+        bool bidFind
+    )
+        internal
+        pure
+    {
+        if (gasUsed > 0) aData.totalGasUsed += uint64(gasUsed / _GAS_USED_DECIMALS_TO_DROP);
+        if (solverWon) {
+            aData.auctionWins++;
+        } else if (!bidFind) {
+            aData.auctionFails++;
+        }
     }
 }


### PR DESCRIPTION
Audit issue: https://github.com/spearbit-audits/review-fastlane/issues/146

Move the stats update in a separate function and add a call to it in `_credit()`.
Note that the function updates the `EscrowAccountAccessData` struct, which is passed by reference. The function caller is responsible for updating the storage if necessary.