### PR TITLE
Remove Unused ERC20 Variables

### DIFF
--- a/src/contracts/atlas/Storage.sol
+++ b/src/contracts/atlas/Storage.sol
@@ -16,7 +16,7 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
     AtlasVerification public immutable VERIFICATION;
     address public immutable SIMULATOR;
 
-    // AtlETH ERC-20 public constants
+    // AtlETH public constants
     string public constant name = "Atlas ETH";
     string public constant symbol = "atlETH";
     uint8 public constant decimals = 18;
@@ -27,17 +27,12 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
     uint256 public constant SURCHARGE_SCALE = 10_000_000; // 10_000_000 / 10_000_000 = 100%
     uint256 public constant FIXED_GAS_OFFSET = 100_000;
 
-    // AtlETH EIP-2612 constants
-    uint256 internal immutable _INITIAL_CHAIN_ID;
-    bytes32 internal immutable _INITIAL_DOMAIN_SEPARATOR;
-
-    // AtlETH ERC-20 storage
+    // AtlETH storage
     uint256 public totalSupply;
     uint256 public bondedTotalSupply;
 
     mapping(address => uint256) public nonces;
     mapping(address => EscrowAccountBalance) internal _balanceOf;
-    mapping(address => mapping(address => uint256)) public allowance;
     mapping(address => EscrowAccountAccessData) public accessData;
     mapping(bytes32 => bool) internal _solverOpHashes; // NOTE: Only used for when allowTrustedOpHash is enabled
 
@@ -67,8 +62,6 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
         ESCROW_DURATION = _escrowDuration;
         VERIFICATION = AtlasVerification(_verification);
         SIMULATOR = _simulator;
-        _INITIAL_CHAIN_ID = block.chainid;
-        _INITIAL_DOMAIN_SEPARATOR = _computeDomainSeparator();
 
         // Gas Accounting
         // Initialized with msg.value to seed flash loan liquidity

--- a/test/Storage.t.sol
+++ b/test/Storage.t.sol
@@ -19,8 +19,6 @@ contract StorageTest is Test {
         assertEq(s.ESCROW_DURATION(), 1);
         assertEq(address(s.VERIFICATION()), address(1));
         assertEq(s.SIMULATOR(), address(2));
-        assertEq(s.getInitialChainId(), block.chainid);
-        assertEq(s.getInitialDomainSeparator(), bytes32("SEPARATOR"));
     }
 
     function testStorageSlotsDontChange() public {
@@ -60,16 +58,4 @@ contract MockStorageTests is Storage {
     )
         Storage(_escrowDuration, _verification, _simulator, _surchargeRecipient)
     { }
-
-    function getInitialChainId() public view returns (uint256) {
-        return _INITIAL_CHAIN_ID;
-    }
-
-    function getInitialDomainSeparator() public view returns (bytes32) {
-        return _INITIAL_DOMAIN_SEPARATOR;
-    }
-
-    function _computeDomainSeparator() internal view virtual override returns (bytes32) {
-        return bytes32("SEPARATOR");
-    }
 }


### PR DESCRIPTION
Removed ERC20 related vars as AtlETH is no longer an ERC20 token.

With the exception of these constants as they may still be useful to any solvers using AtlETH, as it is still a token technically.

```
// AtlETH public constants
string public constant name = "Atlas ETH";
string public constant symbol = "atlETH";
uint8 public constant decimals = 18;
```