### PR TITLE
Restrict `borrow()` to before `PostSolver` phase

### DIFF
--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -25,7 +25,8 @@ abstract contract GasAccounting is SafetyLocks {
 
     /// @notice Contributes ETH to the contract, increasing the deposits if a non-zero value is sent.
     function contribute() external payable {
-        if (lock.activeEnvironment != msg.sender) revert InvalidExecutionEnvironment(lock.activeEnvironment);
+        address currentEnvironment = lock.activeEnvironment;
+        if (currentEnvironment != msg.sender) revert InvalidExecutionEnvironment(currentEnvironment);
         _contribute();
     }
 
@@ -33,11 +34,11 @@ abstract contract GasAccounting is SafetyLocks {
     /// @dev Borrowing is only available until the end of the SolverOperations phase, for solver protection.
     /// @param amount The amount of ETH to borrow.
     function borrow(uint256 amount) external payable {
-        Lock memory currentLock = lock;
-        if (currentLock.activeEnvironment != msg.sender) {
-            revert InvalidExecutionEnvironment(currentLock.activeEnvironment);
+        Lock memory _lock = lock;
+        if (_lock.activeEnvironment != msg.sender) {
+            revert InvalidExecutionEnvironment(_lock.activeEnvironment);
         }
-        if (currentLock.phase > ExecutionPhase.SolverOperations) revert WrongPhase();
+        if (_lock.phase > ExecutionPhase.SolverOperations) revert WrongPhase();
 
         if (_borrow(amount)) {
             SafeTransferLib.safeTransferETH(msg.sender, amount);

--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -30,9 +30,15 @@ abstract contract GasAccounting is SafetyLocks {
     }
 
     /// @notice Borrows ETH from the contract, transferring the specified amount to the caller if available.
+    /// @dev Borrowing is only available until the end of the SolverOperations phase, for solver protection.
     /// @param amount The amount of ETH to borrow.
     function borrow(uint256 amount) external payable {
-        if (lock.activeEnvironment != msg.sender) revert InvalidExecutionEnvironment(lock.activeEnvironment);
+        Lock memory currentLock = lock;
+        if (currentLock.activeEnvironment != msg.sender) {
+            revert InvalidExecutionEnvironment(currentLock.activeEnvironment);
+        }
+        if (currentLock.phase > ExecutionPhase.SolverOperations) revert WrongPhase();
+
         if (_borrow(amount)) {
             SafeTransferLib.safeTransferETH(msg.sender, amount);
         } else {
@@ -116,6 +122,9 @@ abstract contract GasAccounting is SafetyLocks {
     }
 
     /// @notice Borrows ETH from the contract, transferring the specified amount to the caller if available.
+    /// @dev Borrowing should never be allowed after the SolverOperations phase, for solver safety. This is enforced in
+    /// the external `borrow` function, and the only other time this internal `_borrow` function is called is in
+    /// `_trySolverLock` which happens at the beginning of the SolverOperations phase.
     /// @param amount The amount of ETH to borrow.
     /// @return valid A boolean indicating whether the borrowing operation was successful.
     function _borrow(uint256 amount) internal returns (bool valid) {

--- a/src/contracts/atlas/SafetyLocks.sol
+++ b/src/contracts/atlas/SafetyLocks.sol
@@ -56,8 +56,8 @@ abstract contract SafetyLocks is Storage {
         deposits = msg.value;
     }
 
-    modifier withLockPhase(ExecutionPhase phase) {
-        lock.phase = phase;
+    modifier withLockPhase(ExecutionPhase _phase) {
+        lock.phase = _phase;
         _;
     }
 

--- a/src/contracts/common/Permit69.sol
+++ b/src/contracts/common/Permit69.sol
@@ -62,7 +62,7 @@ abstract contract Permit69 is GasAccounting {
     /// @param user The address of the user invoking the function.
     /// @param control The address of the current DAppControl contract.
     /// @param callConfig The CallConfig of the current DAppControl contract.
-    /// @param phase The lock state indicating the safe execution phase for the token transfer.
+    /// @param currentPhase The lock state indicating the safe execution phase for the token transfer.
     function transferUserERC20(
         address token,
         address destination,
@@ -70,7 +70,7 @@ abstract contract Permit69 is GasAccounting {
         address user,
         address control,
         uint32 callConfig,
-        uint8 phase
+        uint8 currentPhase
     )
         external
     {
@@ -79,7 +79,7 @@ abstract contract Permit69 is GasAccounting {
             user: user,
             control: control,
             callConfig: callConfig,
-            phase: phase,
+            currentPhase: currentPhase,
             safeExecutionPhaseSet: SAFE_USER_TRANSFER
         });
 
@@ -95,7 +95,7 @@ abstract contract Permit69 is GasAccounting {
     /// @param user The address of the user invoking the function.
     /// @param control The address of the current DAppControl contract.
     /// @param callConfig The CallConfig of the current DAppControl contract.
-    /// @param phase The lock state indicating the safe execution phase for the token transfer.
+    /// @param currentPhase The lock state indicating the safe execution phase for the token transfer.
     function transferDAppERC20(
         address token,
         address destination,
@@ -103,7 +103,7 @@ abstract contract Permit69 is GasAccounting {
         address user,
         address control,
         uint32 callConfig,
-        uint8 phase
+        uint8 currentPhase
     )
         external
     {
@@ -112,7 +112,7 @@ abstract contract Permit69 is GasAccounting {
             user: user,
             control: control,
             callConfig: callConfig,
-            phase: phase,
+            currentPhase: currentPhase,
             safeExecutionPhaseSet: SAFE_DAPP_TRANSFER
         });
 
@@ -124,13 +124,13 @@ abstract contract Permit69 is GasAccounting {
     /// @param user The address of the user invoking the function.
     /// @param control The address of the current DAppControl contract.
     /// @param callConfig The CallConfig of the DAppControl contract of the current transaction.
-    /// @param phase The lock state to be checked.
+    /// @param currentPhase The lock state to be checked.
     /// @param safeExecutionPhaseSet The set of safe execution phases.
     function _validateTransfer(
         address user,
         address control,
         uint32 callConfig,
-        uint8 phase,
+        uint8 currentPhase,
         uint8 safeExecutionPhaseSet
     )
         internal
@@ -141,7 +141,7 @@ abstract contract Permit69 is GasAccounting {
         if (_lock.activeEnvironment != msg.sender) {
             revert InvalidEnvironment();
         }
-        if (uint8(_lock.phase) != phase) {
+        if (uint8(_lock.phase) != currentPhase) {
             revert WrongPhase();
         }
 
@@ -155,7 +155,7 @@ abstract contract Permit69 is GasAccounting {
         }
 
         // Verify that the current phase allows for transfers
-        if (1 << phase & safeExecutionPhaseSet == 0) {
+        if (1 << currentPhase & safeExecutionPhaseSet == 0) {
             revert InvalidLockState();
         }
     }


### PR DESCRIPTION
Resolves this audit issue: https://github.com/spearbit-audits/review-fastlane/issues/18