### PR TITLE
Max one return data between preOps and user call

### DIFF
--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -79,6 +79,11 @@ contract AtlasVerification is EIP712, DAppIntegration, AtlasConstants {
         // Verify that the calldata injection came from the dApp frontend
         // and that the signatures are valid.
 
+        if (dConfig.callConfig.needsPreOpsReturnData() && dConfig.callConfig.needsUserReturnData()) {
+            // Max one of preOps or userOp return data can be tracked, not both
+            return (userOpHash, ValidCallsResult.InvalidCallConfig);
+        }
+
         // CASE: Solvers trust app to update content of UserOp after submission of solverOp
         if (dConfig.callConfig.allowsTrustedOpHash()) {
             userOpHash = userOp.getAltOperationHash();

--- a/src/contracts/dapp/DAppControl.sol
+++ b/src/contracts/dapp/DAppControl.sol
@@ -33,6 +33,10 @@ abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
             // Max one of user or dapp nonces can be sequential, not both
             revert AtlasErrors.BothUserAndDAppNoncesCannotBeSequential();
         }
+        if (_callConfig.trackPreOpsReturnData && _callConfig.trackUserReturnData) {
+            // Max one of preOps or userOp return data can be tracked, not both
+            revert AtlasErrors.BothPreOpsAndUserReturnDataCannotBeTracked();
+        }
         CALL_CONFIG = CallBits.encodeCallConfig(_callConfig);
         CONTROL = address(this);
         ATLAS_VERIFICATION = IAtlas(_atlas).VERIFICATION();

--- a/src/contracts/types/AtlasErrors.sol
+++ b/src/contracts/types/AtlasErrors.sol
@@ -113,6 +113,7 @@ contract AtlasErrors {
 
     // DAppControl
     error BothUserAndDAppNoncesCannotBeSequential();
+    error BothPreOpsAndUserReturnDataCannotBeTracked();
     error InvalidControl();
     error NoDelegatecall();
     error MustBeDelegatecalled();

--- a/src/contracts/types/ValidCallsTypes.sol
+++ b/src/contracts/types/ValidCallsTypes.sol
@@ -21,6 +21,7 @@ enum ValidCallsResult {
     InvalidControl,
     InvalidSolverGasLimit,
     InvalidDAppNonce,
+    InvalidCallConfig,
     CallConfigMismatch,
     DAppToInvalid,
     UserFromInvalid,

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -350,9 +350,9 @@ contract EscrowTest is AtlasBaseTest {
     function test_executeSolverOperation_solverOpWrapper_preSolverFailed() public {
         defaultAtlasWithCallConfig(
             defaultCallConfig()
-                .withTrackPreOpsReturnData(true)
+                .withTrackPreOpsReturnData(false)
                 .withTrackUserReturnData(true)
-                .withRequirePreOps(true)
+                .withRequirePreOps(false)
                 .withPreSolver(true)
                 .build()
         );
@@ -373,9 +373,9 @@ contract EscrowTest is AtlasBaseTest {
     function test_executeSolverOperation_solverOpWrapper_postSolverFailed() public {
         defaultAtlasWithCallConfig(
             defaultCallConfig()
-                .withTrackPreOpsReturnData(true)
+                .withTrackPreOpsReturnData(false)
                 .withTrackUserReturnData(true)
-                .withRequirePreOps(true)
+                .withRequirePreOps(false)
                 .withPostSolver(true)
                 .build()
         );
@@ -414,9 +414,9 @@ contract EscrowTest is AtlasBaseTest {
             address(atlas),
             address(governanceEOA),
             defaultCallConfig()
-                .withTrackPreOpsReturnData(true)
+                .withTrackPreOpsReturnData(false)
                 .withTrackUserReturnData(true)
-                .withRequirePreOps(true)
+                .withRequirePreOps(false)
                 .withPostSolver(true)
                 .build());
     


### PR DESCRIPTION
As discussed in this audit issue https://github.com/spearbit-audits/review-fastlane/issues/72, we are limiting the options around tracking return data from hooks, to either tracking preOps return data, or tracking user call return data, or neither, but not both.

This is enforced at the AtlasVerification level, but also checked in the reference DAppControl constructor.

Note: other conflicting CallConfig setting combinations are not enforced at the AtlasVerification level. E.g. DApp and user nonces cannot both be sequential within the same metacall as it may cause a deadlock. This is checked in the reference DAppControl constructor but not in AtlasVerification.

Are we missing any CallConfig settings checks in AtlasVerification that should be there? 