### PR TITLE
Optimize `_verifyUser` in AtlasVerification

### DIFF
--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -601,13 +601,16 @@ contract AtlasVerification is EIP712, DAppIntegration, AtlasConstants {
         // Verify the signature before storing any data to avoid
         // spoof transactions clogging up dapp userNonces
 
-        // if (userOp.callConfig.allowsTrustedOpHash()) {
-        userOpHash = _getUserOperationPayload(userOp);
-        // }
-        bool signatureValid = SignatureChecker.isValidSignatureNow(userOp.from, userOpHash, userOp.signature);
-
         bool userIsBundler = userOp.from == msgSender;
         bool hasNoSignature = userOp.signature.length == 0;
+        bool signatureValid;
+
+        if (!userIsBundler) {
+            if (userOp.callConfig.allowsTrustedOpHash()) {
+                userOpHash = _getUserOperationHash(userOp, false);
+            }
+            signatureValid = SignatureChecker.isValidSignatureNow(userOp.from, userOpHash, userOp.signature);
+        }
 
         if (!(signatureValid || userIsBundler || (isSimulation && hasNoSignature))) {
             return ValidCallsResult.UserSignatureInvalid;
@@ -635,10 +638,6 @@ contract AtlasVerification is EIP712, DAppIntegration, AtlasConstants {
     /// @param userOp The UserOperation struct to generate the payload for.
     /// @return payload The hash of the UserOperation struct for use in signatures.
     function getUserOperationPayload(UserOperation calldata userOp) public view returns (bytes32 payload) {
-        payload = _getUserOperationPayload(userOp);
-    }
-
-    function _getUserOperationPayload(UserOperation calldata userOp) internal view returns (bytes32 payload) {
         payload = _getUserOperationHash(userOp, false);
     }
 


### PR DESCRIPTION
The key idea here is that if user is the bundler, we don't need to check the user signature (or do any of the prerequisite hashing) at all. This can save a lot of gas on a commonly used hot path.

| Metric                          | Before   | After    | Diff    |
|---------------------------------|----------|----------|---------|
| OEV test (gas)                  | 554,406  | 543,477  | -10,929 |
| SwapIntent test (gas)           | 510,641  | 503,570  | -7,071  |
| ExPost Ordering test (gas)      | 1,362,129| 1,356,334| -5,795  |
| Atlas Size (bytes)              | 25,017   | 25,017   | 0       |
| AtlasVerification Size (bytes)  | 15,822   | 15,847   | +25     |

As long as this doesn't skip any checks when they should be happening (scenarios: user is bundler or not X user is EOA or smart wallet X user has empty sig or not), I think the gas savings are worth adding.