### PR TITLE
Refactor Test Harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "source": "source .env",
       "allexport": "set -o allexport; source .env; set +o allexport",
       "reinstall": "rm -rf node_modules && rm -f yarn.lock && yarn clean && yarn",
-      "coverage": "forge coverage --ir-minimum --report lcov && node filter_lcov.js && genhtml lcov_filtered.info --output-directory report && open report/index.html",
+      "coverage": "forge coverage --ir-minimum --no-match-test SkipCoverage --report lcov && node filter_lcov.js && genhtml lcov_filtered.info --output-directory report && open report/index.html",
       "gas": "forge test -vv --gas-report",
       "ftest": "source .env && forge test --gas-price=1500000000",
       "ftest-fork": "source .env && forge test -vvv --fork-url ${ALCHEMY_APIKEY_MUMBAI} --fork-block-number 26702726 --gas-report",

--- a/test/Accounting.t.sol
+++ b/test/Accounting.t.sol
@@ -63,7 +63,7 @@ contract AccountingTest is BaseTest {
         });
     }
 
-    function testSolverBorrowRepaySuccessfully() public {
+    function testSolverBorrowRepaySuccessfully_SkipCoverage() public {
         // Solver deploys the RFQ solver contract (defined at bottom of this file)
         vm.startPrank(solverOneEOA);
         HonestRFQSolver honestSolver = new HonestRFQSolver(WETH_ADDRESS, address(atlas));
@@ -88,7 +88,7 @@ contract AccountingTest is BaseTest {
         // console.log("UserEOA", userEOA);
     }
 
-    function testSolverBorrowWithoutRepayingReverts() public {
+    function testSolverBorrowWithoutRepayingReverts_SkipCoverage() public {
         // Solver deploys the RFQ solver contract (defined at bottom of this file)
         vm.startPrank(solverOneEOA);
         // TODO make evil solver

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -134,7 +134,7 @@ contract EscrowTest is AtlasBaseTest {
     // Ensure the preOps hook is successfully called. To ensure the hooks' returned data is as expected, we forward it
     // to the solver call; the data field of the solverOperation contains the expected value, the check is made in the
     // solver's atlasSolverCall function, as defined in the DummySolver contract.
-    function test_executePreOpsCall_success() public {
+    function test_executePreOpsCall_success_SkipCoverage() public {
         defaultAtlasWithCallConfig(
             defaultCallConfig()
                 .withRequirePreOps(true) // Execute the preOps hook
@@ -160,7 +160,7 @@ contract EscrowTest is AtlasBaseTest {
     // Ensure the user operation executes successfully. To ensure the operation's returned data is as expected, we
     // forward it to the solver call; the data field of the solverOperation contains the expected value, the check is
     // made in the solver's atlasSolverCall function, as defined in the DummySolver contract.
-    function test_executeUserOperation_success() public {
+    function test_executeUserOperation_success_SkipCoverage() public {
         defaultAtlasWithCallConfig(
             defaultCallConfig()
                 .withTrackUserReturnData(true) // Track the user operation's return data
@@ -182,7 +182,7 @@ contract EscrowTest is AtlasBaseTest {
     }
 
     // Ensure metacall reverts with the proper error when the allocateValue hook reverts.
-    function test_executeAllocateValueCall_failure() public {
+    function test_executeAllocateValueCall_failure_SkipCoverage() public {
         defaultAtlasWithCallConfig(
             defaultCallConfig()
                 .withTrackUserReturnData(true) // Track the user operation's return data
@@ -196,7 +196,7 @@ contract EscrowTest is AtlasBaseTest {
 
     // Ensure the postOps hook is successfully called. No return data is expected from the postOps hook, so we do not
     // forward any data to the solver call.
-    function test_executePostOpsCall_success() public {
+    function test_executePostOpsCall_success_SkipCoverage() public {
         defaultAtlasWithCallConfig(
             defaultCallConfig()
                 .withRequirePostOps(true) // Execute the postOps hook
@@ -206,7 +206,7 @@ contract EscrowTest is AtlasBaseTest {
     }
 
     // Ensure metacall reverts with the proper error when the postOps hook reverts.
-    function test_executePostOpsCall_failure() public {
+    function test_executePostOpsCall_failure_SkipCoverage() public {
         defaultAtlasWithCallConfig(
             defaultCallConfig()
                 .withTrackUserReturnData(true) // Track the user operation's return data
@@ -222,7 +222,7 @@ contract EscrowTest is AtlasBaseTest {
     // Ensure the allocateValue hook is successfully called. No return data is expected from the allocateValue hook, so
     // we check by emitting an event in the hook. The emitter must be the executionEnvironment since allocateValue is
     // delegatecalled.
-    function test_allocateValue_success() public {
+    function test_allocateValue_success_SkipCoverage() public {
         defaultAtlasWithCallConfig(
             defaultCallConfig()
                 .withTrackUserReturnData(true) // Track the user operation's return data
@@ -283,7 +283,7 @@ contract EscrowTest is AtlasBaseTest {
         executeSolverOperationCase(userOp, solverOps, false, false, 1 << uint256(SolverOutcome.InvalidTo), true);
     }
 
-    function test_executeSolverOperation_validateSolverOperation_perBlockLimit() public {
+    function test_executeSolverOperation_validateSolverOperation_perBlockLimit_SkipCoverage() public {
         vm.prank(solverOneEOA);
         atlas.unbond(1); // This will set the solver's lastAccessedBlock to the current block
 
@@ -291,7 +291,7 @@ contract EscrowTest is AtlasBaseTest {
         executeSolverOperationCase(userOp, solverOps, false, false, 1 << uint256(SolverOutcome.PerBlockLimit), false);
     }
 
-    function test_executeSolverOperation_validateSolverOperation_insufficientEscrow() public {
+    function test_executeSolverOperation_validateSolverOperation_insufficientEscrow_SkipCoverage() public {
         // Solver only has 1 ETH escrowed
         vm.txGasPrice(10e18); // Set a gas price that will cause the solver to run out of escrow
         uint256 solverGasLimit = 1_000_000;
@@ -307,7 +307,7 @@ contract EscrowTest is AtlasBaseTest {
         executeSolverOperationCase(userOp, solverOps, false, false, 1 << uint256(SolverOutcome.InsufficientEscrow), true);
     }
 
-    function test_executeSolverOperation_validateSolverOperation_callValueTooHigh() public {
+    function test_executeSolverOperation_validateSolverOperation_callValueTooHigh_SkipCoverage() public {
         // Will revert with CallValueTooHigh if more ETH than held in Atlas requested
         uint256 solverOpValue = 100 ether;
         assertTrue(solverOpValue > address(atlas).balance, "solverOpValue must be greater than Atlas balance to trigger CallValueTooHigh");
@@ -320,14 +320,14 @@ contract EscrowTest is AtlasBaseTest {
         executeSolverOperationCase(userOp, solverOps, false, false, 1 << uint256(SolverOutcome.CallValueTooHigh), false);
     }
 
-    function test_executeSolverOperation_validateSolverOperation_userOutOfGas() public {
+    function test_executeSolverOperation_validateSolverOperation_userOutOfGas_SkipCoverage() public {
         (UserOperation memory userOp, SolverOperation[] memory solverOps) = executeSolverOperationInit(defaultCallConfig().build());
         this.executeSolverOperationCase{gas: _VALIDATION_GAS_LIMIT + _SOLVER_GAS_LIMIT + 1_000_000}(
             userOp, solverOps, false, false, 1 << uint256(SolverOutcome.UserOutOfGas), true
         );
     }
 
-    function test_executeSolverOperation_solverOpWrapper_BidNotPaid() public {
+    function test_executeSolverOperation_solverOpWrapper_BidNotPaid_SkipCoverage() public {
         (UserOperation memory userOp, SolverOperation[] memory solverOps) = executeSolverOperationInit(
             defaultCallConfig()
                 .withRequireFulfillment(true)
@@ -340,7 +340,7 @@ contract EscrowTest is AtlasBaseTest {
         executeSolverOperationCase(userOp, solverOps, true, false, result, true);
     }
 
-    function test_executeSolverOperation_solverOpWrapper_CallbackNotCalled() public {
+    function test_executeSolverOperation_solverOpWrapper_CallbackNotCalled_SkipCoverage() public {
         // Fails because solver doesn't call reconcile() at all
         uint256 bidAmount = dummySolver.noGasPayBack(); // Special bid value that will cause the solver to not call reconcile
         deal(address(dummySolver), bidAmount);
@@ -354,7 +354,7 @@ contract EscrowTest is AtlasBaseTest {
         executeSolverOperationCase(userOp, solverOps, true, false, result, true);
     }
 
-    function test_executeSolverOperation_solverOpWrapper_SolverOpReverted() public {
+    function test_executeSolverOperation_solverOpWrapper_SolverOpReverted_SkipCoverage() public {
         (UserOperation memory userOp, SolverOperation[] memory solverOps) = executeSolverOperationInit(
             defaultCallConfig()
                 .withTrackUserReturnData(true)
@@ -370,7 +370,7 @@ contract EscrowTest is AtlasBaseTest {
         executeSolverOperationCase(userOp, solverOps, true, false, result, true);
     }
 
-    function test_executeSolverOperation_solverOpWrapper_preSolverFailed() public {
+    function test_executeSolverOperation_solverOpWrapper_preSolverFailed_SkipCoverage() public {
         defaultAtlasWithCallConfig(
             defaultCallConfig()
                 .withTrackPreOpsReturnData(false)
@@ -394,7 +394,7 @@ contract EscrowTest is AtlasBaseTest {
         executeSolverOperationCase(userOp, solverOps, false, false, result, true);
     }
 
-    function test_executeSolverOperation_solverOpWrapper_postSolverFailed() public {
+    function test_executeSolverOperation_solverOpWrapper_postSolverFailed_SkipCoverage() public {
         defaultAtlasWithCallConfig(
             defaultCallConfig()
                 .withTrackPreOpsReturnData(false)
@@ -418,7 +418,7 @@ contract EscrowTest is AtlasBaseTest {
         executeSolverOperationCase(userOp, solverOps, true, false, result, true);
     }
 
-    function test_executeSolverOperation_solverOpWrapper_BalanceNotReconciled_ifPartialRepayment() public {
+    function test_executeSolverOperation_solverOpWrapper_BalanceNotReconciled_ifPartialRepayment_SkipCoverage() public {
         // Fails because solver calls reconcile but doesn't fully repay the shortfall
         uint256 bidAmount = dummySolver.partialGasPayBack(); // solver only pays half of shortfall
         deal(address(dummySolver), bidAmount);
@@ -434,7 +434,7 @@ contract EscrowTest is AtlasBaseTest {
         executeSolverOperationCase(userOp, solverOps, true, false, expectedResult, true);
     }
 
-    function test_executeSolverOperation_solverOpWrapper_Success_ifPartialRepaymentAndDappCoversTheRest() public {
+    function test_executeSolverOperation_solverOpWrapper_Success_ifPartialRepaymentAndDappCoversTheRest_SkipCoverage() public {
         uint256 bidAmount = dummySolver.partialGasPayBack(); // solver only pays half of shortfall
         deal(address(dummySolver), bidAmount);
 

--- a/test/ExPost.t.sol
+++ b/test/ExPost.t.sol
@@ -51,7 +51,7 @@ contract ExPostTest is BaseTest {
         v2ExPost = new V2ExPost(address(atlas));
     }
 
-    function test_ExPostMEV() public {
+    function test_ExPostMEV_SkipCoverage() public {
 
         Sig memory sig;
 
@@ -281,7 +281,7 @@ contract ExPostTest is BaseTest {
     }
 
     // Shoutout to rholterhus for the test
-    function test_ExPostOrdering_GasCheck() public {
+    function test_ExPostOrdering_GasCheck_SkipCoverage() public {
         uint256 NUM_SOLVE_OPS = 3;
         UserOperation memory userOp = helper.buildUserOperation(POOL_ONE, POOL_TWO, userEOA, TOKEN_ONE);
         userOp.control = address(v2ExPost);

--- a/test/ExecutionEnvironment.t.sol
+++ b/test/ExecutionEnvironment.t.sol
@@ -64,7 +64,7 @@ contract ExecutionEnvironmentTest is BaseTest {
             ExecutionEnvironment(payable(IAtlas(address(atlas)).createExecutionEnvironment(address(dAppControl))));
     }
 
-    function test_modifier_validUser() public {
+    function test_modifier_validUser_SkipCoverage() public {
         UserOperation memory userOp;
         bytes memory preOpsData;
         bool status;
@@ -97,7 +97,7 @@ contract ExecutionEnvironmentTest is BaseTest {
         (status,) = address(executionEnvironment).call(preOpsData);
     }
 
-    function test_modifier_onlyAtlasEnvironment() public {
+    function test_modifier_onlyAtlasEnvironment_SkipCoverage() public {
         UserOperation memory userOp;
         bytes memory preOpsData;
         bool status;
@@ -121,7 +121,7 @@ contract ExecutionEnvironmentTest is BaseTest {
         assertTrue(status, "expectRevert OnlyAtlas: call did not revert");
     }
 
-    function test_modifier_validControlHash() public {
+    function test_modifier_validControlHash_SkipCoverage() public {
         UserOperation memory userOp;
         bytes memory userData;
         bool status;
@@ -147,7 +147,7 @@ contract ExecutionEnvironmentTest is BaseTest {
         (status,) = address(executionEnvironment).call(userData);
     }
 
-    function test_preOpsWrapper() public {
+    function test_preOpsWrapper_SkipCoverage() public {
         UserOperation memory userOp;
         bytes memory preOpsData;
         bool status;
@@ -176,7 +176,7 @@ contract ExecutionEnvironmentTest is BaseTest {
         (status,) = address(executionEnvironment).call(preOpsData);
     }
 
-    function test_userWrapper() public {
+    function test_userWrapper_SkipCoverage() public {
         UserOperation memory userOp;
         bytes memory userData;
         bool status;
@@ -238,7 +238,7 @@ contract ExecutionEnvironmentTest is BaseTest {
         (status,) = address(executionEnvironment).call(userData);
     }
 
-    function test_postOpsWrapper() public {
+    function test_postOpsWrapper_SkipCoverage() public {
         bytes memory postOpsData;
         bool status;
 
@@ -269,7 +269,7 @@ contract ExecutionEnvironmentTest is BaseTest {
         (status,) = address(executionEnvironment).call(postOpsData);
     }
 
-    function test_solverPreTryCatch() public {
+    function test_solverPreTryCatch_SkipCoverage() public {
         bytes memory preTryCatchMetaData;
         bool revertsAsExpected;
 
@@ -330,7 +330,7 @@ contract ExecutionEnvironmentTest is BaseTest {
         assertTrue(revertsAsExpected, "expectRevert PreSolverFailed: call did not revert");
     }
 
-    function test_solverPostTryCatch() public {
+    function test_solverPostTryCatch_SkipCoverage() public {
         bytes memory postTryCatchMetaData;
         bool revertsAsExpected;
 
@@ -407,7 +407,7 @@ contract ExecutionEnvironmentTest is BaseTest {
         assertTrue(revertsAsExpected, "expectRevert PostSolverFailed: call did not revert");
     }
     
-    function test_allocateValue() public {
+    function test_allocateValue_SkipCoverage() public {
         bytes memory allocateData;
         bool status;
 
@@ -431,7 +431,7 @@ contract ExecutionEnvironmentTest is BaseTest {
     }
 
 
-    function test_withdrawERC20() public {
+    function test_withdrawERC20_SkipCoverage() public {
         // FIXME: fix before merging spearbit-reaudit branch
         vm.skip(true);
 
@@ -471,7 +471,7 @@ contract ExecutionEnvironmentTest is BaseTest {
         executionEnvironment.withdrawERC20(chain.weth, 2e18);
     }
 
-    function test_withdrawEther() public {
+    function test_withdrawEther_SkipCoverage() public {
         // FIXME: fix before merging spearbit-reaudit branch
         vm.skip(true);
 
@@ -510,19 +510,19 @@ contract ExecutionEnvironmentTest is BaseTest {
         executionEnvironment.withdrawEther(2e18);
     }
 
-    function test_getUser() public view {
+    function test_getUser_SkipCoverage() public view {
         assertEq(executionEnvironment.getUser(), user);
     }
 
-    function test_getControl() public view {
+    function test_getControl_SkipCoverage() public view {
         assertEq(executionEnvironment.getControl(), address(dAppControl));
     }
 
-    function test_getConfig() public view {
+    function test_getConfig_SkipCoverage() public view {
         assertEq(executionEnvironment.getConfig(), CallBits.encodeCallConfig(callConfig));
     }
 
-    function test_getEscrow() public view {
+    function test_getEscrow_SkipCoverage() public view {
         assertEq(executionEnvironment.getEscrow(), address(atlas));
     }
 }

--- a/test/FlashLoan.t.sol
+++ b/test/FlashLoan.t.sol
@@ -52,7 +52,7 @@ contract FlashLoanTest is BaseTest {
         vm.stopPrank();
     }
 
-    function testFlashLoan() public {
+    function testFlashLoan_SkipCoverage() public {
         vm.startPrank(solverOneEOA);
         SimpleSolver solver = new SimpleSolver(WETH_ADDRESS, address(atlas));
         deal(WETH_ADDRESS, address(solver), 1e18); // 1 WETH to solver to pay bid

--- a/test/MainTest.t.sol
+++ b/test/MainTest.t.sol
@@ -289,7 +289,7 @@ contract MainTest is BaseTest {
         */
     }
 
-    function testMimic() public {
+    function testMimic_SkipCoverage() public {
         // uncomment to debug if this test is broken
         /*
         address aaaaa = atlas.executionTemplate();
@@ -375,7 +375,7 @@ contract MainTest is BaseTest {
         assertTrue(exists, "ExecutionEnvironment wasn't created");
     }
 
-    function testTestUserOperation() public {
+    function testTestUserOperation_SkipCoverage() public {
         uint8 v;
         bytes32 r;
         bytes32 s;
@@ -400,7 +400,7 @@ contract MainTest is BaseTest {
         vm.stopPrank();
     }
 
-    function testSolverCalls() public {
+    function testSolverCalls_SkipCoverage() public {
         uint8 v;
         bytes32 r;
         bytes32 s;

--- a/test/OEV.t.sol
+++ b/test/OEV.t.sol
@@ -111,7 +111,7 @@ contract OEVTest is BaseTest {
     //                  Full OEV Capture Test               //
     // ---------------------------------------------------- //
 
-    function testChainlinkOEV_StandardVersion_GasCheck() public {
+    function testChainlinkOEV_StandardVersion_GasCheck_SkipCoverage() public {
         UserOperation memory userOp;
         SolverOperation[] memory solverOps = new SolverOperation[](1);
         DAppOperation memory dAppOp;

--- a/test/OEValt.t.sol
+++ b/test/OEValt.t.sol
@@ -115,7 +115,7 @@ contract OEVTest is BaseTest {
     //                  Full OEV Capture Test               //
     // ---------------------------------------------------- //
 
-    function testChainlinkOEV_AltVersion() public {
+    function testChainlinkOEV_AltVersion_SkipCoverage() public {
         UserOperation memory userOp;
         SolverOperation[] memory solverOps = new SolverOperation[](1);
         DAppOperation memory dAppOp;
@@ -183,7 +183,7 @@ contract OEVTest is BaseTest {
     //               ChainlinkAtlasWrapper Tests            //
     // ---------------------------------------------------- //
 
-    function testChainlinkAtlasWrapperViewFunctions_AltVersion() public {
+    function testChainlinkAtlasWrapperViewFunctions_AltVersion_SkipCoverage() public {
         // Check wrapper and base start as expected
         assertEq(chainlinkAtlasWrapper.atlasLatestAnswer(), 0, "Wrapper stored latestAnswer should be 0");
         assertTrue(IChainlinkFeed(chainlinkETHUSD).latestAnswer() != 0, "Base latestAnswer should not be 0");
@@ -276,7 +276,7 @@ contract OEVTest is BaseTest {
         // assertEq(chainlinkAtlasWrapper.transmitters(mockEE), true, "EE should be trusted now");
     }
 
-    function testChainlinkAtlasWrapperTransmit_AltVersion() public {
+    function testChainlinkAtlasWrapperTransmit_AltVersion_SkipCoverage() public {
         TransmitData memory transmitData;
         (transmitData.report, transmitData.rs, transmitData.ss, transmitData.rawVs) = getTransmitPayload();
 

--- a/test/Simulator.t.sol
+++ b/test/Simulator.t.sol
@@ -43,7 +43,7 @@ contract SimulatorTest is BaseTest {
         dAppControl = defaultDAppControl().buildAndIntegrate(atlasVerification);
     }
 
-    function test_simUserOperation_success_valid() public {
+    function test_simUserOperation_success_valid_SkipCoverage() public {
         UserOperation memory userOp = validUserOperation().build();
 
         (bool success, Result result, uint256 validCallsResult) = simulator.simUserOperation(userOp);
@@ -62,7 +62,7 @@ contract SimulatorTest is BaseTest {
         assertEq(validCallsResult, uint256(ValidCallsResult.GasPriceHigherThanMax));
     }
 
-    function test_simSolverCall_success_validSolverOutcome() public {
+    function test_simSolverCall_success_validSolverOutcome_SkipCoverage() public {
         vm.startPrank(solverOneEOA);
         DummySolver solver = new DummySolver(WETH_ADDRESS, address(atlas));
         atlas.bond(1e18);
@@ -83,7 +83,7 @@ contract SimulatorTest is BaseTest {
         assertEq(solverOutcomeResult, 0);
     }
 
-    function test_simSolverCall_fail_bubblesUpSolverOutcomeResult() public {
+    function test_simSolverCall_fail_bubblesUpSolverOutcomeResult_SkipCoverage() public {
         vm.startPrank(solverOneEOA);
         DummySolver solver = new DummySolver(WETH_ADDRESS, address(atlas));
         // atlas.bond(1e18); - DO NOT BOND - Triggers InsufficientEscrow error
@@ -104,7 +104,7 @@ contract SimulatorTest is BaseTest {
         assertEq(solverOutcomeResult, 1 << uint256(SolverOutcome.InsufficientEscrow));
     }
 
-    function test_simSolverCalls_success_validSolverOutcome() public {
+    function test_simSolverCalls_success_validSolverOutcome_SkipCoverage() public {
         vm.startPrank(solverOneEOA);
         DummySolver solver = new DummySolver(WETH_ADDRESS, address(atlas));
         atlas.bond(1e18);
@@ -137,7 +137,7 @@ contract SimulatorTest is BaseTest {
         assertEq(solverOutcomeResult, uint256(type(SolverOutcome).max) + 1);
     }
 
-    function test_simSolverCalls_fail_bubblesUpSolverOutcomeResult() public {
+    function test_simSolverCalls_fail_bubblesUpSolverOutcomeResult_SkipCoverage() public {
         vm.startPrank(solverOneEOA);
         DummySolver solver = new DummySolver(WETH_ADDRESS, address(atlas));
         // atlas.bond(1e18); - DO NOT BOND - Triggers InsufficientEscrow error

--- a/test/SwapIntent.t.sol
+++ b/test/SwapIntent.t.sol
@@ -70,7 +70,7 @@ contract SwapIntentTest is BaseTest {
         // atlas.deposit{value: 1e18}();
     }
 
-    function testAtlasSwapIntentWithBasicRFQ_GasCheck() public {
+    function testAtlasSwapIntentWithBasicRFQ_GasCheck_SkipCoverage() public {
         // Swap 10 WETH for 20 DAI
         UserCondition userCondition = new UserCondition();
 
@@ -209,7 +209,7 @@ contract SwapIntentTest is BaseTest {
         assertEq(DAI.balanceOf(userEOA), userDaiBalanceBefore + swapIntent.amountUserBuys, "Did not receive enough DAI");
     }
 
-    function testAtlasSwapIntentWithUniswapSolver() public {
+    function testAtlasSwapIntentWithUniswapSolver_SkipCoverage() public {
         // Swap 10 WETH for 20 DAI
         Condition[] memory conditions;
 

--- a/test/SwapIntentInvertBid.t.sol
+++ b/test/SwapIntentInvertBid.t.sol
@@ -36,7 +36,7 @@ contract SwapIntentTest is BaseTest {
         governanceEOA = vm.addr(governancePK);
     }
 
-    function testAtlasSwapIntentInvertBid_solverBidRetreivalNotRequired() public {
+    function testAtlasSwapIntentInvertBid_solverBidRetreivalNotRequired_SkipCoverage() public {
         vm.startPrank(governanceEOA);
         SwapIntentInvertBidDAppControl controlContract = new SwapIntentInvertBidDAppControl(address(atlas), false);
         address control = address(controlContract);
@@ -71,7 +71,7 @@ contract SwapIntentTest is BaseTest {
         assertEq(DAI.balanceOf(userEOA), userDaiBalanceBefore + swapIntent.amountUserBuys, "Did not receive enough DAI");
     }
 
-    function testAtlasSwapIntentInvertBid_solverBidRetreivalNotRequired_multipleSolvers() public {
+    function testAtlasSwapIntentInvertBid_solverBidRetreivalNotRequired_multipleSolvers_SkipCoverage() public {
         vm.startPrank(governanceEOA);
         SwapIntentInvertBidDAppControl controlContract = new SwapIntentInvertBidDAppControl(address(atlas), false);
         address control = address(controlContract);
@@ -111,7 +111,7 @@ contract SwapIntentTest is BaseTest {
         assertEq(DAI.balanceOf(userEOA), userDaiBalanceBefore + swapIntent.amountUserBuys, "Did not receive enough DAI");
     }
 
-    function testAtlasSwapIntentInvertBid_solverBidRetreivalRequired() public {
+    function testAtlasSwapIntentInvertBid_solverBidRetreivalRequired_SkipCoverage() public {
         vm.startPrank(governanceEOA);
         SwapIntentInvertBidDAppControl controlContract = new SwapIntentInvertBidDAppControl(address(atlas), true);
         address control = address(controlContract);

--- a/test/base/TestAtlas.sol
+++ b/test/base/TestAtlas.sol
@@ -3,6 +3,9 @@ pragma solidity 0.8.25;
 
 import "src/contracts/atlas/Atlas.sol";
 
+/// @title TestAtlas
+/// @author FastLane Labs
+/// @notice A test version of the Atlas contract that just exposes internal transient storage helpers.
 contract TestAtlas is Atlas {
     constructor(
         uint256 escrowDuration,
@@ -16,7 +19,7 @@ contract TestAtlas is Atlas {
 
     // Public functions to expose internal transient helpers for testing
 
-    function clearTransientVariables() public {
+    function clearTransientStorage() public {
         _setLock(Lock(address(0), 0, 0));
         _setSolverLock(0);
         _setSolverTo(address(0));

--- a/test/base/TestAtlas.sol
+++ b/test/base/TestAtlas.sol
@@ -1,0 +1,65 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.25;
+
+import "src/contracts/atlas/Atlas.sol";
+
+contract TestAtlas is Atlas {
+    constructor(
+        uint256 escrowDuration,
+        address verification,
+        address simulator,
+        address initialSurchargeRecipient,
+        address executionTemplate
+    )
+        Atlas(escrowDuration, verification, simulator, initialSurchargeRecipient, executionTemplate)
+    { }
+
+    // Public functions to expose internal transient helpers for testing
+
+    function clearTransientVariables() public {
+        _setLock(Lock(address(0), 0, 0));
+        _setSolverLock(0);
+        _setSolverTo(address(0));
+        _setClaims(0);
+        _setFees(0);
+        _setWriteoffs(0);
+        _setWithdrawals(0);
+        _setDeposits(0);
+    }
+
+    function setLock(Lock memory newLock) public {
+        _setLock(newLock);
+    }
+
+    function setLockPhase(uint8 newPhase) public {
+        _setLockPhase(newPhase);
+    }
+
+    function setSolverLock(uint256 newSolverLock) public {
+        _setSolverLock(newSolverLock);
+    }
+
+    function setSolverTo(address newSolverTo) public {
+        _setSolverTo(newSolverTo);
+    }
+
+    function setClaims(uint256 newClaims) public {
+        _setClaims(newClaims);
+    }
+
+    function setFees(uint256 newFees) public {
+        _setFees(newFees);
+    }
+
+    function setWriteoffs(uint256 newWriteoffs) public {
+        _setWriteoffs(newWriteoffs);
+    }
+
+    function setWithdrawals(uint256 newWithdrawals) public {
+        _setWithdrawals(newWithdrawals);
+    }
+
+    function setDeposits(uint256 newDeposits) public {
+        _setDeposits(newDeposits);
+    }
+}


### PR DESCRIPTION
### Foundry Config

The foundry.toml includes these settings which impact the tests. Note, `isolate` must be `false` for us to be able to set a positive `tx.gasprice`. If `tx.gasprice = 0` then many of the tests break as that causes problems in Atlas' accounting.
```
  gas_price = 1500000000
  solc_version = "0.8.25"
  evm_version = "cancun"
  isolate = false
```
With `isolate` set to `false` we need to be careful how we handle Atlas' transient storage variables in tests, as they will not be automatically cleared between transactions within a single test. To help with this, there's now a `TestAtlas.sol` contract which inherits from Atlas but exposes the transient storage setter functions, and includes a `clearTransientStorage()` function which can be called before and after an Atlas function call if we wish to simulate the behaviour of the transient variables more accurately.

### Test Coverage

Due to recent changes to Foundry, and the way Mimic creation code is modified, the test coverage checker via `forge coverage` is quite fragile. We will bundle all of the settings needed to get it to run, into the `coverage` script in `package.json`. The final script looks like this:

`forge coverage --ir-minimum --no-match-test SkipCoverage --report lcov && node filter_lcov.js && genhtml lcov_filtered.info --output-directory report && open report/index.html`

1. We need to add the `--ir-minimum` to avoid Stack Too Deep in the compilation before coverage check is run.
2. We need to add `_SkipCoverage` to the name of each test which would fail if `tx.gasprice = 0`, as we have no control over the `tx.gasprice` during this coverage check. Tests could also be failing due to Mimic creation code changing as the compilation process is different (because of `--ir-minimum`). We then add `--no-match-test SkipCoverage` to skip those tests during the coverage check.
3. We add `--report lcov` to output the coverage results to an `lcov.info` file.
4. We then filter the test coverage output using `node filter_lcov.js` to exclude coverage of `script/` and `test/` folders.
5. Finally we open the coverage report in the browser.

### Atlas Function Tests

These sections need the most attention as they've been most affected by audit fix changes. In these cases it probably makes sense to test each function in affected module from scratch, instead of trying to modify the existing outdated tests:

- GasAccounting.sol
- SafetyLocks.sol
- Storage.sol
- AccountingMath.sol

These sections of tests should still be relevant for the most part, but may need to be updated to ensure coverage:

- AtlasVerification.sol
- DAppIntegration.sol
- NonceManager.sol
- Escrow.sol
- Factory.sol
- Permit69.sol
- AtlETH.sol
- ExecutionBase.sol
- ExecutionEnvironment.sol
- Mimic.sol
- EscrowBits.sol
- SafetyBits.sol

### Scenario Tests

For each "prod" DAppControl we should have a variety of scenario tests, besides full coverage of the non-hook functions of the DAppControl contract:

- 0 solvers
- 1 solver (win and fail cases)
- 3 solvers (2nd solver has the winning bid)

We may also want to add a TestDAppControl contract where the purpose is just to run checks in each of the hooks to check Atlas state throughout the metacall.
