### PR TITLE
Fix Solver Analytics

### DIFF
--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -202,7 +202,7 @@ abstract contract Escrow is AtlETH {
         ctx.solverOutcome = uint24(_result);
 
         // Account for failed SolverOperation gas costs
-        _handleSolverAccounting(solverOp, _gasWaterMark, _result, !prevalidated);
+        _handleSolverAccounting(solverOp, _gasWaterMark, _result, !prevalidated, ctx.bidFind);
 
         emit SolverTxResult(solverOp.solver, solverOp.from, _result.executedWithError(), false, _result);
 

--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -202,7 +202,7 @@ abstract contract Escrow is AtlETH {
         ctx.solverOutcome = uint24(_result);
 
         // Account for failed SolverOperation gas costs
-        _handleSolverAccounting(solverOp, _gasWaterMark, _result, !prevalidated, ctx.bidFind);
+        _handleSolverAccounting(solverOp, _gasWaterMark, _result, !prevalidated);
 
         emit SolverTxResult(solverOp.solver, solverOp.from, _result.executedWithError(), false, _result);
 

--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -420,6 +420,11 @@ abstract contract GasAccounting is SafetyLocks {
         return (claimsPaidToBundler, netAtlasGasSurcharge);
     }
 
+    /// @notice Updates auctionWins, auctionFails, and totalGasUsed values of a solver's EscrowAccountAccessData.
+    /// @dev This function is only ever called in the context of bidFind = false so no risk of doublecounting changes.
+    /// @param aData The Solver's EscrowAccountAccessData struct to update.
+    /// @param auctionWon A boolean indicating whether the solver's solverOp won the auction.
+    /// @param gasUsed The amount of gas used by the solverOp.
     function _updateAnalytics(EscrowAccountAccessData memory aData, bool auctionWon, uint256 gasUsed) internal pure {
         if (auctionWon) {
             unchecked {

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -44,7 +44,7 @@ contract MockGasAccounting is GasAccounting, Test {
     }
 
     function assign(address owner, uint256 value, bool solverWon) external returns (uint256) {
-        return _assign(owner, value, value, solverWon, false);
+        return _assign(owner, value, value, solverWon);
     }
 
     function credit(address owner, uint256 value) external {
@@ -52,7 +52,7 @@ contract MockGasAccounting is GasAccounting, Test {
     }
 
     function releaseSolverLock(SolverOperation calldata solverOp, uint256 gasWaterMark, uint256 result) external {
-        _handleSolverAccounting(solverOp, gasWaterMark, result, true, false);
+        _handleSolverAccounting(solverOp, gasWaterMark, result, true);
     }
 
     function settle(address winningSolver, address bundler) external returns (uint256, uint256) {

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -44,11 +44,11 @@ contract MockGasAccounting is GasAccounting, Test {
     }
 
     function assign(address owner, uint256 value, bool solverWon) external returns (uint256) {
-        return _assign(owner, value, solverWon);
+        return _assign(owner, value, solverWon, value);
     }
 
     function credit(address owner, uint256 value) external {
-        _credit(owner, value);
+        _credit(owner, value, value);
     }
 
     function releaseSolverLock(SolverOperation calldata solverOp, uint256 gasWaterMark, uint256 result) external {

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -44,7 +44,7 @@ contract MockGasAccounting is GasAccounting, Test {
     }
 
     function assign(address owner, uint256 value, bool solverWon) external returns (uint256) {
-        return _assign(owner, value, solverWon, value);
+        return _assign(owner, value, value, solverWon, false);
     }
 
     function credit(address owner, uint256 value) external {
@@ -52,7 +52,7 @@ contract MockGasAccounting is GasAccounting, Test {
     }
 
     function releaseSolverLock(SolverOperation calldata solverOp, uint256 gasWaterMark, uint256 result) external {
-        _handleSolverAccounting(solverOp, gasWaterMark, result, true);
+        _handleSolverAccounting(solverOp, gasWaterMark, result, true, false);
     }
 
     function settle(address winningSolver, address bundler) external returns (uint256, uint256) {


### PR DESCRIPTION
Resolves https://github.com/FastLane-Labs/atlas-issues/issues/106

Looks like `_updateAnalytics()` was dropped in one of the previous audit fix PRs. This PR adds it back.

Changes/Decisions:

- Gas used analytics should include the Atlas surcharge
- `_assign()` and `_credit()` never called in bid finding context - no `bidFind` flag needed
