### PR TITLE
Return deficit amount from _assign function

### DIFF
--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -139,8 +139,8 @@ abstract contract GasAccounting is SafetyLocks {
     /// @param amount The amount of AtlETH to be taken.
     /// @param solverWon A boolean indicating whether the solver won the bid.
     /// @param bidFind Indicates if called in the context of `_getBidAmount` in Escrow.sol (true) or not (false).
-    /// @return isDeficit A boolean indicating whether there is a deficit after the assignment.
-    function _assign(address owner, uint256 amount, bool solverWon, bool bidFind) internal returns (bool isDeficit) {
+    /// @return deficit The amount of AtlETH that was not repaid, if any.
+    function _assign(address owner, uint256 amount, bool solverWon, bool bidFind) internal returns (uint256 deficit) {
         if (amount == 0) {
             accessData[owner].lastAccessedBlock = uint32(block.number); // still save on bidFind
         } else {
@@ -159,8 +159,8 @@ abstract contract GasAccounting is SafetyLocks {
                     // The unbonding balance is insufficient to cover the remaining amount owed. There is a deficit. Set
                     // both bonded and unbonding balances to 0 and adjust the "amount" variable to reflect the amount
                     // that was actually deducted.
-                    isDeficit = true;
                     amount = uint256(bData.unbonding + aData.bonded); // contribute less to deposits ledger
+                    deficit = uint256(amt) - amount;
                     _balanceOf[owner].unbonding = 0;
                     aData.bonded = 0;
                 } else {
@@ -281,8 +281,9 @@ abstract contract GasAccounting is SafetyLocks {
         if (_deposits < _claims + _withdrawals) {
             // CASE: in deficit, subtract from bonded balance
             uint256 amountOwed = _claims + _withdrawals - _deposits;
-            if (_assign(winningSolver, amountOwed, true, false)) {
-                revert InsufficientTotalBalance((_claims + _withdrawals) - deposits);
+            uint256 deficit = _assign(winningSolver, amountOwed, true, false);
+            if (deficit > 0) {
+                revert InsufficientTotalBalance(deficit);
             }
         } else {
             // CASE: in surplus, add to bonded balance

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -30,7 +30,7 @@ contract MockGasAccounting is GasAccounting, Test {
         _setAtlasLock(executionEnvironment, gasMarker, userOpValue);
     }
 
-    function assign(address owner, uint256 value, bool solverWon) external returns (bool) {
+    function assign(address owner, uint256 value, bool solverWon) external returns (uint256) {
         return _assign(owner, value, solverWon, false);
     }
 
@@ -185,7 +185,7 @@ contract GasAccountingTest is Test {
 
         bondedTotalSupplyBefore = mockGasAccounting.bondedTotalSupply();
         depositsBefore = mockGasAccounting.deposits();
-        assertFalse(mockGasAccounting.assign(solverOp.from, 0, true));
+        assertEq(mockGasAccounting.assign(solverOp.from, 0, true), 0);
         (, lastAccessedBlock,,,) = mockGasAccounting.accessData(solverOp.from);
         assertEq(lastAccessedBlock, uint32(block.number));
         assertEq(mockGasAccounting.bondedTotalSupply(), bondedTotalSupplyBefore);
@@ -193,7 +193,7 @@ contract GasAccountingTest is Test {
 
         bondedTotalSupplyBefore = mockGasAccounting.bondedTotalSupply();
         depositsBefore = mockGasAccounting.deposits();
-        assertTrue(mockGasAccounting.assign(solverOp.from, assignedAmount, true));
+        assertGt(mockGasAccounting.assign(solverOp.from, assignedAmount, true), 0);
         (, lastAccessedBlock,,,) = mockGasAccounting.accessData(solverOp.from);
         assertEq(lastAccessedBlock, uint32(block.number));
         assertEq(mockGasAccounting.bondedTotalSupply(), bondedTotalSupplyBefore);
@@ -207,7 +207,7 @@ contract GasAccountingTest is Test {
         mockGasAccounting.increaseUnbondingBalance(solverOp.from, unbondingAmount);
         bondedTotalSupplyBefore = mockGasAccounting.bondedTotalSupply();
         depositsBefore = mockGasAccounting.deposits();
-        assertFalse(mockGasAccounting.assign(solverOp.from, assignedAmount, true));
+        assertEq(mockGasAccounting.assign(solverOp.from, assignedAmount, true), 0);
         (, lastAccessedBlock,,,) = mockGasAccounting.accessData(solverOp.from);
         assertEq(lastAccessedBlock, uint32(block.number));
         assertEq(mockGasAccounting.bondedTotalSupply(), bondedTotalSupplyBefore - assignedAmount);
@@ -222,7 +222,7 @@ contract GasAccountingTest is Test {
         bondedTotalSupplyBefore = mockGasAccounting.bondedTotalSupply();
         depositsBefore = mockGasAccounting.deposits();
         (, uint112 unbondingBefore) = mockGasAccounting.balanceOf(solverOp.from);
-        assertFalse(mockGasAccounting.assign(solverOp.from, assignedAmount, true));
+        assertEq(mockGasAccounting.assign(solverOp.from, assignedAmount, true), 0);
         (, lastAccessedBlock,,,) = mockGasAccounting.accessData(solverOp.from);
         assertEq(lastAccessedBlock, uint32(block.number));
         assertEq(mockGasAccounting.bondedTotalSupply(), bondedTotalSupplyBefore - assignedAmount);

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -62,7 +62,7 @@ contract MockGasAccounting is GasAccounting, Test {
         bondedTotalSupply += amount;
     }
 
-    function calldataLengthPremium() external returns (uint256) {
+    function calldataLengthPremium() external pure returns (uint256) {
         return _CALLDATA_LENGTH_PREMIUM;
     }
 }


### PR DESCRIPTION
Related audit issue: https://github.com/spearbit-audits/review-fastlane/issues/126

Change the `_assign` function to return the deficit amount (which can be 0), instead of returning a boolean indicating if there is a deficit. In case of deficit, the `_settle` function will revert with the `InsufficientTotalBalance` error with the deficit amount returned by `_assign` as parameter, instead of calculating it. This improves code readability.