### PR TITLE
Gracefully returns when validateCalls fails

### DIFF
--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -60,7 +60,9 @@ contract Atlas is Escrow, Factory {
             if (isSimulation) revert VerificationSimFail(validCallsResult);
 
             // Gracefully return for results that need nonces to be stored and prevent replay attacks
-            if (uint8(validCallsResult) >= _GRACEFUL_RETURN_THRESHOLD && !dConfig.callConfig.allowsReuseUserOps()) return false;
+            if (uint8(validCallsResult) >= _GRACEFUL_RETURN_THRESHOLD && !dConfig.callConfig.allowsReuseUserOps()) {
+                return false;
+            }
 
             // Revert for all other results
             revert ValidCalls(validCallsResult);

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -60,7 +60,7 @@ contract Atlas is Escrow, Factory {
             if (isSimulation) revert VerificationSimFail(validCallsResult);
 
             // Gracefully return for results that need nonces to be stored and prevent replay attacks
-            if (uint8(validCallsResult) > uint8(ValidCallsResult.GRACEFUL_RETURN_THRESHOLD)) return false;
+            if (uint8(validCallsResult) >= _GRACEFUL_RETURN_THRESHOLD) return false;
 
             // Revert for all other results
             revert ValidCalls(validCallsResult);

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -59,9 +59,11 @@ contract Atlas is Escrow, Factory {
         if (validCallsResult != ValidCallsResult.Valid) {
             if (isSimulation) revert VerificationSimFail(validCallsResult);
 
-            // Gracefully return if invalid and not in simulation mode. This allows nonces to be stored and prevents
-            // replay attacks.
-            return false;
+            // Gracefully return for results that need nonces to be stored and prevent replay attacks
+            if (uint8(validCallsResult) > uint8(ValidCallsResult.GRACEFUL_RETURN_THRESHOLD)) return false;
+
+            // Revert for all other results
+            revert ValidCalls(validCallsResult);
         }
 
         // Initialize the lock

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -54,14 +54,14 @@ contract Atlas is Escrow, Factory {
 
         (address executionEnvironment, DAppConfig memory dConfig) = _getOrCreateExecutionEnvironment(userOp);
 
-        // Gracefully return if not valid. This allows signature data to be stored, which helps prevent
-        // replay attacks.
-        // NOTE: Currently reverting instead of graceful return to help w/ testing. TODO - still reverting?
         ValidCallsResult validCallsResult =
             VERIFICATION.validateCalls(dConfig, userOp, solverOps, dAppOp, msg.value, msg.sender, isSimulation);
         if (validCallsResult != ValidCallsResult.Valid) {
             if (isSimulation) revert VerificationSimFail(validCallsResult);
-            revert ValidCalls(validCallsResult);
+
+            // Gracefully return if invalid and not in simulation mode. This allows nonces to be stored and prevents
+            // replay attacks.
+            return false;
         }
 
         // Initialize the lock

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -60,7 +60,7 @@ contract Atlas is Escrow, Factory {
             if (isSimulation) revert VerificationSimFail(validCallsResult);
 
             // Gracefully return for results that need nonces to be stored and prevent replay attacks
-            if (uint8(validCallsResult) >= _GRACEFUL_RETURN_THRESHOLD) return false;
+            if (uint8(validCallsResult) >= _GRACEFUL_RETURN_THRESHOLD && !dConfig.callConfig.allowsReuseUserOps()) return false;
 
             // Revert for all other results
             revert ValidCalls(validCallsResult);

--- a/src/contracts/atlas/Storage.sol
+++ b/src/contracts/atlas/Storage.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.22;
 
 import "src/contracts/types/EscrowTypes.sol";
 import "src/contracts/types/LockTypes.sol";
+import "src/contracts/types/ValidCallsTypes.sol";
 import { AtlasEvents } from "src/contracts/types/AtlasEvents.sol";
 import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 import { AtlasConstants } from "src/contracts/types/AtlasConstants.sol";
@@ -33,6 +34,8 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
     // AtlETH ERC-20 storage
     uint256 public totalSupply;
     uint256 public bondedTotalSupply;
+
+    uint8 internal constant _GRACEFUL_RETURN_THRESHOLD = uint8(ValidCallsResult.InvertBidValueCannotBeExPostBids) + 1;
 
     mapping(address => uint256) public nonces;
     mapping(address => EscrowAccountBalance) internal _balanceOf;

--- a/src/contracts/types/ValidCallsTypes.sol
+++ b/src/contracts/types/ValidCallsTypes.sol
@@ -6,7 +6,7 @@ pragma solidity 0.8.22;
 /// @dev A single ValidCallsResult is returned by `validateCalls` in AtlasVerification
 enum ValidCallsResult {
     Valid,
-    // Results below will cause metacall to revert
+    // Results below this line will cause metacall to revert
     UserFromInvalid,
     UserSignatureInvalid,
     DAppSignatureInvalid,
@@ -15,9 +15,10 @@ enum ValidCallsResult {
     UnknownAuctioneerNotAllowed,
     InvalidAuctioneer,
     InvalidBundler,
-    InvertBidValueCannotBeExPostBids,
-    GRACEFUL_RETURN_THRESHOLD, // Do not use this value as a result
-    // Results below will cause metacall to gracefully return
+    // Results above this line will cause metacall to revert
+    InvertBidValueCannotBeExPostBids, // Threshold value (included in the revert range), any new reverting values should
+        // be included above this line
+    // Results below this line will cause metacall to gracefully return
     GasPriceHigherThanMax,
     TxValueLowerThanCallValue,
     TooManySolverOps,

--- a/src/contracts/types/ValidCallsTypes.sol
+++ b/src/contracts/types/ValidCallsTypes.sol
@@ -6,33 +6,36 @@ pragma solidity 0.8.22;
 /// @dev A single ValidCallsResult is returned by `validateCalls` in AtlasVerification
 enum ValidCallsResult {
     Valid,
+    // Results below will cause metacall to revert
+    UserFromInvalid,
+    UserSignatureInvalid,
+    DAppSignatureInvalid,
+    UserNonceInvalid,
+    InvalidDAppNonce,
+    UnknownAuctioneerNotAllowed,
+    InvalidAuctioneer,
+    InvalidBundler,
+    InvertBidValueCannotBeExPostBids,
+    GRACEFUL_RETURN_THRESHOLD, // Do not use this value as a result
+    // Results below will cause metacall to gracefully return
     GasPriceHigherThanMax,
     TxValueLowerThanCallValue,
-    DAppSignatureInvalid,
-    UserSignatureInvalid,
     TooManySolverOps,
     UserDeadlineReached,
     DAppDeadlineReached,
     ExecutionEnvEmpty,
     NoSolverOp,
-    UnknownAuctioneerNotAllowed,
     InvalidSequence,
-    InvalidAuctioneer,
-    InvalidBundler,
     OpHashMismatch,
     DeadlineMismatch,
     InvalidControl,
     InvalidSolverGasLimit,
-    InvalidDAppNonce,
     InvalidCallConfig,
     CallConfigMismatch,
     DAppToInvalid,
-    UserFromInvalid,
     UserToInvalid,
     ControlMismatch,
-    UserNonceInvalid,
     InvalidCallChainHash,
     DAppNotEnabled,
-    BothUserAndDAppNoncesCannotBeSequential,
-    InvertBidValueCannotBeExPostBids
+    BothUserAndDAppNoncesCannotBeSequential
 }


### PR DESCRIPTION
Gracefully returns on `validateCalls` failure.
This is in order to store nonces and avoid replay attacks.

Note: we could make this depend on the `reuseUserOp` config flag.