### PR TITLE
Only `solverOp.solver` can call `reconcile()`

### DIFF
--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -591,6 +591,7 @@ abstract contract Escrow is AtlETH {
 
         // Set the solver lock - if we revert here we'll catch the error in `_solverOpWrapper()` above
         _setSolverLock(uint256(uint160(solverOp.from)));
+        _setSolverTo(solverOp.solver);
 
         // Optimism's SafeCall lib allows us to limit how much returndata gets copied to memory, to prevent OOG attacks.
         _success = solverOp.solver.safeCall(

--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -98,6 +98,7 @@ abstract contract GasAccounting is SafetyLocks {
         // calls directly to the solver contract in this phase, the solver should be careful to not call malicious
         // contracts which may call reconcile() on their behalf, with an excessive maxApprovedGasSpend.
         if (_phase() != uint8(ExecutionPhase.SolverOperation)) revert WrongPhase();
+        if (msg.sender != _solverTo()) revert InvalidAccess();
 
         (address _currentSolver, bool _calledBack, bool _fulfilled) = _solverLockData();
         uint256 _bondedBalance = uint256(S_accessData[_currentSolver].bonded);

--- a/src/contracts/atlas/Storage.sol
+++ b/src/contracts/atlas/Storage.sol
@@ -31,6 +31,7 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
     // Transient storage slots
     bytes32 private constant _T_LOCK_SLOT = keccak256("LOCK");
     bytes32 private constant _T_SOLVER_LOCK_SLOT = keccak256("SOLVER_LOCK");
+    bytes32 private constant _T_SOLVER_TO_SLOT = keccak256("SOLVER_TO");
     bytes32 private constant _T_CLAIMS_SLOT = keccak256("CLAIMS");
     bytes32 private constant _T_FEES_SLOT = keccak256("FEES");
     bytes32 private constant _T_WRITEOFFS_SLOT = keccak256("WRITEOFFS");
@@ -190,6 +191,10 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
         fulfilled = _solverLock & _SOLVER_FULFILLED_MASK != 0;
     }
 
+    function _solverTo() internal view returns (address) {
+        return address(uint160(uint256(_tload(_T_SOLVER_TO_SLOT))));
+    }
+
     function _isUnlocked() internal view returns (bool) {
         return _tload(_T_LOCK_SLOT) == bytes32(0);
     }
@@ -216,6 +221,10 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
 
     function _setSolverLock(uint256 newSolverLock) internal {
         _tstore(_T_SOLVER_LOCK_SLOT, bytes32(newSolverLock));
+    }
+
+    function _setSolverTo(address newSolverTo) internal {
+        _tstore(_T_SOLVER_TO_SLOT, bytes32(uint256(uint160(newSolverTo))));
     }
 
     function _setClaims(uint256 newClaims) internal {


### PR DESCRIPTION
An updated resolution to this audit issue: https://github.com/spearbit-audits/review-fastlane/issues/21

Summary: only the `solverOp.solver` address is able to call `reconcile()` in a solver's `SolverOperation` phase. 

Code Changes:

- Added a new transient storage variable for `solverOp.solver` address which is set just before the solver call, and just after the `solverLock` is set.
- Added a check in `reconcile()` that the caller is the current `solverOp.solver` as read from the  `_solverTo()` transient storage var. 

Metric Changes:

| Metric           | Before   | After    | Diff      |
|------------------|----------|----------|-----------|
| SwapIntent test (gas)          | 401,563  | 402,051   | +488       |
| ExPost Ordering test (gas)              | 1,311,055| 1,313,007 | +1,952     |
| OEV test (gas)                  | 458,929  | 459,417   | +488       |
| Atlas size (bytes)         | 24,194   | 24,343    | +149       |

So about 500 gas increase per solver that needs to be set and read in the new transient storage variable, per metacall.