### PR TITLE
Move solver gas lim calc to AccountingMath lib

### DIFF
--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -12,6 +12,7 @@ import { SafeCall } from "src/contracts/libraries/SafeCall/SafeCall.sol";
 import { EscrowBits } from "src/contracts/libraries/EscrowBits.sol";
 import { CallBits } from "src/contracts/libraries/CallBits.sol";
 import { SafetyBits } from "src/contracts/libraries/SafetyBits.sol";
+import { AccountingMath } from "src/contracts/libraries/AccountingMath.sol";
 import { DAppConfig } from "src/contracts/types/ConfigTypes.sol";
 import "src/contracts/types/SolverOperation.sol";
 import "src/contracts/types/UserOperation.sol";
@@ -295,9 +296,7 @@ abstract contract Escrow is AtlETH {
             );
         }
 
-        gasLimit = _SOLVER_GAS_LIMIT_SCALE
-            * (solverOp.gas < dConfig.solverGasLimit ? solverOp.gas : dConfig.solverGasLimit)
-            / (_SOLVER_GAS_LIMIT_SCALE + _SOLVER_GAS_LIMIT_BUFFER_PERCENTAGE) + _FASTLANE_GAS_BUFFER;
+        gasLimit = AccountingMath.solverGasLimitScaledDown(solverOp.gas, dConfig.solverGasLimit) + _FASTLANE_GAS_BUFFER;
 
         uint256 _gasCost = (tx.gasprice * gasLimit) + _getCalldataCost(solverOp.data.length);
 

--- a/src/contracts/atlas/Storage.sol
+++ b/src/contracts/atlas/Storage.sol
@@ -26,7 +26,7 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
     // Gas Accounting public constants
     uint256 public constant ATLAS_SURCHARGE_RATE = AccountingMath._ATLAS_SURCHARGE_RATE;
     uint256 public constant BUNDLER_SURCHARGE_RATE = AccountingMath._BUNDLER_SURCHARGE_RATE;
-    uint256 public constant SURCHARGE_SCALE = AccountingMath._SURCHARGE_SCALE;
+    uint256 public constant SCALE = AccountingMath._SCALE;
     uint256 public constant FIXED_GAS_OFFSET = AccountingMath._FIXED_GAS_OFFSET;
 
     // Transient storage slots

--- a/src/contracts/helpers/Sorter.sol
+++ b/src/contracts/helpers/Sorter.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.25;
 import { IAtlas } from "../interfaces/IAtlas.sol";
 import { IDAppControl } from "../interfaces/IDAppControl.sol";
 import { CallBits } from "src/contracts/libraries/CallBits.sol";
+import { AccountingMath } from "src/contracts/libraries/AccountingMath.sol";
 import { CallVerification } from "../libraries/CallVerification.sol";
 import { IAtlasVerification } from "../interfaces/IAtlasVerification.sol";
 import { AtlasConstants } from "../types/AtlasConstants.sol";
