### PR TITLE
Remove currentPhase and callConfig parameters from _validateTransfer function

### DIFF
--- a/src/contracts/common/ExecutionBase.sol
+++ b/src/contracts/common/ExecutionBase.sol
@@ -218,7 +218,7 @@ contract ExecutionBase is Base {
     /// @param destination The address to which the tokens will be transferred.
     /// @param amount The amount of tokens to transfer.
     function _transferUserERC20(address token, address destination, uint256 amount) internal {
-        IPermit69(ATLAS).transferUserERC20(token, destination, amount, _user(), _control(), _config(), _phase());
+        IPermit69(ATLAS).transferUserERC20(token, destination, amount, _user(), _control());
     }
 
     /// @notice Transfers ERC20 tokens from the DApp of the current metacall tx, via Atlas, to a specified destination.
@@ -227,7 +227,7 @@ contract ExecutionBase is Base {
     /// @param destination The address to which the tokens will be transferred.
     /// @param amount The amount of tokens to transfer.
     function _transferDAppERC20(address token, address destination, uint256 amount) internal {
-        IPermit69(ATLAS).transferDAppERC20(token, destination, amount, _user(), _control(), _config(), _phase());
+        IPermit69(ATLAS).transferDAppERC20(token, destination, amount, _user(), _control());
     }
 
     /// @notice Returns a bool indicating whether a source address has approved the Atlas contract to transfer a certain

--- a/src/contracts/common/Permit69.sol
+++ b/src/contracts/common/Permit69.sol
@@ -61,27 +61,17 @@ abstract contract Permit69 is GasAccounting {
     /// @param amount The amount of tokens to transfer.
     /// @param user The address of the user invoking the function.
     /// @param control The address of the current DAppControl contract.
-    /// @param callConfig The CallConfig of the current DAppControl contract.
-    /// @param currentPhase The lock state indicating the safe execution phase for the token transfer.
     function transferUserERC20(
         address token,
         address destination,
         uint256 amount,
         address user,
-        address control,
-        uint32 callConfig,
-        uint8 currentPhase
+        address control
     )
         external
     {
         // Validate that the transfer is legitimate
-        _validateTransfer({
-            user: user,
-            control: control,
-            callConfig: callConfig,
-            currentPhase: currentPhase,
-            safeExecutionPhaseSet: SAFE_USER_TRANSFER
-        });
+        _validateTransfer({ user: user, control: control, safeExecutionPhaseSet: SAFE_USER_TRANSFER });
 
         // Transfer token
         ERC20(token).safeTransferFrom(user, destination, amount);
@@ -94,27 +84,17 @@ abstract contract Permit69 is GasAccounting {
     /// @param amount The amount of tokens to transfer.
     /// @param user The address of the user invoking the function.
     /// @param control The address of the current DAppControl contract.
-    /// @param callConfig The CallConfig of the current DAppControl contract.
-    /// @param currentPhase The lock state indicating the safe execution phase for the token transfer.
     function transferDAppERC20(
         address token,
         address destination,
         uint256 amount,
         address user,
-        address control,
-        uint32 callConfig,
-        uint8 currentPhase
+        address control
     )
         external
     {
         // Validate that the transfer is legitimate
-        _validateTransfer({
-            user: user,
-            control: control,
-            callConfig: callConfig,
-            currentPhase: currentPhase,
-            safeExecutionPhaseSet: SAFE_DAPP_TRANSFER
-        });
+        _validateTransfer({ user: user, control: control, safeExecutionPhaseSet: SAFE_DAPP_TRANSFER });
 
         // Transfer token
         ERC20(token).safeTransferFrom(control, destination, amount);
@@ -123,39 +103,22 @@ abstract contract Permit69 is GasAccounting {
     /// @notice Verifies whether the lock state allows execution in the specified safe execution phase.
     /// @param user The address of the user invoking the function.
     /// @param control The address of the current DAppControl contract.
-    /// @param callConfig The CallConfig of the DAppControl contract of the current transaction.
-    /// @param currentPhase The lock state to be checked.
     /// @param safeExecutionPhaseSet The set of safe execution phases.
-    function _validateTransfer(
-        address user,
-        address control,
-        uint32 callConfig,
-        uint8 currentPhase,
-        uint8 safeExecutionPhaseSet
-    )
-        internal
-    {
+    function _validateTransfer(address user, address control, uint8 safeExecutionPhaseSet) internal {
         Lock memory _lock = lock;
 
         // Verify that the ExecutionEnvironment's context is correct.
         if (_lock.activeEnvironment != msg.sender) {
             revert InvalidEnvironment();
         }
-        if (uint8(_lock.phase) != currentPhase) {
-            revert WrongPhase();
-        }
-
-        if (_lock.callConfig != callConfig) {
-            revert EnvironmentMismatch();
-        }
 
         // Verify that the given user and control are the owners of this ExecutionEnvironment
-        if (!_verifyUserControlExecutionEnv(msg.sender, user, control, callConfig)) {
+        if (!_verifyUserControlExecutionEnv(msg.sender, user, control, _lock.callConfig)) {
             revert EnvironmentMismatch();
         }
 
         // Verify that the current phase allows for transfers
-        if (1 << currentPhase & safeExecutionPhaseSet == 0) {
+        if (1 << uint8(_lock.phase) & safeExecutionPhaseSet == 0) {
             revert InvalidLockState();
         }
     }

--- a/src/contracts/interfaces/IPermit69.sol
+++ b/src/contracts/interfaces/IPermit69.sol
@@ -17,9 +17,7 @@ interface IPermit69 {
         address destination,
         uint256 amount,
         address user,
-        address control,
-        uint32 callConfig,
-        uint8 phase
+        address control
     )
         external;
 
@@ -28,9 +26,7 @@ interface IPermit69 {
         address destination,
         uint256 amount,
         address user,
-        address control,
-        uint32 callConfig,
-        uint8 phase
+        address control
     )
         external;
 }

--- a/test/Permit69.t.sol
+++ b/test/Permit69.t.sol
@@ -98,7 +98,7 @@ contract Permit69Test is BaseTest {
         vm.prank(solverOneEOA);
         vm.expectRevert(AtlasErrors.InvalidEnvironment.selector);
         mockAtlas.transferUserERC20(
-            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl, mockCallConfig, uint8(phase)
+            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl
         );
     }
 
@@ -113,7 +113,7 @@ contract Permit69Test is BaseTest {
         // Uninitialized
         vm.expectRevert(AtlasErrors.InvalidLockState.selector);
         mockAtlas.transferUserERC20(
-            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl, mockCallConfig, uint8(phase)
+            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl
         );
 
         // AllocateValue
@@ -122,7 +122,7 @@ contract Permit69Test is BaseTest {
         mockAtlas.setPhase(phase);
         vm.expectRevert(AtlasErrors.InvalidLockState.selector);
         mockAtlas.transferUserERC20(
-            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl, mockCallConfig, uint8(phase)
+            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl
         );
 
         // Releasing
@@ -131,7 +131,7 @@ contract Permit69Test is BaseTest {
         mockAtlas.setPhase(phase);
         vm.expectRevert(AtlasErrors.InvalidLockState.selector);
         mockAtlas.transferUserERC20(
-            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl, mockCallConfig, uint8(phase)
+            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl
         );
 
         vm.stopPrank();
@@ -152,7 +152,7 @@ contract Permit69Test is BaseTest {
 
         vm.prank(mockExecutionEnvAddress);
         mockAtlas.transferUserERC20(
-            WETH_ADDRESS, solverOneEOA, wethTransferred, mockUser, mockDAppControl, mockCallConfig, uint8(phase)
+            WETH_ADDRESS, solverOneEOA, wethTransferred, mockUser, mockDAppControl
         );
 
         assertEq(WETH.balanceOf(mockUser), userWethBefore - wethTransferred, "User did not lose WETH");
@@ -168,7 +168,7 @@ contract Permit69Test is BaseTest {
         vm.prank(solverOneEOA);
         vm.expectRevert(AtlasErrors.InvalidEnvironment.selector);
         mockAtlas.transferDAppERC20(
-            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl, mockCallConfig, uint8(phase)
+            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl
         );
     }
 
@@ -182,7 +182,7 @@ contract Permit69Test is BaseTest {
         mockAtlas.setPhase(phase);
         vm.expectRevert(AtlasErrors.InvalidLockState.selector);
         mockAtlas.transferDAppERC20(
-            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl, mockCallConfig, uint8(phase)
+            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl
         );
 
         // UserOperation
@@ -190,7 +190,7 @@ contract Permit69Test is BaseTest {
         mockAtlas.setPhase(phase);
         vm.expectRevert(AtlasErrors.InvalidLockState.selector);
         mockAtlas.transferDAppERC20(
-            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl, mockCallConfig, uint8(phase)
+            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl
         );
 
         // SolverOperations
@@ -198,7 +198,7 @@ contract Permit69Test is BaseTest {
         mockAtlas.setPhase(phase);
         vm.expectRevert(AtlasErrors.InvalidLockState.selector);
         mockAtlas.transferDAppERC20(
-            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl, mockCallConfig, uint8(phase)
+            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl
         );
 
         // Releasing
@@ -206,7 +206,7 @@ contract Permit69Test is BaseTest {
         mockAtlas.setPhase(phase);
         vm.expectRevert(AtlasErrors.InvalidLockState.selector);
         mockAtlas.transferDAppERC20(
-            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl, mockCallConfig, uint8(phase)
+            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl
         );
 
         vm.stopPrank();
@@ -226,7 +226,7 @@ contract Permit69Test is BaseTest {
 
         vm.prank(mockExecutionEnvAddress);
         mockAtlas.transferDAppERC20(
-            WETH_ADDRESS, solverOneEOA, wethTransferred, mockUser, mockDAppControl, mockCallConfig, uint8(phase)
+            WETH_ADDRESS, solverOneEOA, wethTransferred, mockUser, mockDAppControl
         );
 
         assertEq(WETH.balanceOf(mockDAppControl), dAppWethBefore - wethTransferred, "DApp did not lose WETH");


### PR DESCRIPTION
Related audit issue: https://github.com/spearbit-audits/review-fastlane/issues/194

Removing `currentPhase` and `callConfig` parameters for `transferUserERC20` and `transferDAppERC20` functions, and read them from `lock`, which is our most trusted source of truth.

Diffs for `metacall` in `testAtlasSwapIntentWithBasicRFQ`:
| Metric       | Before              | After               | Change |
| ---------- | -------------- | --------------|------- |
| Gas           | 518,471          | 517,788          | -683     |
| Atlas size  | 25,450 bytes  | 25,336 bytes | -114 bytes |