### PR TITLE
Add `FullyLocked` phase set before final ETH sent

### DIFF
--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -92,6 +92,8 @@ contract Atlas is Escrow, Factory {
         } catch (bytes memory revertData) {
             // Bubble up some specific errors
             _handleErrors(revertData, _dConfig.callConfig);
+            // Set lock to FullyLocked to prevent any reentrancy possibility
+            _setLockPhase(uint8(ExecutionPhase.FullyLocked));
 
             // Refund the msg.value to sender if it errored
             // WARNING: If msg.sender is a disposable address such as a session key, make sure to remove ETH from it

--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -395,6 +395,9 @@ abstract contract GasAccounting is SafetyLocks {
             _credit(_winningSolver, _amountSolverReceives - _amountSolverPays);
         }
 
+        // Set lock to FullyLocked to prevent any reentrancy possibility
+        _setLockPhase(uint8(ExecutionPhase.FullyLocked));
+
         if (claimsPaidToBundler != 0) SafeTransferLib.safeTransferETH(ctx.bundler, claimsPaidToBundler);
 
         return (claimsPaidToBundler, netAtlasGasSurcharge);

--- a/src/contracts/types/LockTypes.sol
+++ b/src/contracts/types/LockTypes.sol
@@ -30,5 +30,6 @@ enum ExecutionPhase {
     SolverOperation,
     PostSolver,
     AllocateValue,
-    PostOps
+    PostOps,
+    FullyLocked
 }


### PR DESCRIPTION
Addresses https://github.com/FastLane-Labs/atlas-issues/issues/79

Precautionary measure to prevent reentrancy by setting lock to a final phase. 