### PR TITLE
Refactor constants to shared file

### DIFF
--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -285,7 +285,7 @@ contract Atlas is Escrow, Factory {
                 // The array is filled with non-zero bids from the right. This causes all zero bids to be on the left -
                 // in their sorted position, so fewer operations are needed in the sorting step below.
                 bidsAndIndices[bidsAndIndicesLastIndex - (i - zeroBidCount)] =
-                    uint256(bidAmountFound << BITS_FOR_INDEX | uint16(i));
+                    uint256(bidAmountFound << _BITS_FOR_INDEX | uint16(i));
             }
         }
 
@@ -297,13 +297,13 @@ contract Atlas is Escrow, Factory {
         // Finally, iterate through sorted bidsAndIndices array in descending order of bidAmount.
         for (uint256 i = bidsAndIndicesLastIndex; i >= 0; --i) {
             // Isolate the bidAmount from the packed uint256 value
-            bidAmountFound = (bidsAndIndices[i] >> BITS_FOR_INDEX) & FIRST_240_BITS_MASK;
+            bidAmountFound = (bidsAndIndices[i] >> _BITS_FOR_INDEX) & _FIRST_240_BITS_TRUE_MASK;
 
             // If we reach the zero bids on the left of array, break as all valid bids already checked.
             if (bidAmountFound == 0) break;
 
             // Isolate the original solverOps index from the packed uint256 value
-            uint256 solverOpsIndex = bidsAndIndices[i] & FIRST_16_BITS_MASK;
+            uint256 solverOpsIndex = bidsAndIndices[i] & _FIRST_16_BITS_TRUE_MASK;
 
             (auctionWon, key) = _executeSolverOperation(
                 dConfig, userOp, solverOps[solverOpsIndex], returnData, bidAmountFound, true, key

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -25,11 +25,6 @@ contract AtlasVerification is EIP712, DAppIntegration, AtlasConstants {
     using CallBits for uint32;
     using CallVerification for UserOperation;
 
-    uint256 internal constant _FULL_BITMAP = uint256(0x0000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
-    uint256 internal constant _FIRST_16_BITS_FULL = uint256(0xFFFF);
-    uint256 internal constant _FIRST_4_BITS_FULL = uint256(0xF);
-    uint256 internal constant _NONCES_PER_BITMAP = 240;
-
     constructor(address _atlas) EIP712("AtlasVerification", "1.0") DAppIntegration(_atlas) { }
 
     /// @notice The validateCalls function verifies the validity of the metacall calldata components.
@@ -704,14 +699,14 @@ contract AtlasVerification is EIP712, DAppIntegration, AtlasConstants {
 
         for (uint256 i = 0; i < 240; i += 16) {
             // Isolate the next 16 bits to check
-            uint256 chunk16 = (bitmap >> i) & _FIRST_16_BITS_FULL;
+            uint256 chunk16 = (bitmap >> i) & _FIRST_16_BITS_TRUE_MASK;
             // Find non-full 16-bit chunk
-            if (chunk16 != _FIRST_16_BITS_FULL) {
+            if (chunk16 != _FIRST_16_BITS_TRUE_MASK) {
                 for (uint256 j = 0; j < 16; j += 4) {
                     // Isolate the next 4 bits within the 16-bit chunk to check
-                    uint256 chunk4 = (chunk16 >> j) & _FIRST_4_BITS_FULL;
+                    uint256 chunk4 = (chunk16 >> j) & _FIRST_4_BITS_TRUE_MASK;
                     // Find non-full 4-bit chunk
-                    if (chunk4 != _FIRST_4_BITS_FULL) {
+                    if (chunk4 != _FIRST_4_BITS_TRUE_MASK) {
                         for (uint256 k = 0; k < 4; k++) {
                             // Find first unused bit
                             if ((chunk4 >> k) & 0x1 == 0) {

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -3,12 +3,13 @@ pragma solidity 0.8.22;
 
 import { EIP712 } from "openzeppelin-contracts/contracts/utils/cryptography/EIP712.sol";
 import { ECDSA } from "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
-import { DAppIntegration } from "./DAppIntegration.sol";
+import { DAppIntegration } from "src/contracts/atlas/DAppIntegration.sol";
 
 import { EscrowBits } from "src/contracts/libraries/EscrowBits.sol";
 import { CallBits } from "src/contracts/libraries/CallBits.sol";
 import { CallVerification } from "src/contracts/libraries/CallVerification.sol";
 import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
+import { AtlasConstants } from "src/contracts/types/AtlasConstants.sol";
 import "src/contracts/types/SolverCallTypes.sol";
 import "src/contracts/types/UserCallTypes.sol";
 import "src/contracts/types/DAppApprovalTypes.sol";
@@ -19,7 +20,7 @@ import "src/contracts/types/ValidCallsTypes.sol";
 /// @author FastLane Labs
 /// @notice AtlasVerification handles the verification of DAppConfigs, UserOperations, SolverOperations, and
 /// DAppOperations within a metacall to ensure that calldata sourced from various parties is safe and valid.
-contract AtlasVerification is EIP712, DAppIntegration {
+contract AtlasVerification is EIP712, DAppIntegration, AtlasConstants {
     using ECDSA for bytes32;
     using CallBits for uint32;
     using CallVerification for UserOperation;
@@ -28,7 +29,6 @@ contract AtlasVerification is EIP712, DAppIntegration {
     uint256 internal constant _FIRST_16_BITS_FULL = uint256(0xFFFF);
     uint256 internal constant _FIRST_4_BITS_FULL = uint256(0xF);
     uint256 internal constant _NONCES_PER_BITMAP = 240;
-    uint8 internal constant _MAX_SOLVERS = type(uint8).max - 2;
 
     constructor(address _atlas) EIP712("AtlasVerification", "1.0") DAppIntegration(_atlas) { }
 
@@ -126,7 +126,7 @@ contract AtlasVerification is EIP712, DAppIntegration {
                 return (userOpHash, ValidCallsResult.UserSignatureInvalid);
             }
 
-            // Check solvers not over the max (253)
+            // Check number of solvers not greater than max, to prevent overflows in `callIndex`
             if (solverOpCount > _MAX_SOLVERS) {
                 return (userOpHash, ValidCallsResult.TooManySolverOps);
             }

--- a/src/contracts/atlas/SafetyLocks.sol
+++ b/src/contracts/atlas/SafetyLocks.sol
@@ -74,7 +74,7 @@ abstract contract SafetyLocks is Storage {
             solverSuccessful: false,
             paymentsSuccessful: false,
             callIndex: dConfig.callConfig.needsPreOpsCall() ? 0 : 1,
-            callCount: solverOpCount + 4,
+            callCount: solverOpCount + _CALL_COUNT_EXCL_SOLVER_CALLS,
             lockState: 0,
             solverOutcome: 0,
             bidFind: false,

--- a/src/contracts/atlas/Storage.sol
+++ b/src/contracts/atlas/Storage.sol
@@ -11,25 +11,18 @@ import { AtlasConstants } from "src/contracts/types/AtlasConstants.sol";
 /// @author FastLane Labs
 /// @notice Storage manages all storage variables and constants for the Atlas smart contract.
 contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
-    // Atlas constants
-    uint256 internal constant _GAS_USED_DECIMALS_TO_DROP = 1000;
-    address internal constant _UNLOCKED = address(1);
-    uint256 internal constant _UNLOCKED_UINT = 1;
-
-    // Atlas constants used in `_bidFindingIteration()`
-    uint256 internal constant BITS_FOR_INDEX = 16;
-    uint256 internal constant FIRST_16_BITS_MASK = uint256(0xFFFF);
-    uint256 internal constant FIRST_240_BITS_MASK =
-        uint256(0x0000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
-
     uint256 public immutable ESCROW_DURATION;
     address public immutable VERIFICATION;
     address public immutable SIMULATOR;
 
-    // AtlETH ERC-20 constants
+    // AtlETH ERC-20 public constants
     string public constant name = "Atlas ETH";
     string public constant symbol = "atlETH";
     uint8 public constant decimals = 18;
+
+    // Gas Accounting public constants
+    uint256 public constant SURCHARGE_RATE = 1_000_000; // 1_000_000 / 10_000_000 = 10%
+    uint256 public constant SURCHARGE_SCALE = 10_000_000; // 10_000_000 / 10_000_000 = 100%
 
     // AtlETH EIP-2612 constants
     uint256 internal immutable _INITIAL_CHAIN_ID;
@@ -45,19 +38,6 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
     mapping(address => EscrowAccountAccessData) public accessData;
     mapping(bytes32 => bool) internal _solverOpHashes; // NOTE: Only used for when allowTrustedOpHash is enabled
 
-    // Escrow constants
-    uint256 internal constant _VALIDATION_GAS_LIMIT = 500_000;
-    uint256 internal constant _SOLVER_GAS_LIMIT_BUFFER_PERCENTAGE = 5; // out of 100 = 5%
-    uint256 internal constant _SOLVER_GAS_LIMIT_SCALE = 100; // out of 100 = 100%
-    uint256 internal constant _FASTLANE_GAS_BUFFER = 125_000; // integer amount
-
-    // Gas Accounting constants
-    uint256 public constant SURCHARGE_RATE = 1_000_000; // 1_000_000 / 10_000_000 = 10%
-    uint256 public constant SURCHARGE_SCALE = 10_000_000; // 10_000_000 / 10_000_000 = 100%
-    uint256 internal constant _CALLDATA_LENGTH_PREMIUM = 32; // 16 (default) * 2
-    uint256 internal constant _SOLVER_OP_BASE_CALLDATA = 608; // SolverOperation calldata length excluding solverOp.data
-    uint256 internal constant _SOLVER_LOCK_GAS_BUFFER = 5000; // Base gas charged to solver in `_releaseSolverLock()`
-
     // atlETH GasAccounting storage
     uint256 public cumulativeSurcharge; // Cumulative gas surcharges collected
     address public surchargeRecipient; // Fastlane surcharge recipient
@@ -69,12 +49,6 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
     uint256 public withdrawals; // transient storage
     uint256 public deposits; // transient storage
     uint256 internal _solverLock; // transient storage
-
-    // First 160 bits of _solverLock are the address of the current solver.
-    // The 161st bit represents whether the solver has called back via `reconcile`.
-    // The 162nd bit represents whether the solver's outstanding debt has been repaid via `reconcile`.
-    uint256 internal constant _SOLVER_CALLED_BACK_MASK = 1 << 161;
-    uint256 internal constant _SOLVER_FULFILLED_MASK = 1 << 162;
 
     constructor(
         uint256 _escrowDuration,

--- a/src/contracts/atlas/Storage.sol
+++ b/src/contracts/atlas/Storage.sol
@@ -5,11 +5,12 @@ import "src/contracts/types/EscrowTypes.sol";
 import "src/contracts/types/LockTypes.sol";
 import { AtlasEvents } from "src/contracts/types/AtlasEvents.sol";
 import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
+import { AtlasConstants } from "src/contracts/types/AtlasConstants.sol";
 
 /// @title Storage
 /// @author FastLane Labs
 /// @notice Storage manages all storage variables and constants for the Atlas smart contract.
-contract Storage is AtlasEvents, AtlasErrors {
+contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
     // Atlas constants
     uint256 internal constant _GAS_USED_DECIMALS_TO_DROP = 1000;
     address internal constant _UNLOCKED = address(1);

--- a/src/contracts/types/AtlasConstants.sol
+++ b/src/contracts/types/AtlasConstants.sol
@@ -1,15 +1,55 @@
 //SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.22;
 
-// NOTE: Constants that are defined but not used in the logic of a smart contract, will not be included in the bytecode
-// of the smart contract when compiled.
-contract AtlasConstants {
-    // Atlas Constants
-    // TODO refactor constants to this file if we like this pattern
+// NOTE: Internal constants that are defined but not used in the logic of a smart contract, will NOT be included in the
+// bytecode of the smart contract when compiled. However, public constants will be included in every inheriting contract
+// as they are part of the ABI. As such, only internal constants are defined in this shared contract.
 
-    // AtlasVerification Constants
+contract AtlasConstants {
+    // ------------------------------------------------------- //
+    //                      ATLAS CONSTANTS                    //
+    // ------------------------------------------------------- //
+
+    // Atlas constants
+    uint256 internal constant _GAS_USED_DECIMALS_TO_DROP = 1000;
+    address internal constant _UNLOCKED = address(1);
+    uint256 internal constant _UNLOCKED_UINT = 1;
+
+    // Atlas constants used in `_bidFindingIteration()`
+    uint256 internal constant _BITS_FOR_INDEX = 16;
+
+    // Escrow constants
+    uint256 internal constant _VALIDATION_GAS_LIMIT = 500_000;
+    uint256 internal constant _SOLVER_GAS_LIMIT_BUFFER_PERCENTAGE = 5; // out of 100 = 5%
+    uint256 internal constant _SOLVER_GAS_LIMIT_SCALE = 100; // out of 100 = 100%
+    uint256 internal constant _FASTLANE_GAS_BUFFER = 125_000; // integer amount
+
+    // Gas Accounting constants
+    uint256 internal constant _CALLDATA_LENGTH_PREMIUM = 32; // 16 (default) * 2
+    uint256 internal constant _SOLVER_OP_BASE_CALLDATA = 608; // SolverOperation calldata length excluding solverOp.data
+    uint256 internal constant _SOLVER_LOCK_GAS_BUFFER = 5000; // Base gas charged to solver in `_releaseSolverLock()`
+
+    // First 160 bits of _solverLock are the address of the current solver.
+    // The 161st bit represents whether the solver has called back via `reconcile`.
+    // The 162nd bit represents whether the solver's outstanding debt has been repaid via `reconcile`.
+    uint256 internal constant _SOLVER_CALLED_BACK_MASK = 1 << 161;
+    uint256 internal constant _SOLVER_FULFILLED_MASK = 1 << 162;
+
+    // ------------------------------------------------------- //
+    //               ATLAS VERIFICATION CONSTANTS              //
+    // ------------------------------------------------------- //
+
+    uint256 internal constant _FULL_BITMAP = _FIRST_240_BITS_TRUE_MASK;
+    uint256 internal constant _NONCES_PER_BITMAP = 240;
     uint8 internal constant _MAX_SOLVERS = type(uint8).max - _CALL_COUNT_EXCL_SOLVER_CALLS;
 
-    // Shared Constants
+    // ------------------------------------------------------- //
+    //                     SHARED CONSTANTS                    //
+    // ------------------------------------------------------- //
+
+    uint256 internal constant _FIRST_240_BITS_TRUE_MASK =
+        uint256(0x0000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
+    uint256 internal constant _FIRST_16_BITS_TRUE_MASK = uint256(0xFFFF);
+    uint256 internal constant _FIRST_4_BITS_TRUE_MASK = uint256(0xF);
     uint8 internal constant _CALL_COUNT_EXCL_SOLVER_CALLS = 4;
 }

--- a/src/contracts/types/AtlasConstants.sol
+++ b/src/contracts/types/AtlasConstants.sol
@@ -1,0 +1,15 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.22;
+
+// NOTE: Constants that are defined but not used in the logic of a smart contract, will not be included in the bytecode
+// of the smart contract when compiled.
+contract AtlasConstants {
+    // Atlas Constants
+    // TODO refactor constants to this file if we like this pattern
+
+    // AtlasVerification Constants
+    uint8 internal constant _MAX_SOLVERS = type(uint8).max - _CALL_COUNT_EXCL_SOLVER_CALLS;
+
+    // Shared Constants
+    uint8 internal constant _CALL_COUNT_EXCL_SOLVER_CALLS = 4;
+}


### PR DESCRIPTION
Refactor constants to more cleanly achieve what I've outlined in [this comment](https://github.com/FastLane-Labs/atlas/pull/201#discussion_r1623381156) in https://github.com/FastLane-Labs/atlas/pull/201

Note: Only _internal_ constants can be shared contract-size-efficiently this way. _Public_ constants are part of the ABI, which means they would increase the size of every contract that inherits from the one in which they are defined. So we only define internal constants in the shared AtlasConstants.sol file. 