### PR TITLE
Delegate call storage variables

### DIFF
--- a/src/contracts/dapp/DAppControl.sol
+++ b/src/contracts/dapp/DAppControl.sol
@@ -181,13 +181,13 @@ abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
 
     /// @notice Returns the current governance address of this DAppControl contract.
     /// @return The address of the current governance account of this DAppControl contract.
-    function getDAppSignatory() external view returns (address) {
+    function getDAppSignatory() external view mustBeCalled returns (address) {
         return governance;
     }
 
     /// @notice Starts the transfer of governance to a new address. Only callable by the current governance address.
     /// @param newGovernance The address of the new governance.
-    function transferGovernance(address newGovernance) external {
+    function transferGovernance(address newGovernance) external mustBeCalled {
         if (msg.sender != governance) {
             revert AtlasErrors.OnlyGovernance();
         }
@@ -196,7 +196,7 @@ abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
     }
 
     /// @notice Accepts the transfer of governance to a new address. Only callable by the new governance address.
-    function acceptGovernance() external {
+    function acceptGovernance() external mustBeCalled {
         address newGovernance = pendingGovernance;
         if (msg.sender != newGovernance) {
             revert AtlasErrors.Unauthorized();

--- a/src/contracts/dapp/DAppControl.sol
+++ b/src/contracts/dapp/DAppControl.sol
@@ -19,8 +19,10 @@ import { IDAppIntegration } from "src/contracts/interfaces/IDAppIntegration.sol"
 /// @notice Storage variables (except immutable) will be defaulted if accessed by delegatecalls.
 /// @notice If an extension DAppControl uses storage variables, those should not be accessed by delegatecalls.
 abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
-    // Reserved storage slots to avoid conflicts with ReentrancyGuard which is used in ExecutionEnvironment which delegatecalls this
-    // Attempts to use the same storage slots as ReentrancyGuard will result in storage collisions and a Dapp which does this should 
+    // Reserved storage slots to avoid conflicts with ReentrancyGuard which is used in ExecutionEnvironment which
+    // delegatecalls this
+    // Attempts to use the same storage slots as ReentrancyGuard will result in storage collisions and a Dapp which does
+    // this should
     // be considered malicious.
     uint256 private _reentrancyGuardReserved;
 

--- a/src/contracts/dapp/DAppControl.sol
+++ b/src/contracts/dapp/DAppControl.sol
@@ -16,6 +16,8 @@ import { IDAppIntegration } from "src/contracts/interfaces/IDAppIntegration.sol"
 /// @title DAppControl
 /// @author FastLane Labs
 /// @notice DAppControl is the base contract which should be inherited by any Atlas dApps.
+/// @notice Storage variables (except immutable) will be defaulted if accessed by delegatecalls.
+/// @notice If an extension DAppControl uses storage variables, those should not be accessed by delegatecalls.
 abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
     using CallBits for uint32;
 

--- a/src/contracts/dapp/DAppControl.sol
+++ b/src/contracts/dapp/DAppControl.sol
@@ -19,6 +19,11 @@ import { IDAppIntegration } from "src/contracts/interfaces/IDAppIntegration.sol"
 /// @notice Storage variables (except immutable) will be defaulted if accessed by delegatecalls.
 /// @notice If an extension DAppControl uses storage variables, those should not be accessed by delegatecalls.
 abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
+    // Reserved storage slots to avoid conflicts with ReentrancyGuard which is used in ExecutionEnvironment which delegatecalls this
+    // Attempts to use the same storage slots as ReentrancyGuard will result in storage collisions and a Dapp which does this should 
+    // be considered malicious.
+    uint256 private _reentrancyGuardReserved;
+
     using CallBits for uint32;
 
     uint8 private constant _CONTROL_DEPTH = 1 << 2;


### PR DESCRIPTION
To fix - https://github.com/spearbit-audits/review-fastlane/issues/186

Not sure how to address the `OZ ReentrancyGuard` part of the comment `Document the use of storage variables versus delegatecall, also taking into account usage in an indirect way, for example via OZ ReentrancyGuard.` in the issue.