### PR TITLE
fix: removed _FIRST_240_BITS_TRUE_MASK

### DIFF
--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -230,7 +230,7 @@ contract Atlas is Escrow, Factory {
         // Finally, iterate through sorted bidsAndIndices array in descending order of bidAmount.
         for (uint256 i = _bidsAndIndicesLastIndex; i >= 0; --i) {
             // Isolate the bidAmount from the packed uint256 value
-            _bidAmountFound = (_bidsAndIndices[i] >> _BITS_FOR_INDEX) & _FIRST_240_BITS_TRUE_MASK;
+            _bidAmountFound = _bidsAndIndices[i] >> _BITS_FOR_INDEX;
 
             // If we reach the zero bids on the left of array, break as all valid bids already checked.
             if (_bidAmountFound == 0) break;


### PR DESCRIPTION
Audit Issue: https://github.com/FastLane-Labs/atlas-issues/issues/82

Changes:

- removed  _FIRST_240_BITS_TRUE_MASK check, since the lower 16 bits have been discarded by the right shift, the resulting value is guaranteed to fit within 240 bits