### PR TITLE
Refactor: VerificationSimFail error to use consistant type

### DIFF
--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -62,7 +62,7 @@ contract Atlas is Escrow, Factory {
             dConfig, userOp, solverOps, dAppOp, msg.value, msg.sender, isSimulation
         );
         if (validCallsResult != ValidCallsResult.Valid) {
-            if (isSimulation) revert VerificationSimFail(uint256(validCallsResult));
+            if (isSimulation) revert VerificationSimFail(validCallsResult);
             revert ValidCalls(validCallsResult);
         }
 

--- a/src/contracts/types/AtlasErrors.sol
+++ b/src/contracts/types/AtlasErrors.sol
@@ -29,7 +29,7 @@ contract AtlasErrors {
     error PostSolverFailed();
     error InsufficientEscrow();
 
-    error VerificationSimFail(uint256 validCallsResult);
+    error VerificationSimFail(ValidCallsResult);
     error PreOpsSimFail();
     error UserOpSimFail();
     error SolverSimFail(uint256 solverOutcomeResult); // uint param is result returned in `verifySolverOp`


### PR DESCRIPTION
addresses issue https://github.com/spearbit-audits/review-fastlane/issues/16

The [`VerificationSimFail`](https://github.com/FastLane-Labs/atlas/blob/551eb4f637f6f10121f7cf108f4266f952861101/src/contracts/types/AtlasErrors.sol#L32) error in `AtlasErrors.sol` used a `uint256` parameter, while the [`ValidCalls`](https://github.com/FastLane-Labs/atlas/blob/551eb4f637f6f10121f7cf108f4266f952861101/src/contracts/types/AtlasErrors.sol#L37) error used a `ValidCallsResult` parameter. It was recommended making these consistent.

Changes include:
- Updating `VerificationSimFail` to use `ValidCallsResult` instead of `uint256`.
- Modifying the `metacall` function in `Atlas.sol` to use [`ValidCallsResult`](https://github.com/FastLane-Labs/atlas/blob/551eb4f637f6f10121f7cf108f4266f952861101/src/contracts/atlas/Atlas.sol#L63) directly without casting.

All tests passing. 2 lines changed.