@@ -74,9 +75,9 @@ contract Sorter is AtlasConstants {
     {
         // Make sure the solver has enough funds bonded
         uint256 solverBalance = IAtlas(address(ATLAS)).balanceOfBonded(solverOp.from);
-        uint256 gasLimit = _SOLVER_GAS_LIMIT_SCALE
-            * (solverOp.gas < dConfig.solverGasLimit ? solverOp.gas : dConfig.solverGasLimit)
-            / (_SOLVER_GAS_LIMIT_SCALE + _SOLVER_GAS_LIMIT_BUFFER_PERCENTAGE) + _FASTLANE_GAS_BUFFER;
+
+        uint256 gasLimit =
+            AccountingMath.solverGasLimitScaledDown(solverOp.gas, dConfig.solverGasLimit) + _FASTLANE_GAS_BUFFER;
 
         uint256 calldataCost =
             (solverOp.data.length + _SOLVER_OP_BASE_CALLDATA) * _CALLDATA_LENGTH_PREMIUM * solverOp.maxFeePerGas;

--- a/src/contracts/libraries/AccountingMath.sol
+++ b/src/contracts/libraries/AccountingMath.sol
@@ -3,26 +3,38 @@ pragma solidity 0.8.25;
 
 library AccountingMath {
     // Gas Accounting public constants
-    uint256 internal constant _ATLAS_SURCHARGE_RATE = 1_000_000; // 1_000_000 / 10_000_000 = 10%
-    uint256 internal constant _BUNDLER_SURCHARGE_RATE = 1_000_000; // 1_000_000 / 10_000_000 = 10%
-    uint256 internal constant _SURCHARGE_SCALE = 10_000_000; // 10_000_000 / 10_000_000 = 100%
+    uint256 internal constant _ATLAS_SURCHARGE_RATE = 1_000_000; // out of 10_000_000 = 10%
+    uint256 internal constant _BUNDLER_SURCHARGE_RATE = 1_000_000; // out of 10_000_000 = 10%
+    uint256 internal constant _SOLVER_GAS_LIMIT_BUFFER_PERCENTAGE = 500_000; // out of 10_000_000 = 5%
+    uint256 internal constant _SCALE = 10_000_000; // 10_000_000 / 10_000_000 = 100%
     uint256 internal constant _FIXED_GAS_OFFSET = 100_000;
 
     function withBundlerSurcharge(uint256 amount) internal pure returns (uint256 adjustedAmount) {
-        adjustedAmount = amount * (_SURCHARGE_SCALE + _BUNDLER_SURCHARGE_RATE) / _SURCHARGE_SCALE;
+        adjustedAmount = amount * (_SCALE + _BUNDLER_SURCHARGE_RATE) / _SCALE;
     }
 
     function withoutBundlerSurcharge(uint256 amount) internal pure returns (uint256 unadjustedAmount) {
-        unadjustedAmount = amount * _SURCHARGE_SCALE / (_SURCHARGE_SCALE + _BUNDLER_SURCHARGE_RATE);
+        unadjustedAmount = amount * _SCALE / (_SCALE + _BUNDLER_SURCHARGE_RATE);
     }
 
     function withAtlasAndBundlerSurcharges(uint256 amount) internal pure returns (uint256 adjustedAmount) {
-        adjustedAmount =
-            amount * (_SURCHARGE_SCALE + _ATLAS_SURCHARGE_RATE + _BUNDLER_SURCHARGE_RATE) / _SURCHARGE_SCALE;
+        adjustedAmount = amount * (_SCALE + _ATLAS_SURCHARGE_RATE + _BUNDLER_SURCHARGE_RATE) / _SCALE;
     }
 
     // gets the Atlas surcharge from an unadjusted amount
     function getAtlasSurcharge(uint256 amount) internal pure returns (uint256 surcharge) {
-        surcharge = amount * _ATLAS_SURCHARGE_RATE / _SURCHARGE_SCALE;
+        surcharge = amount * _ATLAS_SURCHARGE_RATE / _SCALE;
+    }
+
+    function solverGasLimitScaledDown(
+        uint256 solverOpGasLimit,
+        uint256 dConfigGasLimit
+    )
+        internal
+        pure
+        returns (uint256 gasLimit)
+    {
+        gasLimit = (solverOpGasLimit < dConfigGasLimit ? solverOpGasLimit : dConfigGasLimit) * _SCALE
+            / (_SCALE + _SOLVER_GAS_LIMIT_BUFFER_PERCENTAGE);
     }
 }

--- a/src/contracts/types/AtlasConstants.sol
+++ b/src/contracts/types/AtlasConstants.sol
@@ -22,8 +22,6 @@ contract AtlasConstants {
 
     // Escrow constants
     uint256 internal constant _VALIDATION_GAS_LIMIT = 500_000;
-    uint256 internal constant _SOLVER_GAS_LIMIT_BUFFER_PERCENTAGE = 5; // out of 100 = 5%
-    uint256 internal constant _SOLVER_GAS_LIMIT_SCALE = 100; // out of 100 = 100%
     uint256 internal constant _FASTLANE_GAS_BUFFER = 125_000; // integer amount
 
     // Gas Accounting constants

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -122,16 +122,16 @@ contract GasAccountingTest is Test {
     function getInitialClaims(uint256 _gasMarker) public view returns (uint256 claims) {
         uint256 rawClaims = (_gasMarker + mockGasAccounting.FIXED_GAS_OFFSET()) * tx.gasprice;
         claims = rawClaims * (
-            mockGasAccounting.SURCHARGE_SCALE() + mockGasAccounting.ATLAS_SURCHARGE_RATE() + mockGasAccounting.BUNDLER_SURCHARGE_RATE()
-        ) / mockGasAccounting.SURCHARGE_SCALE();
+            mockGasAccounting.SCALE() + mockGasAccounting.ATLAS_SURCHARGE_RATE() + mockGasAccounting.BUNDLER_SURCHARGE_RATE()
+        ) / mockGasAccounting.SCALE();
     }
 
     function initEscrowLock(uint256 metacallValue) public {
         mockGasAccounting.initializeLock{value: metacallValue}(executionEnvironment, gasMarker, 0);
         uint256 rawClaims = (gasMarker + mockGasAccounting.FIXED_GAS_OFFSET()) * tx.gasprice;
         initialClaims = rawClaims * (
-            mockGasAccounting.SURCHARGE_SCALE() + mockGasAccounting.ATLAS_SURCHARGE_RATE() + mockGasAccounting.BUNDLER_SURCHARGE_RATE()
-        ) / mockGasAccounting.SURCHARGE_SCALE();
+            mockGasAccounting.SCALE() + mockGasAccounting.ATLAS_SURCHARGE_RATE() + mockGasAccounting.BUNDLER_SURCHARGE_RATE()
+        ) / mockGasAccounting.SCALE();
     }
 
     function test_contribute() public {
@@ -462,7 +462,7 @@ contract GasAccountingTest is Test {
         // FULL_REFUND
         result = EscrowBits._FULL_REFUND;
         maxGasUsed = gasWaterMark + calldataCost;
-        maxGasUsed = maxGasUsed * (mockGasAccounting.SURCHARGE_SCALE() + mockGasAccounting.ATLAS_SURCHARGE_RATE() + mockGasAccounting.BUNDLER_SURCHARGE_RATE()) / mockGasAccounting.SURCHARGE_SCALE()
+        maxGasUsed = maxGasUsed * (mockGasAccounting.SCALE() + mockGasAccounting.ATLAS_SURCHARGE_RATE() + mockGasAccounting.BUNDLER_SURCHARGE_RATE()) / mockGasAccounting.SCALE()
             * tx.gasprice;
         mockGasAccounting.increaseBondedBalance(solverOp.from, maxGasUsed);
         (bondedBefore,,,,) = mockGasAccounting.accessData(solverOp.from);
@@ -470,7 +470,7 @@ contract GasAccountingTest is Test {
         (bondedAfter,,,,) = mockGasAccounting.accessData(solverOp.from);
         assertGt(
             bondedBefore - bondedAfter,
-            calldataCost * (mockGasAccounting.SURCHARGE_SCALE() + mockGasAccounting.ATLAS_SURCHARGE_RATE() + mockGasAccounting.BUNDLER_SURCHARGE_RATE()) / mockGasAccounting.ATLAS_SURCHARGE_RATE()
+            calldataCost * (mockGasAccounting.SCALE() + mockGasAccounting.ATLAS_SURCHARGE_RATE() + mockGasAccounting.BUNDLER_SURCHARGE_RATE()) / mockGasAccounting.ATLAS_SURCHARGE_RATE()
                 * tx.gasprice
         ); // Must be greater than calldataCost
         assertLt(bondedBefore - bondedAfter, maxGasUsed); // Must be less than maxGasUsed
@@ -535,7 +535,7 @@ contract GasAccountingTest is Test {
     //     // Revert calculations to reach the second gas marker value in _settle()
     //     (uint256 claimsPaidToBundler, uint256 netGasSurcharge) = mockGasAccounting.settle(solverOp.from, makeAddr("bundler"));
     //     uint256 settleGasRemainder = initialClaims - (claimsPaidToBundler + netGasSurcharge);
-    //     settleGasRemainder = settleGasRemainder * mockGasAccounting.SURCHARGE_SCALE() / (mockGasAccounting.SURCHARGE_SCALE() + mockGasAccounting.ATLAS_SURCHARGE_RATE());
+    //     settleGasRemainder = settleGasRemainder * mockGasAccounting.SCALE() / (mockGasAccounting.SCALE() + mockGasAccounting.ATLAS_SURCHARGE_RATE());
 
     //     // The bundler must be repaid the gas cost between the 2 markers
     //     uint256 diff = rawClaims - settleGasRemainder;


### PR DESCRIPTION
Resolves https://github.com/FastLane-Labs/atlas-issues/issues/94

Changes:

- Uses same scale (10 million) for surcharge and solver gas calculations, saves a constant.
- Solver gas limit scaling calculation moved to AccountingMath lib, shared between Sorter.sol and Escrow.sol
- Left the `+ _FASTLANE_GAS_BUFFER` part out of the lib function, as its deducted a few lines later in `_validateSolverOpGas()`, to show where that subtracted amount originally came from.