### PR TITLE
fix: Compensate for Missing Nonce 0

### DIFF
--- a/src/contracts/atlas/NonceManager.sol
+++ b/src/contracts/atlas/NonceManager.sol
@@ -167,6 +167,11 @@ contract NonceManager is AtlasConstants {
         while (true) {
             uint256 _bitmap = S_userNonSequentialNonceTrackers[user][wordIndex];
 
+            // Compensate for missing nonce 0
+            if (wordIndex == 0) {
+                _bitmap |= 1;
+            }
+
             if (_bitmap == type(uint256).max) {
                 // Full bitmap, move to the next word
                 ++wordIndex;


### PR DESCRIPTION
Audit Issue: https://github.com/FastLane-Labs/atlas-issues/issues/101


Changes:
- void the Nonce 0 to improve efficiency for later uses


Note: Increase gas for the first call slightly but will unlock gas savings for larger nonce
  
| Metric                                | Before (gas) | After (gas)  | Diff   |
|---------------------------------------|--------------|--------------|--------|
| Atlas Swap test                       | 1,681,511    | 1,681,539    | +28    |
| Ex Post test                          | 7,686,519    | 7,686,547    | +28    |
| OEV test                              | 1,467,938    | 1,467,966    | +28    | 