### PR TITLE
Pass `ctx` struct by reference

### DIFF
--- a/test/Atlas.t.sol
+++ b/test/Atlas.t.sol
@@ -147,6 +147,7 @@ contract MockAtlas is Atlas {
         bytes memory returnData,
         Context memory ctx
     ) public returns (Context memory) {
-        return _bidFindingIteration(ctx, dConfig, userOp, solverOps, returnData);
+        _bidFindingIteration(ctx, dConfig, userOp, solverOps, returnData);
+        return ctx;
     }
 }

--- a/test/OEV.t.sol
+++ b/test/OEV.t.sol
@@ -110,7 +110,7 @@ contract OEVTest is BaseTest {
     //                  Full OEV Capture Test               //
     // ---------------------------------------------------- //
 
-    function testChainlinkOEV_StandardVersion() public {
+    function testChainlinkOEV_StandardVersion_GasCheck() public {
         UserOperation memory userOp;
         SolverOperation[] memory solverOps = new SolverOperation[](1);
         DAppOperation memory dAppOp;
@@ -185,7 +185,7 @@ contract OEVTest is BaseTest {
         vm.prank(userEOA);
         atlas.metacall({ userOp: userOp, solverOps: solverOps, dAppOp: dAppOp });
 
-        console.log("OEV Metacall Gas Cost:", gasLeftBefore - gasleft());
+        console.log("Metacall Gas Cost:", gasLeftBefore - gasleft());
 
         assertEq(uint(chainlinkAtlasWrapper.latestAnswer()), targetOracleAnswer, "Wrapper did not update as expected");
         assertTrue(uint(chainlinkAtlasWrapper.latestAnswer()) != uint(AggregatorV2V3Interface(chainlinkETHUSD).latestAnswer()), "Wrapper and base feed should report different answers");

--- a/test/SwapIntent.t.sol
+++ b/test/SwapIntent.t.sol
@@ -69,7 +69,7 @@ contract SwapIntentTest is BaseTest {
         // atlas.deposit{value: 1e18}();
     }
 
-    function testAtlasSwapIntentWithBasicRFQ() public {
+    function testAtlasSwapIntentWithBasicRFQ_GasCheck() public {
         // Swap 10 WETH for 20 DAI
         UserCondition userCondition = new UserCondition();
 
@@ -192,7 +192,7 @@ contract SwapIntentTest is BaseTest {
 
         atlas.metacall({ userOp: userOp, solverOps: solverOps, dAppOp: dAppOp });
 
-        console.log("OEV Metacall Gas Cost:", gasLeftBefore - gasleft());
+        console.log("Metacall Gas Cost:", gasLeftBefore - gasleft());
         vm.stopPrank();
 
         console.log("\nAFTER METACALL");


### PR DESCRIPTION
Resolves this audit issue: https://github.com/spearbit-audits/review-fastlane/issues/49

| Metric       | Before  | After   | Change   |
|--------------|---------|---------|----------|
| SwapIntent Tx (gas)   | 498,590 | 497,295 | -1,295   |
| OEV Tx (gas)         | 540,886 | 539,560 | -1,326   |
| Atlas Size (bytes)        | 25,461  | 25,304  | -157     |
