### PR TITLE
checkUserOperation template in preOpsHook

### DIFF
--- a/src/contracts/examples/ex-post-mev-example/V2ExPost.sol
+++ b/src/contracts/examples/ex-post-mev-example/V2ExPost.sol
@@ -68,7 +68,7 @@ contract V2ExPost is DAppControl {
         )
     { }
 
-    function _checkUserOperation(UserOperation calldata userOp) internal view {
+    function _checkUserOperation(UserOperation memory userOp) internal view {
         require(bytes4(userOp.data) == IUniswapV2Pair.swap.selector, "ERR-H10 InvalidFunction");
         require(
             IUniswapV2Factory(IUniswapV2Pair(userOp.dapp).factory()).getPair(

--- a/src/contracts/examples/ex-post-mev-example/V2ExPost.sol
+++ b/src/contracts/examples/ex-post-mev-example/V2ExPost.sol
@@ -68,7 +68,7 @@ contract V2ExPost is DAppControl {
         )
     { }
 
-    function _preOpsCall(UserOperation calldata userOp) internal override returns (bytes memory returnData) {
+    function _checkUserOperation(UserOperation calldata userOp) internal view {
         require(bytes4(userOp.data) == IUniswapV2Pair.swap.selector, "ERR-H10 InvalidFunction");
         require(
             IUniswapV2Factory(IUniswapV2Pair(userOp.dapp).factory()).getPair(
@@ -76,6 +76,11 @@ contract V2ExPost is DAppControl {
             ) == userOp.dapp,
             "ERR-H11 Invalid pair"
         );
+    }
+
+    function _preOpsCall(UserOperation calldata userOp) internal override returns (bytes memory returnData) {
+        // check if dapps using this DApontrol can handle the userOp
+        _checkUserOperation(userOp);
 
         (
             uint256 amount0Out,

--- a/src/contracts/examples/v2-example-router/V2RewardDAppControl.sol
+++ b/src/contracts/examples/v2-example-router/V2RewardDAppControl.sol
@@ -130,6 +130,11 @@ contract V2RewardDAppControl is DAppControl {
     //                     Atlas hooks                      //
     // ---------------------------------------------------- //
 
+    function _checkUserOperation(UserOperation calldata userOp) internal view {
+        // User is only allowed to call UniswapV2Router02
+        require(userOp.dapp == uniswapV2Router02, "V2RewardDAppControl: InvalidDestination");
+    }
+
     /*
     * @notice This function is called before the user's call to UniswapV2Router02
     * @dev This function is delegatecalled: msg.sender = Atlas, address(this) = ExecutionEnvironment
@@ -140,8 +145,8 @@ contract V2RewardDAppControl is DAppControl {
         _postOpsCall hook to refund leftover dust, if any
     */
     function _preOpsCall(UserOperation calldata userOp) internal override returns (bytes memory) {
-        // User is only allowed to call UniswapV2Router02
-        require(userOp.dapp == uniswapV2Router02, "V2RewardDAppControl: InvalidDestination");
+        // check if dapps using this DAppControl can handle the userOp
+        _checkUserOperation(userOp);
 
         // The current hook is delegatecalled, so we need to call the userOp.control to access the mappings
         (address tokenSold, uint256 amountSold) = V2RewardDAppControl(userOp.control).getTokenSold(userOp.data);

--- a/src/contracts/examples/v2-example-router/V2RewardDAppControl.sol
+++ b/src/contracts/examples/v2-example-router/V2RewardDAppControl.sol
@@ -130,7 +130,7 @@ contract V2RewardDAppControl is DAppControl {
     //                     Atlas hooks                      //
     // ---------------------------------------------------- //
 
-    function _checkUserOperation(UserOperation calldata userOp) internal view {
+    function _checkUserOperation(UserOperation memory userOp) internal view {
         // User is only allowed to call UniswapV2Router02
         require(userOp.dapp == uniswapV2Router02, "V2RewardDAppControl: InvalidDestination");
     }

--- a/src/contracts/examples/v2-example/V2DAppControl.sol
+++ b/src/contracts/examples/v2-example/V2DAppControl.sol
@@ -86,7 +86,7 @@ contract V2DAppControl is DAppControl {
         }
     }
 
-    function _checkUserOperation(UserOperation calldata userOp) internal view {
+    function _checkUserOperation(UserOperation memory userOp) internal view {
         require(bytes4(userOp.data) == SWAP, "ERR-H10 InvalidFunction");
 
         require(

--- a/src/contracts/examples/v2-example/V2DAppControl.sol
+++ b/src/contracts/examples/v2-example/V2DAppControl.sol
@@ -86,7 +86,7 @@ contract V2DAppControl is DAppControl {
         }
     }
 
-    function _preOpsCall(UserOperation calldata userOp) internal override returns (bytes memory) {
+    function _checkUserOperation(UserOperation calldata userOp) internal view {
         require(bytes4(userOp.data) == SWAP, "ERR-H10 InvalidFunction");
 
         require(
@@ -95,6 +95,12 @@ contract V2DAppControl is DAppControl {
             ) == userOp.dapp,
             "ERR-H11 Invalid pair"
         );
+    }
+
+    function _preOpsCall(UserOperation calldata userOp) internal override returns (bytes memory) {
+        // check if dapps using this DAppControl can handle the userOp
+        _checkUserOperation(userOp);
+
         (
             uint256 amount0Out,
             uint256 amount1Out,

--- a/src/contracts/examples/v4-example/V4DAppControl.sol
+++ b/src/contracts/examples/v4-example/V4DAppControl.sol
@@ -88,7 +88,7 @@ contract V4DAppControl is DAppControl {
     //                   ATLAS CALLS                       //
     /////////////////////////////////////////////////////////
 
-    function _checkUserOperation(UserOperation calldata userOp) internal view {
+    function _checkUserOperation(UserOperation memory userOp) internal view {
         require(bytes4(userOp.data) == SWAP, "ERR-H10 InvalidFunction");
         require(userOp.dapp == v4Singleton, "ERR-H11 InvalidTo"); // this is wrong
     }

--- a/src/contracts/examples/v4-example/V4DAppControl.sol
+++ b/src/contracts/examples/v4-example/V4DAppControl.sol
@@ -88,17 +88,21 @@ contract V4DAppControl is DAppControl {
     //                   ATLAS CALLS                       //
     /////////////////////////////////////////////////////////
 
+    function _checkUserOperation(UserOperation calldata userOp) internal view {
+        require(bytes4(userOp.data) == SWAP, "ERR-H10 InvalidFunction");
+        require(userOp.dapp == v4Singleton, "ERR-H11 InvalidTo"); // this is wrong
+    }
+
     /////////////// DELEGATED CALLS //////////////////
     function _preOpsCall(UserOperation calldata userOp) internal override returns (bytes memory preOpsData) {
         // This function is delegatecalled
         // address(this) = ExecutionEnvironment
         // msg.sender = Atlas Escrow
 
+        // check if dapps using this DAppControl can handle the userOp
+        _checkUserOperation(userOp);
+
         require(!_currentKey.initialized, "ERR-H09 AlreadyInitialized");
-
-        require(bytes4(userOp.data) == SWAP, "ERR-H10 InvalidFunction");
-
-        require(userOp.dapp == v4Singleton, "ERR-H11 InvalidTo"); // this is wrong
 
         // Verify that the swapper went through the FastLane Atlas MEV Auction
         // and that DAppControl supplied a valid signature

--- a/src/contracts/types/DAppApprovalTypes.sol
+++ b/src/contracts/types/DAppApprovalTypes.sol
@@ -35,6 +35,8 @@ struct CallConfig {
     // the callChainHash.
     bool dappNoncesSequential;
     // requirePreOps: The preOps hook is executed before the userOp is executed. If false, the preOps hook is skipped.
+    // the dapp control should check the validity of the user operation (whether its dapps can support userOp.dapp and
+    // userOp.data) in the preOps hook.
     bool requirePreOps;
     // trackPreOpsReturnData: The return data from the preOps hook is passed to the next call phase. If false preOps
     // return data is discarded. If both trackPreOpsReturnData and trackUserReturnData are true, they are concatenated.


### PR DESCRIPTION
Added a `_checkUserOperation()` function in some `DAppControl` examples which use the `preOpsHook` to check if the `userOp.dapp` and `userOp.data` can be supported by the dapps using the respective controls.

To partially address https://github.com/spearbit-audits/review-fastlane/issues/199