### PR TITLE
Separate storage for user and dApp nonces

### DIFF
--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -401,7 +401,7 @@ contract AtlasVerification is EIP712, DAppIntegration, AtlasConstants {
         returns (bool validNonce)
     {
         NonceTracker memory nonceTracker = userNonceTrackers[user];
-        (validNonce, nonceTracker) = _handleNonces(nonceTracker, user, true, nonce, sequential);
+        validNonce = _handleNonces(nonceTracker, user, true, nonce, sequential);
         if (validNonce && !isSimulation) {
             // Update storage only if valid and not in simulation
             userNonceTrackers[user] = nonceTracker;
@@ -425,7 +425,7 @@ contract AtlasVerification is EIP712, DAppIntegration, AtlasConstants {
         returns (bool validNonce)
     {
         NonceTracker memory nonceTracker = dAppNonceTrackers[dAppSignatory];
-        (validNonce, nonceTracker) = _handleNonces(nonceTracker, dAppSignatory, false, nonce, sequential);
+        validNonce = _handleNonces(nonceTracker, dAppSignatory, false, nonce, sequential);
         if (validNonce && !isSimulation) {
             // Update storage only if valid and not in simulation
             dAppNonceTrackers[dAppSignatory] = nonceTracker;
@@ -449,20 +449,20 @@ contract AtlasVerification is EIP712, DAppIntegration, AtlasConstants {
         bool sequential
     )
         internal
-        returns (bool, NonceTracker memory)
+        returns (bool)
     {
         if (nonce > type(uint128).max - 1) {
-            return (false, nonceTracker);
+            return false;
         }
 
         // 0 Nonces are not allowed. Nonces start at 1 for both sequential and non-sequential.
-        if (nonce == 0) return (false, nonceTracker);
+        if (nonce == 0) return false;
 
         if (sequential) {
             // SEQUENTIAL NONCES
 
             // Nonces must increase by 1 if sequential
-            if (nonce != nonceTracker.lastUsedSeqNonce + 1) return (false, nonceTracker);
+            if (nonce != nonceTracker.lastUsedSeqNonce + 1) return false;
 
             ++nonceTracker.lastUsedSeqNonce;
         } else {
@@ -484,7 +484,7 @@ contract AtlasVerification is EIP712, DAppIntegration, AtlasConstants {
 
             // Check if nonce has already been used
             if (_nonceUsedInBitmap(bitmap, bitmapNonce)) {
-                return (false, nonceTracker);
+                return false;
             }
 
             // Mark nonce as used in bitmap
@@ -508,7 +508,7 @@ contract AtlasVerification is EIP712, DAppIntegration, AtlasConstants {
             nonceBitmaps[bitmapKey] = nonceBitmap;
         }
 
-        return (true, nonceTracker);
+        return true;
     }
 
     /// @notice Increments the `highestFullNonSeqBitmap` of a given `nonceTracker` for the specified `account` until a

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -440,7 +440,6 @@ contract AtlasVerification is EIP712, DAppIntegration, AtlasConstants {
     /// @param nonce The nonce to verify.
     /// @param sequential A boolean indicating if the nonce mode is sequential (true) or not (false)
     /// @return A boolean indicating if the nonce is valid.
-    /// @return The updated NonceTracker.
     function _handleNonces(
         NonceTracker memory nonceTracker,
         address account,

--- a/src/contracts/atlas/DAppIntegration.sol
+++ b/src/contracts/atlas/DAppIntegration.sol
@@ -26,7 +26,8 @@ contract DAppIntegration {
     address public immutable ATLAS;
 
     // from => nonceTracker
-    mapping(address => NonceTracker) public nonceTrackers;
+    mapping(address => NonceTracker) public userNonceTrackers;
+    mapping(address => NonceTracker) public dAppNonceTrackers;
 
     // keccak256(from, bitmapNonceIndex) => nonceBitmap
     mapping(bytes32 => NonceBitmap) public nonceBitmaps;

--- a/src/contracts/atlas/DAppIntegration.sol
+++ b/src/contracts/atlas/DAppIntegration.sol
@@ -29,7 +29,7 @@ contract DAppIntegration {
     mapping(address => NonceTracker) public userNonceTrackers;
     mapping(address => NonceTracker) public dAppNonceTrackers;
 
-    // keccak256(from, bitmapNonceIndex) => nonceBitmap
+    // keccak256(from, isUser, bitmapNonceIndex) => nonceBitmap
     mapping(bytes32 => NonceBitmap) public nonceBitmaps;
 
     // NOTE: To prevent builder censorship, dApp nonces can be

--- a/src/contracts/helpers/TxBuilder.sol
+++ b/src/contracts/helpers/TxBuilder.sol
@@ -35,16 +35,17 @@ contract TxBuilder {
 
     function governanceNextNonce(address signatory) public view returns (uint256) {
         // Assume userNoncesSequential = false if control is not set
-        if (control == address(0)) return IAtlasVerification(verification).getNextNonce(signatory, false);
-        return IAtlasVerification(verification).getNextNonce(
+        if (control == address(0)) return IAtlasVerification(verification).getDAppNextNonce(signatory, false);
+        return IAtlasVerification(verification).getDAppNextNonce(
             signatory, IDAppControl(control).requireSequentialDAppNonces()
         );
     }
 
     function userNextNonce(address user) public view returns (uint256) {
         // Assume userNoncesSequential = false if control is not set
-        if (control == address(0)) return IAtlasVerification(verification).getNextNonce(user, false);
-        return IAtlasVerification(verification).getNextNonce(user, IDAppControl(control).requireSequentialUserNonces());
+        if (control == address(0)) return IAtlasVerification(verification).getUserNextNonce(user, false);
+        return
+            IAtlasVerification(verification).getUserNextNonce(user, IDAppControl(control).requireSequentialUserNonces());
     }
 
     function getControlCodeHash(address dAppControl) external view returns (bytes32) {

--- a/src/contracts/interfaces/IAtlasVerification.sol
+++ b/src/contracts/interfaces/IAtlasVerification.sol
@@ -33,7 +33,9 @@ interface IAtlasVerification {
     function getUserOperationPayload(UserOperation memory userOp) external view returns (bytes32 payload);
     function getSolverPayload(SolverOperation calldata solverOp) external view returns (bytes32 payload);
     function getDAppOperationPayload(DAppOperation memory dAppOp) external view returns (bytes32 payload);
-    function getNextNonce(address account, bool sequential) external view returns (uint256 nextNonce);
+
+    function getUserNextNonce(address user, bool sequential) external view returns (uint256 nextNonce);
+    function getDAppNextNonce(address dApp, bool sequential) external view returns (uint256 nextNonce);
 
     function initializeGovernance(address control) external;
     function addSignatory(address control, address signatory) external;

--- a/test/AtlasVerificationNonces.t.sol
+++ b/test/AtlasVerificationNonces.t.sol
@@ -14,20 +14,20 @@ contract AtlasVerificationNoncesTest is AtlasVerificationBase {
 
     function testGetNextNonceReturnsOneForNewAccount_Sequential() public {
         defaultAtlasWithCallConfig(defaultCallConfig().withUserNoncesSequential(true).build());
-        assertEq(atlasVerification.getNextNonce(userEOA, true), 1, "User seq next nonce should be 1");
-        assertEq(atlasVerification.getNextNonce(governanceEOA, true), 1, "Gov seq next nonce should be 1");
+        assertEq(atlasVerification.getUserNextNonce(userEOA, true), 1, "User seq next nonce should be 1");
+        assertEq(atlasVerification.getDAppNextNonce(governanceEOA, true), 1, "Gov seq next nonce should be 1");
     }
 
     function testGetNextNonceReturnsOneForNewAccount_NonSeq() public {
         defaultAtlasWithCallConfig(defaultCallConfig().withUserNoncesSequential(false).build());
-        assertEq(atlasVerification.getNextNonce(userEOA, false), 1, "User non-seq next nonce should be 1");
-        assertEq(atlasVerification.getNextNonce(governanceEOA, false), 1, "Gov non-seq next nonce should be 1");
+        assertEq(atlasVerification.getUserNextNonce(userEOA, false), 1, "User non-seq next nonce should be 1");
+        assertEq(atlasVerification.getDAppNextNonce(governanceEOA, false), 1, "Gov non-seq next nonce should be 1");
     }
 
     function testUsingSeqNoncesDoNotChangeNextNonSeqNonce() public {
         defaultAtlasWithCallConfig(defaultCallConfig().withUserNoncesSequential(true).build());
-        assertEq(atlasVerification.getNextNonce(userEOA, true), 1, "User next seq nonce should be 1");
-        assertEq(atlasVerification.getNextNonce(userEOA, false), 1, "User next non-seq nonce should be 1");
+        assertEq(atlasVerification.getUserNextNonce(userEOA, true), 1, "User next seq nonce should be 1");
+        assertEq(atlasVerification.getUserNextNonce(userEOA, false), 1, "User next non-seq nonce should be 1");
 
         UserOperation memory userOp = validUserOperation().withNonce(1).build();
         SolverOperation[] memory solverOps = validSolverOperations(userOp);
@@ -35,14 +35,14 @@ contract AtlasVerificationNoncesTest is AtlasVerificationBase {
         doValidateCalls(AtlasVerificationBase.ValidCallsCall({
             userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
         ));
-        assertEq(atlasVerification.getNextNonce(userEOA, true), 2, "User next seq nonce should now be 2");
-        assertEq(atlasVerification.getNextNonce(userEOA, false), 1, "User next non-seq nonce should still be 1");
+        assertEq(atlasVerification.getUserNextNonce(userEOA, true), 2, "User next seq nonce should now be 2");
+        assertEq(atlasVerification.getUserNextNonce(userEOA, false), 1, "User next non-seq nonce should still be 1");
     }
 
     function testUsingNonSeqNoncesDoNotChangeNextSeqNonce() public {
         defaultAtlasWithCallConfig(defaultCallConfig().withUserNoncesSequential(false).build());
-        assertEq(atlasVerification.getNextNonce(userEOA, true), 1, "User next seq nonce should be 1");
-        assertEq(atlasVerification.getNextNonce(userEOA, false), 1, "User next non-seq nonce should be 1");
+        assertEq(atlasVerification.getUserNextNonce(userEOA, true), 1, "User next seq nonce should be 1");
+        assertEq(atlasVerification.getUserNextNonce(userEOA, false), 1, "User next non-seq nonce should be 1");
 
         UserOperation memory userOp = validUserOperation().withNonce(1).build();
         SolverOperation[] memory solverOps = validSolverOperations(userOp);
@@ -50,8 +50,8 @@ contract AtlasVerificationNoncesTest is AtlasVerificationBase {
         doValidateCalls(AtlasVerificationBase.ValidCallsCall({
             userOp: userOp, solverOps: solverOps, dAppOp: dappOp, msgValue: 0, msgSender: userEOA, isSimulation: false}
         ));
-        assertEq(atlasVerification.getNextNonce(userEOA, true), 1, "User next seq nonce should still be 1");
-        assertEq(atlasVerification.getNextNonce(userEOA, false), 2, "User next non-seq nonce should now be 2");
+        assertEq(atlasVerification.getUserNextNonce(userEOA, true), 1, "User next seq nonce should still be 1");
+        assertEq(atlasVerification.getUserNextNonce(userEOA, false), 2, "User next non-seq nonce should now be 2");
     }
 
     function testSameNonceCannotBeUsedTwice_UserSequential_DAppNonSeq() public {
@@ -210,7 +210,7 @@ contract AtlasVerificationNoncesTest is AtlasVerificationBase {
 
         // Testing nonces 2 - 8
         for (uint256 i = 2; i < 9; i++) {
-            assertEq(atlasVerification.getNextNonce(governanceEOA, true), i, "Next nonce not incrementing as expected");
+            assertEq(atlasVerification.getDAppNextNonce(governanceEOA, true), i, "Next nonce not incrementing as expected");
             
             userOp = validUserOperation().withNonce(i).build();
             solverOps = validSolverOperations(userOp);
@@ -220,7 +220,7 @@ contract AtlasVerificationNoncesTest is AtlasVerificationBase {
             ), ValidCallsResult.Valid);
         }
 
-        assertEq(atlasVerification.getNextNonce(governanceEOA, true), 9, "Next nonce should be 9 after 8 seq nonces used");
+        assertEq(atlasVerification.getDAppNextNonce(governanceEOA, true), 9, "Next nonce should be 9 after 8 seq nonces used");
     }
 
     function testHighestFullBitmapIncreasesWhenFilled_NonSeq() public {
@@ -245,11 +245,11 @@ contract AtlasVerificationNoncesTest is AtlasVerificationBase {
         vm.store(address(atlasVerification), reads[0], bytes32(nonceBitmapSlot));
         
         // Check storage slot has been modified correctly
-        (, highestFullBitmap) = atlasVerification.nonceTrackers(userEOA);
+        (, highestFullBitmap) = atlasVerification.userNonceTrackers(userEOA);
         assertEq(highestFullBitmap, 0, "Highest full bitmap should 0 if 239 nonces used");
         (highestUsedNonce,) = atlasVerification.nonceBitmaps(bitmapKey);
         assertEq(highestUsedNonce, noncesUsed, "Highest used nonce should be 239");
-        assertEq(atlasVerification.getNextNonce(userEOA, false), 240, "Next nonce should be 240 if 239 nonces used");
+        assertEq(atlasVerification.getUserNextNonce(userEOA, false), 240, "Next nonce should be 240 if 239 nonces used");
 
         // Testing nonce 240
         UserOperation memory userOp = validUserOperation().withNonce(240).build();
@@ -260,9 +260,9 @@ contract AtlasVerificationNoncesTest is AtlasVerificationBase {
         ), ValidCallsResult.Valid);
 
         // The next recommended non-seq nonce should be 241 and the highest full bitmap should have increased from 0 to 1
-        (, highestFullBitmap) = atlasVerification.nonceTrackers(userEOA);
+        (, highestFullBitmap) = atlasVerification.userNonceTrackers(userEOA);
         assertEq(highestFullBitmap, 1, "Highest full bitmap should be 1 after 240 nonces used");
-        assertEq(atlasVerification.getNextNonce(userEOA, false), 241, "Next nonce should be 241 after 240 nonces used");
+        assertEq(atlasVerification.getUserNextNonce(userEOA, false), 241, "Next nonce should be 241 after 240 nonces used");
     }
 
     function testGetFirstUnusedNonceInBitmap() public {
@@ -333,7 +333,7 @@ contract AtlasVerificationNoncesTest is AtlasVerificationBase {
         vm.store(address(atlasVerification), reads[1], bytes32(almostFullBitmapSlot));
 
         // Check highestFullNonSeqBitmap is still 0
-        (, highestFullBitmap) = atlasVerification.nonceTrackers(userEOA);
+        (, highestFullBitmap) = atlasVerification.userNonceTrackers(userEOA);
         assertEq(highestFullBitmap, 0, "Highest full bitmap should 0 if 239 nonces used");
 
         // Now use nonce 240, which should set highestFullNonSeqBitmap to 1
@@ -345,11 +345,11 @@ contract AtlasVerificationNoncesTest is AtlasVerificationBase {
         ), ValidCallsResult.Valid);
 
         // Check highestFullNonSeqBitmap is now 1
-        (, highestFullBitmap) = atlasVerification.nonceTrackers(userEOA);
+        (, highestFullBitmap) = atlasVerification.userNonceTrackers(userEOA);
         assertEq(highestFullBitmap, 1, "Highest full bitmap value should be 1");
 
         // getNextNonce should return 480 = (240 used in slot 1 + 239 used in slot 2)
-        assertEq(atlasVerification.getNextNonce(userEOA, false), 480, "Next unused nonce should be 480");
+        assertEq(atlasVerification.getUserNextNonce(userEOA, false), 480, "Next unused nonce should be 480");
 
         // Now use nonce 480, which should full bitmap 2 and set highest bitmap to the next consecutive full bitmap (4)
         userOp = validUserOperation().withNonce(480).build();
@@ -360,20 +360,20 @@ contract AtlasVerificationNoncesTest is AtlasVerificationBase {
         ), ValidCallsResult.Valid);
 
         // Check highestFullNonSeqBitmap is now 4
-        (, highestFullBitmap) = atlasVerification.nonceTrackers(userEOA);
+        (, highestFullBitmap) = atlasVerification.userNonceTrackers(userEOA);
         assertEq(highestFullBitmap, 4, "Highest full bitmap value should be 4");
 
         // getNextNonce should return the correct next nonce = 240 * 4 + 1 = 961
-        assertEq(atlasVerification.getNextNonce(userEOA, false), 961, "Next unused nonce should be 961");
+        assertEq(atlasVerification.getUserNextNonce(userEOA, false), 961, "Next unused nonce should be 961");
 
         // MAIN PART OF TEST: Call manuallyUpdateNonSeqNonceTracker to set highestFullNonSeqBitmap to 4
         vm.prank(userEOA);
-        atlasVerification.manuallyUpdateNonSeqNonceTracker();
+        atlasVerification.manuallyUpdateUserNonSeqNonceTracker();
 
         // Check highestFullNonSeqBitmap is now 4 and getNextNonce returns 240 * 4 + 1 = 961
-        (, highestFullBitmap) = atlasVerification.nonceTrackers(userEOA);
+        (, highestFullBitmap) = atlasVerification.userNonceTrackers(userEOA);
         assertEq(highestFullBitmap, 4, "Highest full bitmap should be 4 after manually updating");
-        assertEq(atlasVerification.getNextNonce(userEOA, false), 961, "Next unused nonce should be 961");
+        assertEq(atlasVerification.getUserNextNonce(userEOA, false), 961, "Next unused nonce should be 961");
     }
 
     function testManuallyUpdateNonceTracker() public {
@@ -402,19 +402,19 @@ contract AtlasVerificationNoncesTest is AtlasVerificationBase {
         vm.store(address(atlasVerification), reads[3], bytes32(fullBitmapSlot));
 
         // Check highestFullNonSeqBitmap is still 0
-        (, highestFullBitmap) = atlasVerification.nonceTrackers(userEOA);
+        (, highestFullBitmap) = atlasVerification.userNonceTrackers(userEOA);
         assertEq(highestFullBitmap, 0, "Highest full bitmap should 0 because not updated yet");
 
         // MAIN PART OF TEST: Call manuallyUpdateNonSeqNonceTracker to update highestFullNonSeqBitmap to 4
         vm.prank(userEOA);
-        atlasVerification.manuallyUpdateNonSeqNonceTracker();
+        atlasVerification.manuallyUpdateUserNonSeqNonceTracker();
 
         // Check highestFullNonSeqBitmap is now 4
-        (, highestFullBitmap) = atlasVerification.nonceTrackers(userEOA);
+        (, highestFullBitmap) = atlasVerification.userNonceTrackers(userEOA);
         assertEq(highestFullBitmap, 4, "Highest full bitmap should be 4 after manually updating");
 
         // getNextNonce should return 240 * 4 + 1 = 961
-        assertEq(atlasVerification.getNextNonce(userEOA, false), 961, "Next unused nonce should be 961");
+        assertEq(atlasVerification.getUserNextNonce(userEOA, false), 961, "Next unused nonce should be 961");
     }
 }
 

--- a/test/AtlasVerificationNonces.t.sol
+++ b/test/AtlasVerificationNonces.t.sol
@@ -233,7 +233,7 @@ contract AtlasVerificationNoncesTest is AtlasVerificationBase {
         uint256 bitmap = (2 ** noncesUsed - 1) << 8;
         uint256 highestUsedNonceInBitmap = uint256(noncesUsed);
         uint256 nonceBitmapSlot = highestUsedNonceInBitmap | bitmap;
-        bytes32 bitmapKey = keccak256(abi.encode(userEOA, 1));
+        bytes32 bitmapKey = keccak256(abi.encode(userEOA, true, 1));
 
         // Only concerned with non-seq user nonces in this test
         defaultAtlasWithCallConfig(defaultCallConfig().withUserNoncesSequential(false).withDappNoncesSequential(true).build());
@@ -308,10 +308,10 @@ contract AtlasVerificationNoncesTest is AtlasVerificationBase {
         uint256 almostFullBitmapSlot = uint256(239) | (uint256(type(uint240).max - (2 ** 239)) << 8);
         uint256 fullBitmapSlot = uint256(240) | (uint256(type(uint240).max) << 8);
 
-        bytes32 bitmap1Key = keccak256(abi.encode(userEOA, 1));
-        bytes32 bitmap2Key = keccak256(abi.encode(userEOA, 2));
-        bytes32 bitmap3Key = keccak256(abi.encode(userEOA, 3));
-        bytes32 bitmap4Key = keccak256(abi.encode(userEOA, 4));
+        bytes32 bitmap1Key = keccak256(abi.encode(userEOA, true, 1));
+        bytes32 bitmap2Key = keccak256(abi.encode(userEOA, true, 2));
+        bytes32 bitmap3Key = keccak256(abi.encode(userEOA, true, 3));
+        bytes32 bitmap4Key = keccak256(abi.encode(userEOA, true, 4));
 
         // Only concerned with non-seq user nonces in this test
         defaultAtlasWithCallConfig(defaultCallConfig().withUserNoncesSequential(false).withDappNoncesSequential(true).build());
@@ -381,10 +381,10 @@ contract AtlasVerificationNoncesTest is AtlasVerificationBase {
         uint8 highestUsedNonce;
 
         uint256 fullBitmapSlot = uint256(240) | (uint256(type(uint240).max) << 8);
-        bytes32 bitmap1Key = keccak256(abi.encode(userEOA, 1));
-        bytes32 bitmap2Key = keccak256(abi.encode(userEOA, 2));
-        bytes32 bitmap3Key = keccak256(abi.encode(userEOA, 3));
-        bytes32 bitmap4Key = keccak256(abi.encode(userEOA, 4));
+        bytes32 bitmap1Key = keccak256(abi.encode(userEOA, true, 1));
+        bytes32 bitmap2Key = keccak256(abi.encode(userEOA, true, 2));
+        bytes32 bitmap3Key = keccak256(abi.encode(userEOA, true, 3));
+        bytes32 bitmap4Key = keccak256(abi.encode(userEOA, true, 4));
 
         // Only concerned with non-seq user nonces in this test
         defaultAtlasWithCallConfig(defaultCallConfig().withUserNoncesSequential(false).withDappNoncesSequential(true).build());

--- a/test/base/builders/DAppOperationBuilder.sol
+++ b/test/base/builders/DAppOperationBuilder.sol
@@ -36,7 +36,7 @@ contract DAppOperationBuilder is Test {
 
     function withNonce(address atlasVerification, address account) public returns (DAppOperationBuilder) {
         // Assumes dappNoncesSequential = false. Use withNonce(address, address, bool) to specify sequential or not.
-        dappOperation.nonce = IAtlasVerification(atlasVerification).getNextNonce(account, false);
+        dappOperation.nonce = IAtlasVerification(atlasVerification).getDAppNextNonce(account, false);
         return this;
     }
 
@@ -48,7 +48,7 @@ contract DAppOperationBuilder is Test {
         public
         returns (DAppOperationBuilder)
     {
-        dappOperation.nonce = IAtlasVerification(atlasVerification).getNextNonce(account, sequential);
+        dappOperation.nonce = IAtlasVerification(atlasVerification).getDAppNextNonce(account, sequential);
         return this;
     }
 
@@ -116,7 +116,7 @@ contract DAppOperationBuilder is Test {
         return this;
     }
 
-    function build() public returns (DAppOperation memory) {
+    function build() public view returns (DAppOperation memory) {
         return dappOperation;
     }
 

--- a/test/base/builders/UserOperationBuilder.sol
+++ b/test/base/builders/UserOperationBuilder.sol
@@ -46,18 +46,18 @@ contract UserOperationBuilder is Test {
 
     function withNonce(address atlasVerification) public returns (UserOperationBuilder) {
         // Assumes sequential = false. Use withNonce(address, bool) to specify sequential.
-        userOperation.nonce = IAtlasVerification(atlasVerification).getNextNonce(userOperation.from, false);
+        userOperation.nonce = IAtlasVerification(atlasVerification).getUserNextNonce(userOperation.from, false);
         return this;
     }
 
     function withNonce(address atlasVerification, bool sequential) public returns (UserOperationBuilder) {
-        userOperation.nonce = IAtlasVerification(atlasVerification).getNextNonce(userOperation.from, sequential);
+        userOperation.nonce = IAtlasVerification(atlasVerification).getUserNextNonce(userOperation.from, sequential);
         return this;
     }
 
     function withNonce(address atlasVerification, address account) public returns (UserOperationBuilder) {
         // Assumes sequential = false. Use withNonce(address, address, bool) to specify sequential.
-        userOperation.nonce = IAtlasVerification(atlasVerification).getNextNonce(account, false);
+        userOperation.nonce = IAtlasVerification(atlasVerification).getUserNextNonce(account, false);
         return this;
     }
 
@@ -69,7 +69,7 @@ contract UserOperationBuilder is Test {
         public
         returns (UserOperationBuilder)
     {
-        userOperation.nonce = IAtlasVerification(atlasVerification).getNextNonce(account, sequential);
+        userOperation.nonce = IAtlasVerification(atlasVerification).getUserNextNonce(account, sequential);
         return this;
     }
 
@@ -120,7 +120,7 @@ contract UserOperationBuilder is Test {
         return this;
     }
 
-    function build() public returns (UserOperation memory) {
+    function build() public view returns (UserOperation memory) {
         return userOperation;
     }
 


### PR DESCRIPTION
Related audit issue: https://github.com/spearbit-audits/review-fastlane/issues/155

Separate storage for user and dApp nonces + updated tests.