### PR TITLE
refactor: cache the _total balance in _assign

### DIFF
--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -172,13 +172,13 @@ abstract contract GasAccounting is SafetyLocks {
             // not meant to be used within an Atlas transaction, and must remain independent.
 
             EscrowAccountBalance memory _bData = s_balanceOf[owner];
-            uint256 _bondedAndUnbonding = uint256(_bData.unbonding) + uint256(_aData.bonded);
+            uint256 _total = uint256(_bData.unbonding) + uint256(_aData.bonded);
 
-            if (_amt > _bondedAndUnbonding) {
+            if (_amt > _total) {
                 // The unbonding balance is insufficient to cover the remaining amount owed. There is a deficit. Set
                 // both bonded and unbonding balances to 0 and adjust the "amount" variable to reflect the amount
                 // that was actually deducted.
-                deficit = amount - _bondedAndUnbonding;
+                deficit = amount - _total;
                 s_balanceOf[owner].unbonding = 0;
                 _aData.bonded = 0;
 
@@ -187,7 +187,7 @@ abstract contract GasAccounting is SafetyLocks {
             } else {
                 // The unbonding balance is sufficient to cover the remaining amount owed. Draw everything from the
                 // bonded balance, and adjust the unbonding balance accordingly.
-                s_balanceOf[owner].unbonding = uint112(_bondedAndUnbonding - _amt);
+                s_balanceOf[owner].unbonding = uint112(_total - _amt);
                 _aData.bonded = 0;
             }
         } else {

--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -164,19 +164,21 @@ abstract contract GasAccounting is SafetyLocks {
         uint112 _amt = uint112(amount);
 
         EscrowAccountAccessData memory _aData = S_accessData[owner];
-        EscrowAccountBalance memory _bData = s_balanceOf[owner];
 
-        uint256 _total = uint256(_bData.unbonding) + uint256(_aData.bonded); // Combine the balances
         if (_amt > _aData.bonded) {
             // The bonded balance does not cover the amount owed. Check if there is enough unbonding balance to
             // make up for the missing difference. If not, there is a deficit. Atlas does not consider drawing from
             // the regular AtlETH balance (not bonded nor unbonding) to cover the remaining deficit because it is
             // not meant to be used within an Atlas transaction, and must remain independent.
-            if (_amt > _total) {
+
+            EscrowAccountBalance memory _bData = s_balanceOf[owner];
+            uint256 _bondedAndUnbonding = uint256(_bData.unbonding) + uint256(_aData.bonded);
+
+            if (_amt > _bondedAndUnbonding) {
                 // The unbonding balance is insufficient to cover the remaining amount owed. There is a deficit. Set
                 // both bonded and unbonding balances to 0 and adjust the "amount" variable to reflect the amount
                 // that was actually deducted.
-                deficit = amount - _total;
+                deficit = amount - _bondedAndUnbonding;
                 s_balanceOf[owner].unbonding = 0;
                 _aData.bonded = 0;
 
@@ -185,7 +187,7 @@ abstract contract GasAccounting is SafetyLocks {
             } else {
                 // The unbonding balance is sufficient to cover the remaining amount owed. Draw everything from the
                 // bonded balance, and adjust the unbonding balance accordingly.
-                s_balanceOf[owner].unbonding = uint112(_total - _amt);
+                s_balanceOf[owner].unbonding = uint112(_bondedAndUnbonding - _amt);
                 _aData.bonded = 0;
             }
         } else {

--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -164,19 +164,18 @@ abstract contract GasAccounting is SafetyLocks {
         uint112 _amt = uint112(amount);
 
         EscrowAccountAccessData memory _aData = S_accessData[owner];
+        EscrowAccountBalance memory _bData = s_balanceOf[owner];
 
+        uint256 _total = uint256(_bData.unbonding) + uint256(_aData.bonded); // Combine the balances
         if (_amt > _aData.bonded) {
             // The bonded balance does not cover the amount owed. Check if there is enough unbonding balance to
             // make up for the missing difference. If not, there is a deficit. Atlas does not consider drawing from
             // the regular AtlETH balance (not bonded nor unbonding) to cover the remaining deficit because it is
             // not meant to be used within an Atlas transaction, and must remain independent.
-            EscrowAccountBalance memory _bData = s_balanceOf[owner];
-
-            if (_amt > _bData.unbonding + _aData.bonded) {
+            if (_amt > _total) {
                 // The unbonding balance is insufficient to cover the remaining amount owed. There is a deficit. Set
                 // both bonded and unbonding balances to 0 and adjust the "amount" variable to reflect the amount
                 // that was actually deducted.
-                uint256 _total = uint256(_bData.unbonding + _aData.bonded); // contribute less to deposits ledger
                 deficit = amount - _total;
                 s_balanceOf[owner].unbonding = 0;
                 _aData.bonded = 0;
@@ -186,7 +185,7 @@ abstract contract GasAccounting is SafetyLocks {
             } else {
                 // The unbonding balance is sufficient to cover the remaining amount owed. Draw everything from the
                 // bonded balance, and adjust the unbonding balance accordingly.
-                s_balanceOf[owner].unbonding = _bData.unbonding + _aData.bonded - _amt;
+                s_balanceOf[owner].unbonding = uint112(_total - _amt);
                 _aData.bonded = 0;
             }
         } else {


### PR DESCRIPTION
Audit Issue: https://github.com/FastLane-Labs/atlas-issues/issues/105

Changes:
- introduce new local var _total to cache calculation for  _assign