### PR TITLE
Invert bid value example

### DIFF
--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -233,7 +233,7 @@ contract AtlasVerification is EIP712, DAppIntegration, AtlasConstants {
     /// @return The result of the ValidCalls check, in enum ValidCallsResult form.
     function _verifyCallConfig(uint32 callConfig) internal pure returns (ValidCallsResult) {
         CallConfig memory decodedCallConfig = CallBits.decodeCallConfig(callConfig);
-         if (decodedCallConfig.userNoncesSequential && decodedCallConfig.dappNoncesSequential) {
+        if (decodedCallConfig.userNoncesSequential && decodedCallConfig.dappNoncesSequential) {
             // Max one of user or dapp nonces can be sequential, not both
             return ValidCallsResult.BothUserAndDAppNoncesCannotBeSequential;
         }

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -136,6 +136,12 @@ contract AtlasVerification is EIP712, DAppIntegration, AtlasConstants {
             }
         }
 
+        // Check if the call configuration is valid
+        ValidCallsResult verifyCallConfigResult = _verifyCallConfig(dConfig.callConfig);
+        if (verifyCallConfigResult != ValidCallsResult.Valid) {
+            return (userOpHash, verifyCallConfigResult);
+        }
+
         // CASE: Solvers trust app to update content of UserOp after submission of solverOp
         if (dConfig.callConfig.allowsTrustedOpHash()) {
             userOpHash = userOp.getAltOperationHash();
@@ -220,6 +226,22 @@ contract AtlasVerification is EIP712, DAppIntegration, AtlasConstants {
             // No refund
             result |= (1 << uint256(SolverOutcome.InvalidSignature));
         }
+    }
+
+    /// @notice The _verifyCallConfig internal function verifies the validity of the call configuration.
+    /// @param callConfig The call configuration to verify.
+    /// @return The result of the ValidCalls check, in enum ValidCallsResult form.
+    function _verifyCallConfig(uint32 callConfig) internal pure returns (ValidCallsResult) {
+        CallConfig memory decodedCallConfig = CallBits.decodeCallConfig(callConfig);
+         if (decodedCallConfig.userNoncesSequential && decodedCallConfig.dappNoncesSequential) {
+            // Max one of user or dapp nonces can be sequential, not both
+            return ValidCallsResult.BothUserAndDAppNoncesCannotBeSequential;
+        }
+        if (decodedCallConfig.invertBidValue && decodedCallConfig.exPostBids) {
+            // If both invertBidValue and exPostBids are true, solver's retreived bid cannot be determined
+            return ValidCallsResult.InvertBidValueCannotBeExPostBids;
+        }
+        return ValidCallsResult.Valid;
     }
 
     /// @notice The _verifyAuctioneer internal function is called by _validCalls to verify that the auctioneer of the

--- a/src/contracts/dapp/DAppControl.sol
+++ b/src/contracts/dapp/DAppControl.sol
@@ -34,6 +34,10 @@ abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
             // Max one of user or dapp nonces can be sequential, not both
             revert AtlasErrors.BothUserAndDAppNoncesCannotBeSequential();
         }
+        if (_callConfig.invertBidValue && _callConfig.exPostBids) {
+            // If both invertBidValue and exPostBids are true, solver's retreived bid cannot be determined
+            revert AtlasErrors.InvertBidValueCannotBeExPostBids();
+        }
         CALL_CONFIG = CallBits.encodeCallConfig(_callConfig);
         CONTROL = address(this);
         ATLAS_VERIFICATION = IAtlas(_atlas).VERIFICATION();

--- a/src/contracts/examples/intents-example/SwapIntentInvertBidDAppControl.sol
+++ b/src/contracts/examples/intents-example/SwapIntentInvertBidDAppControl.sol
@@ -36,7 +36,9 @@ struct SwapIntent {
 contract SwapIntentInvertBidDAppControl is DAppControl {
     using SafeTransferLib for ERC20;
 
-    constructor(address _atlas)
+    bool _solverBidRetrievalRequired;
+
+    constructor(address _atlas, bool bidFind, bool solverBidRetrievalRequired)
         DAppControl(
             _atlas,
             msg.sender,
@@ -60,10 +62,12 @@ contract SwapIntentInvertBidDAppControl is DAppControl {
                 requireFulfillment: true,
                 trustedOpHash: true,
                 invertBidValue: true,
-                exPostBids: false
+                exPostBids: bidFind
             })
         )
-    { }
+    { 
+        _solverBidRetrievalRequired = solverBidRetrievalRequired;
+    }
 
     // ---------------------------------------------------- //
     //                       Custom                         //

--- a/src/contracts/examples/intents-example/SwapIntentInvertBidDAppControl.sol
+++ b/src/contracts/examples/intents-example/SwapIntentInvertBidDAppControl.sol
@@ -1,0 +1,180 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.16;
+
+// Base Imports
+import { SafeTransferLib, ERC20 } from "solmate/utils/SafeTransferLib.sol";
+
+// Atlas Base Imports
+import { IEscrow } from "../../interfaces/IEscrow.sol";
+
+import { CallConfig } from "../../types/DAppApprovalTypes.sol";
+import "../../types/UserCallTypes.sol";
+import "../../types/SolverCallTypes.sol";
+import "../../types/LockTypes.sol";
+
+// Atlas DApp-Control Imports
+import { DAppControl } from "../../dapp/DAppControl.sol";
+
+import "forge-std/Test.sol";
+
+/**
+ * @notice SwapIntent which wants exact amount of `tokenUserBuys` and is willing to sell up to `maxAmountUserSells` of
+ * `tokenUserSells` for it
+ */
+struct SwapIntent {
+    address tokenUserBuys;
+    address tokenUserSells;
+    uint256 amountUserBuys;
+    uint256 maxAmountUserSells;
+}
+
+/**
+ * @title SwapIntentInvertBidDAppControl
+ * @notice A DAppControl contract that allows a user to swap tokens with a solver using a `SwapIntent`
+ * @dev The invertBidValue flag is set to true
+ */
+contract SwapIntentInvertBidDAppControl is DAppControl {
+    using SafeTransferLib for ERC20;
+
+    constructor(address _atlas)
+        DAppControl(
+            _atlas,
+            msg.sender,
+            CallConfig({
+                userNoncesSequential: false,
+                dappNoncesSequential: false,
+                requirePreOps: false,
+                trackPreOpsReturnData: false,
+                trackUserReturnData: true,
+                delegateUser: true,
+                preSolver: true,
+                postSolver: true,
+                requirePostOps: false,
+                zeroSolvers: false,
+                reuseUserOp: true,
+                userAuctioneer: false,
+                solverAuctioneer: false,
+                unknownAuctioneer: false,
+                verifyCallChainHash: true,
+                forwardReturnData: false,
+                requireFulfillment: true,
+                trustedOpHash: true,
+                invertBidValue: true,
+                exPostBids: false
+            })
+        )
+    { }
+
+    // ---------------------------------------------------- //
+    //                       Custom                         //
+    // ---------------------------------------------------- //
+
+    /*
+    * @notice This is the user operation target function
+    * @dev This function is delegatecalled: msg.sender = Atlas, address(this) = ExecutionEnvironment
+    * @dev It checks that the user has approved Atlas to spend the tokens they are selling and the conditions are met
+    * @param swapIntent The SwapIntent struct
+    */
+    function swap(SwapIntent calldata swapIntent) external payable returns (SwapIntent memory) {
+        require(msg.sender == ATLAS, "SwapIntentDAppControl: InvalidSender");
+        require(_addressPointer() == CONTROL, "SwapIntentDAppControl: InvalidLockState");
+        require(address(this) != CONTROL, "SwapIntentDAppControl: MustBeDelegated");
+
+        address user = _user();
+
+        require(
+            _availableFundsERC20(
+                swapIntent.tokenUserSells, user, swapIntent.maxAmountUserSells, ExecutionPhase.PreSolver
+            ),
+            "SwapIntentDAppControl: SellFundsUnavailable"
+        );
+
+        return SwapIntent({
+            tokenUserBuys: swapIntent.tokenUserBuys,
+            tokenUserSells: swapIntent.tokenUserSells,
+            amountUserBuys: swapIntent.amountUserBuys,
+            maxAmountUserSells: swapIntent.maxAmountUserSells
+        });
+    }
+
+    // ---------------------------------------------------- //
+    //                     Atlas hooks                      //
+    // ---------------------------------------------------- //
+
+    /*
+    * @notice This function is called before a solver operation executes
+    * @dev This function is delegatecalled: msg.sender = Atlas, address(this) = ExecutionEnvironment
+    * @dev It transfers the tokens that the user is selling to the solver
+    * @param solverOp The SolverOperation that is about to execute
+    * @return true if the transfer was successful, false otherwise
+    */
+    function _preSolverCall(SolverOperation calldata solverOp, bytes calldata returnData) internal override {
+        address solverTo = solverOp.solver;
+        if (solverTo == address(this) || solverTo == _control() || solverTo == ATLAS) {
+            revert();
+        }
+
+        SwapIntent memory swapData = abi.decode(returnData, (SwapIntent));
+
+        // The solver must be bidding less than the intent's maxAmountUserSells
+        require(solverOp.bidAmount <= swapData.maxAmountUserSells, "SwapIntentInvertBid: BidTooHigh");
+
+        // Optimistically transfer to the solver contract the amount that the solver is invert bidding
+        _transferUserERC20(swapData.tokenUserSells, solverTo, solverOp.bidAmount);
+
+        return; // success
+    }
+
+    /*
+    * @notice This function is called after a solver operation executed
+    * @dev This function is delegatecalled: msg.sender = Atlas, address(this) = ExecutionEnvironment
+    * @dev It transfers to the user the tokens they are buying
+    * @param _
+    * @param returnData The return data from the user operation (swap data)
+    * @return true if the transfer was successful, false otherwise
+    */
+    function _postSolverCall(SolverOperation calldata, bytes calldata returnData) internal override {
+        SwapIntent memory swapIntent = abi.decode(returnData, (SwapIntent));
+        uint256 buyTokenBalance = ERC20(swapIntent.tokenUserBuys).balanceOf(address(this));
+
+        if (buyTokenBalance < swapIntent.amountUserBuys) {
+            revert();
+        }
+
+        // Transfer the tokens the user is buying to the user
+        ERC20(swapIntent.tokenUserBuys).safeTransfer(_user(), swapIntent.amountUserBuys);
+
+        return; // success
+    }
+
+    /*
+    * @notice This function is called after a solver has successfully paid their bid
+    * @dev This function transfers any excess `tokenUserSells` tokens back to the user
+    * @dev This function is delegatecalled: msg.sender = Atlas, address(this) = ExecutionEnvironment
+    * @dev It transfers all the available bid tokens on the contract (instead of only the bid amount,
+    *      to avoid leaving any dust on the contract)
+    * @param bidToken The address of the token used for the winning solver operation's bid
+    * @param _
+    * @param _
+    */
+    function _allocateValueCall(address bidToken, uint256, bytes calldata) internal override {
+        if (bidToken != address(0)) {
+            ERC20(bidToken).safeTransfer(_user(), ERC20(bidToken).balanceOf(address(this)));
+        } else {
+            SafeTransferLib.safeTransferETH(_user(), address(this).balance);
+        }
+    }
+
+    // ---------------------------------------------------- //
+    //                 Getters and helpers                  //
+    // ---------------------------------------------------- //
+
+    function getBidFormat(UserOperation calldata userOp) public pure override returns (address bidToken) {
+        (SwapIntent memory swapIntent) = abi.decode(userOp.data[4:], (SwapIntent));
+        bidToken = swapIntent.tokenUserSells;
+    }
+
+    function getBidValue(SolverOperation calldata solverOp) public pure override returns (uint256) {
+        return solverOp.bidAmount;
+    }
+}

--- a/src/contracts/examples/intents-example/SwapIntentInvertBidDAppControl.sol
+++ b/src/contracts/examples/intents-example/SwapIntentInvertBidDAppControl.sol
@@ -18,7 +18,7 @@ import { DAppControl } from "../../dapp/DAppControl.sol";
 import "forge-std/Test.sol";
 
 /**
- * @notice SwapIntent which wants exact amount of `tokenUserBuys` and is willing to sell up to `maxAmountUserSells` of
+ * @notice SwapIntent where user wants exact amount of `tokenUserBuys` and is willing to sell up to `maxAmountUserSells` of
  * `tokenUserSells` for it
  */
 struct SwapIntent {
@@ -111,7 +111,7 @@ contract SwapIntentInvertBidDAppControl is DAppControl {
     function _preSolverCall(SolverOperation calldata solverOp, bytes calldata returnData) internal override {
         address solverTo = solverOp.solver;
         if (solverTo == address(this) || solverTo == _control() || solverTo == ATLAS) {
-            revert();
+            revert("Invalid solver address - solverOp.solver cannot be execution environment, dapp control or atlas");
         }
 
         SwapIntent memory swapData = abi.decode(returnData, (SwapIntent));
@@ -121,8 +121,6 @@ contract SwapIntentInvertBidDAppControl is DAppControl {
 
         // Optimistically transfer to the solver contract the amount that the solver is invert bidding
         _transferUserERC20(swapData.tokenUserSells, solverTo, solverOp.bidAmount);
-
-        return; // success
     }
 
     /*
@@ -138,13 +136,11 @@ contract SwapIntentInvertBidDAppControl is DAppControl {
         uint256 buyTokenBalance = ERC20(swapIntent.tokenUserBuys).balanceOf(address(this));
 
         if (buyTokenBalance < swapIntent.amountUserBuys) {
-            revert();
+            revert("SwapIntentInvertBid: Intent Unfulfilled - buyTokenBalance < amountUserBuys");
         }
 
         // Transfer the tokens the user is buying to the user
         ERC20(swapIntent.tokenUserBuys).safeTransfer(_user(), swapIntent.amountUserBuys);
-
-        return; // success
     }
 
     /*

--- a/src/contracts/examples/intents-example/SwapIntentInvertBidDAppControl.sol
+++ b/src/contracts/examples/intents-example/SwapIntentInvertBidDAppControl.sol
@@ -18,7 +18,8 @@ import { DAppControl } from "../../dapp/DAppControl.sol";
 import "forge-std/Test.sol";
 
 /**
- * @notice SwapIntent where user wants exact amount of `tokenUserBuys` and is willing to sell up to `maxAmountUserSells` of
+ * @notice SwapIntent where user wants exact amount of `tokenUserBuys` and is willing to sell up to `maxAmountUserSells`
+ * of
  * `tokenUserSells` for it
  */
 struct SwapIntent {
@@ -38,7 +39,11 @@ contract SwapIntentInvertBidDAppControl is DAppControl {
 
     bool public immutable _solverBidRetrievalRequired;
 
-    constructor(address _atlas, bool bidFind, bool solverBidRetrievalRequired)
+    constructor(
+        address _atlas,
+        bool bidFind,
+        bool solverBidRetrievalRequired
+    )
         DAppControl(
             _atlas,
             msg.sender,
@@ -65,7 +70,7 @@ contract SwapIntentInvertBidDAppControl is DAppControl {
                 exPostBids: bidFind
             })
         )
-    { 
+    {
         _solverBidRetrievalRequired = solverBidRetrievalRequired;
     }
 
@@ -122,8 +127,8 @@ contract SwapIntentInvertBidDAppControl is DAppControl {
 
         // The solver must be bidding less than the intent's maxAmountUserSells
         require(solverOp.bidAmount <= swapData.maxAmountUserSells, "SwapIntentInvertBid: BidTooHigh");
-        
-        if (_solverBidRetrievalRequired){
+
+        if (_solverBidRetrievalRequired) {
             // Optimistically transfer to the execution environment the amount that the solver is invert bidding
             _transferUserERC20(swapData.tokenUserSells, address(this), solverOp.bidAmount);
             // Approve the solver to retrieve the bid amount from ee

--- a/src/contracts/examples/intents-example/SwapIntentInvertBidDAppControl.sol
+++ b/src/contracts/examples/intents-example/SwapIntentInvertBidDAppControl.sol
@@ -41,7 +41,6 @@ contract SwapIntentInvertBidDAppControl is DAppControl {
 
     constructor(
         address _atlas,
-        bool bidFind,
         bool solverBidRetrievalRequired
     )
         DAppControl(
@@ -67,7 +66,7 @@ contract SwapIntentInvertBidDAppControl is DAppControl {
                 requireFulfillment: true,
                 trustedOpHash: true,
                 invertBidValue: true,
-                exPostBids: bidFind
+                exPostBids: false
             })
         )
     {

--- a/src/contracts/solver/SolverBaseInvertBid.sol
+++ b/src/contracts/solver/SolverBaseInvertBid.sol
@@ -75,7 +75,7 @@ contract SolverBaseInvertBid is ISolverContract {
         // Environment
         if (_bidRetreivalRequired) {
             require(bidToken != address(0), "Solver cannot retrieve ETH from EE");
-            SafeTransferLib.safeTransferFrom(ERC20(bidToken), msg.sender, address(this), bidAmount);
+            SafeTransferLib.safeTransferFrom(ERC20(bidToken), executionEnvironment, address(this), bidAmount);
         }
         _;
     }

--- a/src/contracts/solver/SolverBaseInvertBid.sol
+++ b/src/contracts/solver/SolverBaseInvertBid.sol
@@ -15,21 +15,20 @@ interface IWETH9 {
 }
 
 /**
- * @title SolverBase
- * @notice A base contract for Solvers
- * @dev Does safety checks, escrow reconciliation and pays bids.
- * @dev Works with DappControls which have set the `invertBidValue` flag to false.
- * @dev Use `SolverBaseInvertBid` for DappControls which have set the `invertBidValue` flag to true.
+ * @title SolverBaseInvertBid
+ * @notice A base contract for Solvers that work with DappControls which have set the `invertBidValue` flag to true.
  */
-contract SolverBase is ISolverContract {
+contract SolverBaseInvertBid is ISolverContract {
     address public immutable WETH_ADDRESS;
     address internal immutable _owner;
     address internal immutable _atlas;
+    bool internal immutable _bidRetreivalRequired;
 
-    constructor(address weth, address atlas, address owner) {
+    constructor(address weth, address atlas, address owner, bool bidRetreivalRequired) {
         WETH_ADDRESS = weth;
         _owner = owner;
         _atlas = atlas;
+        _bidRetreivalRequired = bidRetreivalRequired;
     }
 
     function atlasSolverCall(
@@ -44,7 +43,7 @@ contract SolverBase is ISolverContract {
         payable
         virtual
         safetyFirst(executionEnvironment, solverOpFrom)
-        payBids(executionEnvironment, bidToken, bidAmount)
+        receiveBids(executionEnvironment, bidToken, bidAmount)
         returns (bool success, bytes memory data)
     {
         (success, data) = address(this).call{ value: msg.value }(solverOpData);
@@ -71,28 +70,13 @@ contract SolverBase is ISolverContract {
         IEscrow(_atlas).reconcile{ value: msg.value }(executionEnvironment, solverOpFrom, shortfall);
     }
 
-    modifier payBids(address executionEnvironment, address bidToken, uint256 bidAmount) {
-        _;
-
-        // After the solverCall logic has executed, pay the solver's bid to the Execution Environment of the current
-        // metacall tx.
-
-        if (bidToken == address(0)) {
-            // Pay bid in ETH
-
-            if (bidAmount > address(this).balance) {
-                IWETH9(WETH_ADDRESS).withdraw(bidAmount - address(this).balance);
-            }
-
-            SafeTransferLib.safeTransferETH(executionEnvironment, bidAmount);
-        } else {
-            // Pay bid in ERC20 (bidToken)
-
-            if (msg.value > address(this).balance) {
-                IWETH9(WETH_ADDRESS).withdraw(msg.value - address(this).balance);
-            }
-
-            SafeTransferLib.safeTransfer(ERC20(bidToken), executionEnvironment, bidAmount);
+    modifier receiveBids(address executionEnvironment, address bidToken, uint256 bidAmount) {
+        // Before the solverCall logic executes, the solver's bid must be received by the solver from the Execution
+        // Environment
+        if (_bidRetreivalRequired) {
+            require(bidToken != address(0), "Solver cannot retrieve ETH from EE");
+            SafeTransferLib.safeTransferFrom(ERC20(bidToken), msg.sender, address(this), bidAmount);
         }
+        _;
     }
 }

--- a/src/contracts/types/AtlasErrors.sol
+++ b/src/contracts/types/AtlasErrors.sol
@@ -120,4 +120,5 @@ contract AtlasErrors {
     error WrongDepth();
     error InsufficientLocalFunds();
     error NotImplemented();
+    error InvertBidValueCannotBeExPostBids();
 }

--- a/src/contracts/types/EscrowTypes.sol
+++ b/src/contracts/types/EscrowTypes.sol
@@ -15,9 +15,8 @@ struct EscrowAccountAccessData {
     uint64 totalGasUsed;
 }
 
-enum SolverOutcome
-// no refund (relay error or hostile user)
-{
+enum SolverOutcome {
+    // no refund (relay error or hostile user)
     InvalidSignature,
     InvalidUserHash,
     DeadlinePassedAlt,

--- a/src/contracts/types/EscrowTypes.sol
+++ b/src/contracts/types/EscrowTypes.sol
@@ -15,8 +15,9 @@ struct EscrowAccountAccessData {
     uint64 totalGasUsed;
 }
 
-enum SolverOutcome {
-    // no refund (relay error or hostile user)
+enum SolverOutcome
+// no refund (relay error or hostile user)
+{
     InvalidSignature,
     InvalidUserHash,
     DeadlinePassedAlt,

--- a/src/contracts/types/ValidCallsTypes.sol
+++ b/src/contracts/types/ValidCallsTypes.sol
@@ -27,5 +27,7 @@ enum ValidCallsResult {
     ControlMismatch,
     UserNonceInvalid,
     InvalidCallChainHash,
-    DAppNotEnabled
+    DAppNotEnabled,
+    BothUserAndDAppNoncesCannotBeSequential,
+    InvertBidValueCannotBeExPostBids
 }

--- a/test/SwapIntent.t.sol
+++ b/test/SwapIntent.t.sol
@@ -192,7 +192,7 @@ contract SwapIntentTest is BaseTest {
 
         atlas.metacall({ userOp: userOp, solverOps: solverOps, dAppOp: dAppOp });
 
-        console.log("OEV Metacall Gas Cost:", gasLeftBefore - gasleft());
+        console.log("Metacall Gas Cost:", gasLeftBefore - gasleft());
         vm.stopPrank();
 
         console.log("\nAFTER METACALL");

--- a/test/SwapIntentInvertBid.t.sol
+++ b/test/SwapIntentInvertBid.t.sol
@@ -34,7 +34,7 @@ contract SwapIntentTest is BaseTest {
         governanceEOA = vm.addr(governancePK);
     }
 
-    function testAtlasSwapIntentInvertBid_bidKnown_solverBidRetreivalNotRequired() public {
+    function testAtlasSwapIntentInvertBid_solverBidRetreivalNotRequired() public {
         vm.startPrank(governanceEOA);
         SwapIntentInvertBidDAppControl controlContract = new SwapIntentInvertBidDAppControl(address(atlas), false, false);
         address control = address(controlContract);
@@ -69,7 +69,7 @@ contract SwapIntentTest is BaseTest {
         assertEq(DAI.balanceOf(userEOA), userDaiBalanceBefore + swapIntent.amountUserBuys, "Did not receive enough DAI");
     }
 
-    function testAtlasSwapIntentInvertBid_bidKnown_solverBidRetreivalNotRequired_multipleSolvers() public {
+    function testAtlasSwapIntentInvertBid_solverBidRetreivalNotRequired_multipleSolvers() public {
         vm.startPrank(governanceEOA);
         SwapIntentInvertBidDAppControl controlContract = new SwapIntentInvertBidDAppControl(address(atlas), false, false);
         address control = address(controlContract);
@@ -109,7 +109,7 @@ contract SwapIntentTest is BaseTest {
         assertEq(DAI.balanceOf(userEOA), userDaiBalanceBefore + swapIntent.amountUserBuys, "Did not receive enough DAI");
     }
 
-    function testAtlasSwapIntentInvertBid_bidKnown_solverBidRetreivalRequired() public {
+    function testAtlasSwapIntentInvertBid_solverBidRetreivalRequired() public {
         vm.startPrank(governanceEOA);
         SwapIntentInvertBidDAppControl controlContract = new SwapIntentInvertBidDAppControl(address(atlas), false, true);
         address control = address(controlContract);
@@ -122,41 +122,6 @@ contract SwapIntentTest is BaseTest {
 
         SwapIntent memory swapIntent = createSwapIntent(amountUserBuys, maxAmountUserSells);
         SimpleRFQSolverInvertBid rfqSolver = deployAndFundRFQSolver(swapIntent, true);
-        address executionEnvironment = createExecutionEnvironment(control);
-        UserOperation memory userOp = buildUserOperation(control, swapIntent);
-        SolverOperation memory solverOp = buildSolverOperation(control, userOp, swapIntent, executionEnvironment, address(rfqSolver), solverBidAmount);
-        SolverOperation[] memory solverOps = new SolverOperation[](1);
-        solverOps[0] = solverOp;
-        DAppOperation memory dAppOp = buildDAppOperation(control, userOp, solverOps);
-
-        uint256 userWethBalanceBefore = WETH.balanceOf(userEOA);
-        uint256 userDaiBalanceBefore = DAI.balanceOf(userEOA);
-
-        vm.prank(userEOA); 
-        WETH.transfer(address(1), userWethBalanceBefore - swapIntent.maxAmountUserSells);
-        userWethBalanceBefore = WETH.balanceOf(userEOA);
-        assertTrue(userWethBalanceBefore >= swapIntent.maxAmountUserSells, "Not enough starting WETH");
-
-        approveAtlasAndExecuteSwap(swapIntent, userOp, solverOps, dAppOp);
-
-        // Check user token balances after
-        assertEq(WETH.balanceOf(userEOA), userWethBalanceBefore - solverBidAmount, "Did not spend WETH == solverBidAmount");
-        assertEq(DAI.balanceOf(userEOA), userDaiBalanceBefore + swapIntent.amountUserBuys, "Did not receive enough DAI");
-    }
-
-    function testAtlasSwapIntentInvertBid_bidFind_solverBidRetreivalNotRequired() public {
-        vm.startPrank(governanceEOA);
-        SwapIntentInvertBidDAppControl controlContract = new SwapIntentInvertBidDAppControl(address(atlas), true, false);
-        address control = address(controlContract);
-        atlasVerification.initializeGovernance(control);
-        vm.stopPrank();
-
-        uint256 amountUserBuys = 20e18;
-        uint256 maxAmountUserSells = 10e18;
-        uint256 solverBidAmount = 1e18;
-
-        SwapIntent memory swapIntent = createSwapIntent(amountUserBuys, maxAmountUserSells);
-        SimpleRFQSolverInvertBid rfqSolver = deployAndFundRFQSolver(swapIntent, false);
         address executionEnvironment = createExecutionEnvironment(control);
         UserOperation memory userOp = buildUserOperation(control, swapIntent);
         SolverOperation memory solverOp = buildSolverOperation(control, userOp, swapIntent, executionEnvironment, address(rfqSolver), solverBidAmount);

--- a/test/SwapIntentInvertBid.t.sol
+++ b/test/SwapIntentInvertBid.t.sol
@@ -36,7 +36,7 @@ contract SwapIntentTest is BaseTest {
 
     function testAtlasSwapIntentInvertBid_solverBidRetreivalNotRequired() public {
         vm.startPrank(governanceEOA);
-        SwapIntentInvertBidDAppControl controlContract = new SwapIntentInvertBidDAppControl(address(atlas), false, false);
+        SwapIntentInvertBidDAppControl controlContract = new SwapIntentInvertBidDAppControl(address(atlas), false);
         address control = address(controlContract);
         atlasVerification.initializeGovernance(control);
         vm.stopPrank();
@@ -71,7 +71,7 @@ contract SwapIntentTest is BaseTest {
 
     function testAtlasSwapIntentInvertBid_solverBidRetreivalNotRequired_multipleSolvers() public {
         vm.startPrank(governanceEOA);
-        SwapIntentInvertBidDAppControl controlContract = new SwapIntentInvertBidDAppControl(address(atlas), false, false);
+        SwapIntentInvertBidDAppControl controlContract = new SwapIntentInvertBidDAppControl(address(atlas), false);
         address control = address(controlContract);
         atlasVerification.initializeGovernance(control);
         vm.stopPrank();
@@ -111,7 +111,7 @@ contract SwapIntentTest is BaseTest {
 
     function testAtlasSwapIntentInvertBid_solverBidRetreivalRequired() public {
         vm.startPrank(governanceEOA);
-        SwapIntentInvertBidDAppControl controlContract = new SwapIntentInvertBidDAppControl(address(atlas), false, true);
+        SwapIntentInvertBidDAppControl controlContract = new SwapIntentInvertBidDAppControl(address(atlas), true);
         address control = address(controlContract);
         atlasVerification.initializeGovernance(control);
         vm.stopPrank();

--- a/test/SwapIntentInvertBid.t.sol
+++ b/test/SwapIntentInvertBid.t.sol
@@ -12,8 +12,11 @@ import { SwapIntent, SwapIntentInvertBidDAppControl } from "src/contracts/exampl
 import { SolverBaseInvertBid } from "src/contracts/solver/SolverBaseInvertBid.sol";
 
 contract SwapIntentTest is BaseTest {
-    SwapIntentInvertBidDAppControl public swapIntentControl;
-    TxBuilder public txBuilder;
+    SwapIntentInvertBidDAppControl public swapIntentControl_bidKnown_solverBidRetreivalNotRequired;
+    SwapIntentInvertBidDAppControl public swapIntentControl_bidKnown_solverBidRetreivalRequired;
+    SwapIntentInvertBidDAppControl public swapIntentControl_bidFind_solverBidRetreivalNotRequired;
+    SwapIntentInvertBidDAppControl public swapIntentControl_bidFind_solverBidRetreivalRequired;
+
     Sig public sig;
 
     ERC20 DAI = ERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);
@@ -32,37 +35,39 @@ contract SwapIntentTest is BaseTest {
         governancePK = 11_112;
         governanceEOA = vm.addr(governancePK);
 
-        // Deploy new SwapIntent Control from new gov and initialize in Atlas
+        // Deploy new SwapIntent Controls from new gov and initialize in Atlas
         vm.startPrank(governanceEOA);
-        swapIntentControl = new SwapIntentInvertBidDAppControl(address(atlas));
-        atlasVerification.initializeGovernance(address(swapIntentControl));
-        vm.stopPrank();
+        swapIntentControl_bidKnown_solverBidRetreivalNotRequired = new SwapIntentInvertBidDAppControl(address(atlas), false, false);
+        swapIntentControl_bidKnown_solverBidRetreivalRequired = new SwapIntentInvertBidDAppControl(address(atlas), false, true);
+        swapIntentControl_bidFind_solverBidRetreivalNotRequired = new SwapIntentInvertBidDAppControl(address(atlas), true, false);
+        swapIntentControl_bidFind_solverBidRetreivalRequired = new SwapIntentInvertBidDAppControl(address(atlas), true, true);
 
-        txBuilder = new TxBuilder({
-            _control: address(swapIntentControl),
-            _atlas: address(atlas),
-            _verification: address(atlasVerification)
-        });
+        atlasVerification.initializeGovernance(address(swapIntentControl_bidKnown_solverBidRetreivalNotRequired));
+        atlasVerification.initializeGovernance(address(swapIntentControl_bidKnown_solverBidRetreivalRequired));
+        atlasVerification.initializeGovernance(address(swapIntentControl_bidFind_solverBidRetreivalNotRequired));
+        atlasVerification.initializeGovernance(address(swapIntentControl_bidFind_solverBidRetreivalRequired));
+        vm.stopPrank();
 
         // Deposit ETH from Searcher signer to pay for searcher's gas
         // vm.prank(solverOneEOA);
         // atlas.deposit{value: 1e18}();
     }
 
-    function testAtlasSwapIntentInvertBidWithBasicRFQ() public {
-        // Define hardcoded quantities
+    function testAtlasSwapIntentInvertBid() public {
+        address control = address(swapIntentControl_bidKnown_solverBidRetreivalNotRequired);
+
         uint256 amountUserBuys = 20e18;
         uint256 maxAmountUserSells = 10e18;
         uint256 solverBidAmount = 1e18;
 
         SwapIntent memory swapIntent = createSwapIntent(amountUserBuys, maxAmountUserSells);
         SimpleRFQSolverInvertBid rfqSolver = deployAndFundRFQSolver(swapIntent);
-        address executionEnvironment = createExecutionEnvironment();
-        UserOperation memory userOp = buildUserOperation(swapIntent);
-        SolverOperation memory solverOp = buildSolverOperation(userOp, swapIntent, executionEnvironment, address(rfqSolver), solverBidAmount);
+        address executionEnvironment = createExecutionEnvironment(control);
+        UserOperation memory userOp = buildUserOperation(control, swapIntent);
+        SolverOperation memory solverOp = buildSolverOperation(control, userOp, swapIntent, executionEnvironment, address(rfqSolver), solverBidAmount);
         SolverOperation[] memory solverOps = new SolverOperation[](1);
         solverOps[0] = solverOp;
-        DAppOperation memory dAppOp = buildDAppOperation(userOp, solverOps);
+        DAppOperation memory dAppOp = buildDAppOperation(control, userOp, solverOps);
 
         uint256 userWethBalanceBefore = WETH.balanceOf(userEOA);
         uint256 userDaiBalanceBefore = DAI.balanceOf(userEOA);
@@ -76,6 +81,42 @@ contract SwapIntentTest is BaseTest {
 
         // Check user token balances after
         assertEq(WETH.balanceOf(userEOA), userWethBalanceBefore - solverBidAmount, "Did not spend WETH == solverBidAmount");
+        assertEq(DAI.balanceOf(userEOA), userDaiBalanceBefore + swapIntent.amountUserBuys, "Did not receive enough DAI");
+    }
+
+    function testAtlasSwapIntentInvertBidMultipleSolvers() public {
+        address control = address(swapIntentControl_bidKnown_solverBidRetreivalNotRequired);
+
+        uint256 amountUserBuys = 20e18;
+        uint256 maxAmountUserSells = 10e18;
+
+        uint256 solverBidAmountOne = 1e18;
+        uint256 solverBidAmountTwo = 2e18;
+
+        SwapIntent memory swapIntent = createSwapIntent(amountUserBuys, maxAmountUserSells);
+        SimpleRFQSolverInvertBid rfqSolver = deployAndFundRFQSolver(swapIntent);
+        address executionEnvironment = createExecutionEnvironment(control);
+        UserOperation memory userOp = buildUserOperation(control, swapIntent);
+        SolverOperation memory solverOpOne = buildSolverOperation(control, userOp, swapIntent, executionEnvironment, address(rfqSolver), solverBidAmountOne);
+        SolverOperation memory solverOpTwo = buildSolverOperation(control, userOp, swapIntent, executionEnvironment, address(rfqSolver), solverBidAmountTwo);
+        
+        SolverOperation[] memory solverOps = new SolverOperation[](2);
+        solverOps[0] = solverOpOne;
+        solverOps[1] = solverOpTwo;
+        DAppOperation memory dAppOp = buildDAppOperation(control, userOp, solverOps);
+
+        uint256 userWethBalanceBefore = WETH.balanceOf(userEOA);
+        uint256 userDaiBalanceBefore = DAI.balanceOf(userEOA);
+
+        vm.prank(userEOA); 
+        WETH.transfer(address(1), userWethBalanceBefore - swapIntent.maxAmountUserSells);
+        userWethBalanceBefore = WETH.balanceOf(userEOA);
+        assertTrue(userWethBalanceBefore >= swapIntent.maxAmountUserSells, "Not enough starting WETH");
+
+        approveAtlasAndExecuteSwap(swapIntent, userOp, solverOps, dAppOp);
+
+        // Check user token balances after
+        assertEq(WETH.balanceOf(userEOA), userWethBalanceBefore - solverBidAmountOne, "Did not spend WETH == solverBidAmountOne");
         assertEq(DAI.balanceOf(userEOA), userDaiBalanceBefore + swapIntent.amountUserBuys, "Did not receive enough DAI");
     }
 
@@ -101,9 +142,9 @@ contract SwapIntentTest is BaseTest {
         return rfqSolver;
     }
 
-    function createExecutionEnvironment() internal returns (address){
+    function createExecutionEnvironment(address control) internal returns (address){
         vm.startPrank(userEOA);
-        address executionEnvironment = atlas.createExecutionEnvironment(txBuilder.control());
+        address executionEnvironment = atlas.createExecutionEnvironment(control);
         console.log("executionEnvironment", executionEnvironment);
         vm.stopPrank();
         vm.label(address(executionEnvironment), "EXECUTION ENV");
@@ -111,14 +152,20 @@ contract SwapIntentTest is BaseTest {
         return executionEnvironment;
     }
 
-    function buildUserOperation(SwapIntent memory swapIntent) internal view returns (UserOperation memory) {
+    function buildUserOperation(address control, SwapIntent memory swapIntent) internal returns (UserOperation memory) {
         UserOperation memory userOp;
 
         bytes memory userOpData = abi.encodeCall(SwapIntentInvertBidDAppControl.swap, swapIntent);
 
+        TxBuilder txBuilder = new TxBuilder({
+            _control: control,
+            _atlas: address(atlas),
+            _verification: address(atlasVerification)
+        });
+
         userOp = txBuilder.buildUserOperation({
             from: userEOA,
-            to: address(swapIntentControl),
+            to: txBuilder.control(),
             maxFeePerGas: tx.gasprice + 1,
             value: 0,
             deadline: block.number + 2,
@@ -129,10 +176,16 @@ contract SwapIntentTest is BaseTest {
         return userOp;
     }
 
-    function buildSolverOperation(UserOperation memory userOp, SwapIntent memory swapIntent, address executionEnvironment,
+    function buildSolverOperation(address control, UserOperation memory userOp, SwapIntent memory swapIntent, address executionEnvironment,
         address solverAddress, uint256 solverBidAmount) internal returns (SolverOperation memory) {
         bytes memory solverOpData =
             abi.encodeCall(SimpleRFQSolverInvertBid.fulfillRFQ, (swapIntent, executionEnvironment, solverBidAmount));
+
+        TxBuilder txBuilder = new TxBuilder({
+            _control: control,
+            _atlas: address(atlas),
+            _verification: address(atlasVerification)
+        });
 
         SolverOperation memory solverOp = txBuilder.buildSolverOperation({
             userOp: userOp,
@@ -149,8 +202,13 @@ contract SwapIntentTest is BaseTest {
         return solverOp;
     }
 
-    function buildDAppOperation(UserOperation memory userOp, SolverOperation[] memory solverOps) 
+    function buildDAppOperation(address control, UserOperation memory userOp, SolverOperation[] memory solverOps) 
         internal returns (DAppOperation memory) {
+        TxBuilder txBuilder = new TxBuilder({
+            _control: control,
+            _atlas: address(atlas),
+            _verification: address(atlasVerification)
+        });
         DAppOperation memory dAppOp = txBuilder.buildDAppOperation(governanceEOA, userOp, solverOps);
 
         (sig.v, sig.r, sig.s) = vm.sign(governancePK, atlasVerification.getDAppOperationPayload(dAppOp));

--- a/test/SwapIntentInvertBid.t.sol
+++ b/test/SwapIntentInvertBid.t.sol
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.22;
+
+import "forge-std/Test.sol";
+
+import { ERC20 } from "solmate/tokens/ERC20.sol";
+
+import { BaseTest } from "./base/BaseTest.t.sol";
+import { TxBuilder } from "src/contracts/helpers/TxBuilder.sol";
+
+import { SolverOperation } from "src/contracts/types/SolverCallTypes.sol";
+import { UserOperation } from "src/contracts/types/UserCallTypes.sol";
+import { DAppOperation, DAppConfig } from "src/contracts/types/DAppApprovalTypes.sol";
+
+import { SwapIntent, SwapIntentInvertBidDAppControl } from "src/contracts/examples/intents-example/SwapIntentInvertBidDAppControl.sol";
+import { SolverBaseInvertBid } from "src/contracts/solver/SolverBaseInvertBid.sol";
+
+interface IUniV2Router02 {
+    function swapExactTokensForTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    )
+        external
+        returns (uint256[] memory amounts);
+}
+
+contract SwapIntentTest is BaseTest {
+    SwapIntentInvertBidDAppControl public swapIntentControl;
+    TxBuilder public txBuilder;
+    Sig public sig;
+
+    ERC20 DAI = ERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);
+    address DAI_ADDRESS = address(DAI);
+
+    struct Sig {
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+    }
+
+    function setUp() public virtual override {
+        BaseTest.setUp();
+
+        // Creating new gov address (SignatoryActive error if already registered with control)
+        governancePK = 11_112;
+        governanceEOA = vm.addr(governancePK);
+
+        // Deploy new SwapIntent Control from new gov and initialize in Atlas
+        vm.startPrank(governanceEOA);
+        swapIntentControl = new SwapIntentInvertBidDAppControl(address(atlas));
+        atlasVerification.initializeGovernance(address(swapIntentControl));
+        vm.stopPrank();
+
+        txBuilder = new TxBuilder({
+            _control: address(swapIntentControl),
+            _atlas: address(atlas),
+            _verification: address(atlasVerification)
+        });
+
+        // Deposit ETH from Searcher signer to pay for searcher's gas
+        // vm.prank(solverOneEOA);
+        // atlas.deposit{value: 1e18}();
+    }
+
+    function testAtlasSwapIntentInvertBidWithBasicRFQ() public {
+        // Swap 10 WETH for 20 DAI
+
+        SwapIntent memory swapIntent = SwapIntent({
+            tokenUserBuys: DAI_ADDRESS,
+            amountUserBuys: 20e18,
+            tokenUserSells: WETH_ADDRESS,
+            maxAmountUserSells: 10e18
+        });
+
+        // Solver deploys the RFQ solver contract (defined at bottom of this file)
+        vm.startPrank(solverOneEOA);
+        SimpleRFQSolverInvertBid rfqSolver = new SimpleRFQSolverInvertBid(WETH_ADDRESS, address(atlas));
+        atlas.deposit{ value: 1e18 }();
+        atlas.bond(1 ether);
+        vm.stopPrank();
+
+        // Give 20 DAI to RFQ solver contract
+        deal(DAI_ADDRESS, address(rfqSolver), swapIntent.amountUserBuys);
+        assertEq(DAI.balanceOf(address(rfqSolver)), swapIntent.amountUserBuys, "Did not give enough DAI to solver");
+
+        // Input params for Atlas.metacall() - will be populated below
+        UserOperation memory userOp;
+        SolverOperation[] memory solverOps = new SolverOperation[](1);
+        DAppOperation memory dAppOp;
+
+        vm.startPrank(userEOA);
+        address executionEnvironment = atlas.createExecutionEnvironment(txBuilder.control());
+        console.log("executionEnvironment", executionEnvironment);
+        vm.stopPrank();
+        vm.label(address(executionEnvironment), "EXECUTION ENV");
+
+        bytes memory userOpData = abi.encodeCall(SwapIntentInvertBidDAppControl.swap, swapIntent);
+
+        // Builds the metaTx and to parts of userOp, signature still to be set
+        userOp = txBuilder.buildUserOperation({
+            from: userEOA,
+            to: address(swapIntentControl),
+            maxFeePerGas: tx.gasprice + 1,
+            value: 0,
+            deadline: block.number + 2,
+            data: userOpData
+        });
+        userOp.sessionKey = governanceEOA;
+
+        // User signs the userOp
+        // user doees NOT sign the userOp for when they are bundling
+        // (sig.v, sig.r, sig.s) = vm.sign(userPK, atlas.getUserOperationPayload(userOp));
+        // userOp.signature = abi.encodePacked(sig.r, sig.s, sig.v);
+
+        uint256 solverBidAmount = 1e18;
+
+        // Build solver calldata (function selector on solver contract and its params)
+        bytes memory solverOpData =
+            abi.encodeCall(SimpleRFQSolverInvertBid.fulfillRFQ, (swapIntent, executionEnvironment, solverBidAmount));
+
+        // Builds the SolverOperation
+        solverOps[0] = txBuilder.buildSolverOperation({
+            userOp: userOp,
+            solverOpData: solverOpData,
+            solverEOA: solverOneEOA,
+            solverContract: address(rfqSolver),
+            bidAmount: solverBidAmount,
+            value: 0
+        });
+
+        // Solver signs the solverOp
+        (sig.v, sig.r, sig.s) = vm.sign(solverOnePK, atlasVerification.getSolverPayload(solverOps[0]));
+        solverOps[0].signature = abi.encodePacked(sig.r, sig.s, sig.v);
+
+        // Frontend creates dAppOp calldata after seeing rest of data
+        dAppOp = txBuilder.buildDAppOperation(governanceEOA, userOp, solverOps);
+
+        // Frontend signs the dAppOp payload
+        (sig.v, sig.r, sig.s) = vm.sign(governancePK, atlasVerification.getDAppOperationPayload(dAppOp));
+        dAppOp.signature = abi.encodePacked(sig.r, sig.s, sig.v);
+
+        // Check user token balances before
+        uint256 userWethBalanceBefore = WETH.balanceOf(userEOA);
+        uint256 userDaiBalanceBefore = DAI.balanceOf(userEOA);
+
+        vm.prank(userEOA); // Burn all users WETH except 10 so logs are more readable
+        WETH.transfer(address(1), userWethBalanceBefore - swapIntent.maxAmountUserSells);
+        userWethBalanceBefore = WETH.balanceOf(userEOA);
+
+        assertTrue(userWethBalanceBefore >= swapIntent.maxAmountUserSells, "Not enough starting WETH");
+
+        console.log("\nBEFORE METACALL");
+        console.log("User WETH balance", WETH.balanceOf(userEOA));
+        console.log("User DAI balance", DAI.balanceOf(userEOA));
+        console.log("Solver WETH balance", WETH.balanceOf(address(rfqSolver)));
+        console.log("Solver DAI balance", DAI.balanceOf(address(rfqSolver)));
+
+        vm.startPrank(userEOA);
+
+        (bool simResult,,) = simulator.simUserOperation(userOp);
+        assertFalse(simResult, "metasimUserOperationcall tested true a");
+
+        WETH.approve(address(atlas), swapIntent.maxAmountUserSells);
+
+        (simResult,,) = simulator.simUserOperation(userOp);
+        assertTrue(simResult, "metasimUserOperationcall tested false c");
+
+        uint256 gasLeftBefore = gasleft();
+
+        atlas.metacall({ userOp: userOp, solverOps: solverOps, dAppOp: dAppOp });
+
+        console.log("OEV Metacall Gas Cost:", gasLeftBefore - gasleft());
+        vm.stopPrank();
+
+        console.log("\nAFTER METACALL");
+        console.log("User WETH balance", WETH.balanceOf(userEOA));
+        console.log("User DAI balance", DAI.balanceOf(userEOA));
+        console.log("Solver WETH balance", WETH.balanceOf(address(rfqSolver)));
+        console.log("Solver DAI balance", DAI.balanceOf(address(rfqSolver)));
+
+        // Check user token balances after
+        assertEq(WETH.balanceOf(userEOA), userWethBalanceBefore - solverBidAmount, "Did not spend WETH == solverBidAmount");
+        assertEq(DAI.balanceOf(userEOA), userDaiBalanceBefore + swapIntent.amountUserBuys, "Did not receive enough DAI");
+    }
+}
+
+// This solver magically has the tokens needed to fulfil the user's swap.
+// This might involve an offchain RFQ system
+contract SimpleRFQSolverInvertBid is SolverBaseInvertBid {
+    constructor(address weth, address atlas) SolverBaseInvertBid(weth, atlas, msg.sender, false) { }
+
+    function fulfillRFQ(SwapIntent calldata swapIntent, address executionEnvironment, uint256 solverBidAmount) public {
+        require(
+            ERC20(swapIntent.tokenUserSells).balanceOf(address(this)) >= solverBidAmount,
+            "Did"
+        );
+        require(
+            ERC20(swapIntent.tokenUserBuys).balanceOf(address(this)) >= swapIntent.amountUserBuys,
+            "Not enough tokenUserBuys to fulfill"
+        );
+        ERC20(swapIntent.tokenUserBuys).transfer(executionEnvironment, swapIntent.amountUserBuys);
+    }
+
+    // This ensures a function can only be called through atlasSolverCall
+    // which includes security checks to work safely with Atlas
+    modifier onlySelf() {
+        require(msg.sender == address(this), "Not called via atlasSolverCall");
+        _;
+    }
+
+    fallback() external payable { }
+    receive() external payable { }
+}


### PR DESCRIPTION
To fix https://github.com/spearbit-audits/review-fastlane/issues/151

1. A new base solver contract is implemented which has a modifier `receiveBids` as opposed to `payBids` in `SolverBase` which supports `DAppControl`s which have `invertBidValue == true`
2. A `SwapIntentInvertBidDAppControl` is implemented which enables a user to get exact `tokenUserBuys` tokens in exchange for the minimum `tokenUserSells` tokens from a solver. 
3. Added a Simple RFQ test which uses this DAppControl