### PR TITLE
Increase withdrawals when crediting AtlETH

### DIFF
--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -204,6 +204,7 @@ abstract contract GasAccounting is SafetyLocks {
         _updateAnalytics(aData, 0, true, false);
 
         accessData[owner] = aData;
+        withdrawals += amount;
     }
 
     /// @notice Attempts to lock the solver's operation by borrowing AtlETH.

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -296,6 +296,7 @@ contract GasAccountingTest is Test {
         uint256 lastAccessedBlock;
 
         uint256 bondedTotalSupplyBefore = mockGasAccounting.bondedTotalSupply();
+        uint256 withdrawalsBefore = mockGasAccounting.withdrawals();
         (uint112 bondedBefore,,,,) = mockGasAccounting.accessData(solverOp.from);
         (, lastAccessedBlock,,,) = mockGasAccounting.accessData(solverOp.from);
         assertEq(lastAccessedBlock, 0);
@@ -308,6 +309,7 @@ contract GasAccountingTest is Test {
         assertEq(lastAccessedBlock, uint32(block.number));
         assertEq(mockGasAccounting.bondedTotalSupply(), bondedTotalSupplyBefore + creditedAmount);
         assertEq(bondedAfter, bondedBefore + uint112(creditedAmount));
+        assertEq(mockGasAccounting.withdrawals(), withdrawalsBefore + creditedAmount);
 
         // Testing uint112 boundary values for casting from uint256 to uint112 in _credit()
         uint256 overflowAmount = uint256(type(uint112).max) + 1;


### PR DESCRIPTION
Related audit issue: https://github.com/spearbit-audits/review-fastlane/issues/125

## Rationale
There is 3 variables holding accounting data.
**deposits**
- Initialized with the metacall msg.value
- Incremented by each contribution (`contribute()` calls)
- Incremented by the gas cost collected from solvers

**withdrawals**
- Initialized with userOp.value
- Incremented by each borrow (`borrow()` calls)

**claims**
- Initialized with the metacall expected gas consumption + a surcharge

The `_settle()` function is called as the very last step of a metacall. It checks that the accounting is balanced (`deposits` must be equal or greater than `withdrawals` + adjusted `claims`). If in deficit, it `_assign`s the winning solver to cover it, and revert if it can't. If in excess, it `_credit`s it to the winning solver.

`deposits` is updated by `_assign()`.
`withdrawals` is **not** updated by `_credit()`. <--- This is the audit issue's point

In the current flow, `_settle()` ensures the accounting is balanced, regardless of `deposits` or `withdrawals` being updated or not, we do not read those values anymore after the call. But if we update `deposits` when assigning, it only makes sense to also update `withdrawals` when crediting.

Another reason is the external call being made afterwards. We are transferring ETH to the bundler to reimburse them their gas spent, giving them control. The accounting variables must be up to date to prevent any sort of abuse. Hence, updating the `withdrawals` in the `credit()` function.