### PR TITLE
Refactor Transient Storage Code 

### DIFF
--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -101,8 +101,8 @@ contract Atlas is Escrow, Factory {
             if (msg.value != 0) SafeTransferLib.safeTransferETH(msg.sender, msg.value);
         }
 
-        // The environment lock and accounting values set above are implicitly released here as the transient storage
-        // variables are zeroed out at the end of the transaction.
+        // The environment lock is explicitly released here to allow multiple metacalls in a single transaction
+        _setLock(address(0), 0, 0);
     }
 
     /// @notice execute is called above, in a try-catch block in metacall.

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -129,9 +129,7 @@ contract Atlas is Escrow, Factory {
         if (msg.sender != address(this)) revert InvalidAccess();
 
         // Build the context object
-        ctx = _buildContext(
-            dConfig, executionEnvironment, userOpHash, bundler, uint8(solverOps.length), bundler == SIMULATOR
-        );
+        ctx = _buildContext(executionEnvironment, userOpHash, bundler, uint8(solverOps.length), bundler == SIMULATOR);
 
         bytes memory _returnData;
 

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -101,8 +101,8 @@ contract Atlas is Escrow, Factory {
             if (msg.value != 0) SafeTransferLib.safeTransferETH(msg.sender, msg.value);
         }
 
-        // The environment lock is explicitly released here to allow multiple metacalls in a single transaction
-        _setLock(address(0), 0, 0);
+        // The environment lock is explicitly released here to allow multiple metacalls in a single transaction.
+        _releaseLock();
     }
 
     /// @notice execute is called above, in a try-catch block in metacall.

--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -37,7 +37,16 @@ abstract contract GasAccounting is SafetyLocks {
         // Atlas surcharge is based on the raw claims value.
         _setFees(_rawClaims.getAtlasSurcharge());
         _setDeposits(msg.value);
-        // writeoffs and withdrawawls transient storage variables are already 0
+
+        // Explicitly set writeoffs and withdrawals to 0 in case multiple metacalls in single tx.
+        _setWriteoffs(0);
+        _setWithdrawals(0);
+
+        // Explicitly clear solverLock and solverTo in case multiple metacalls in single tx.
+        _setSolverLock(0);
+        _setSolverTo(address(0));
+
+        // The Lock slot is cleared at the end of the metacall, so no need to zero again here.
     }
 
     /// @notice Contributes ETH to the contract, increasing the deposits if a non-zero value is sent.

--- a/src/contracts/atlas/SafetyLocks.sol
+++ b/src/contracts/atlas/SafetyLocks.sol
@@ -35,7 +35,7 @@ abstract contract SafetyLocks is Storage {
         _setLock({
             activeEnvironment: executionEnvironment,
             callConfig: dConfig.callConfig,
-            phase: dConfig.callConfig.needsPreOpsCall() ? uint8(ExecutionPhase.PreOps) : uint8(ExecutionPhase.UserOperation)
+            phase: uint8(ExecutionPhase.PreOps)
         });
     }
 
@@ -46,7 +46,6 @@ abstract contract SafetyLocks is Storage {
 
     /// @notice Builds an Context struct with the specified parameters, called at the start of
     /// `_preOpsUserExecutionIteration`.
-    /// @param dConfig The DAppConfig of the current DAppControl contract.
     /// @param executionEnvironment The address of the current Execution Environment.
     /// @param userOpHash The UserOperation hash.
     /// @param bundler The address of the bundler.
@@ -54,7 +53,6 @@ abstract contract SafetyLocks is Storage {
     /// @param isSimulation Boolean indicating whether the call is a simulation or not.
     /// @return An Context struct initialized with the provided parameters.
     function _buildContext(
-        DAppConfig memory dConfig,
         address executionEnvironment,
         bytes32 userOpHash,
         address bundler,
@@ -73,7 +71,7 @@ abstract contract SafetyLocks is Storage {
             paymentsSuccessful: false,
             solverIndex: 0,
             solverCount: solverOpCount,
-            phase: dConfig.callConfig.needsPreOpsCall() ? uint8(ExecutionPhase.PreOps) : uint8(ExecutionPhase.UserOperation),
+            phase: uint8(ExecutionPhase.PreOps),
             solverOutcome: 0,
             bidFind: false,
             isSimulation: isSimulation,

--- a/src/contracts/atlas/SafetyLocks.sol
+++ b/src/contracts/atlas/SafetyLocks.sol
@@ -32,15 +32,11 @@ abstract contract SafetyLocks is Storage {
         if (!_isUnlocked()) revert AlreadyInitialized();
 
         // Initialize the Lock
-        _setLock(
-            Lock({
-                activeEnvironment: executionEnvironment,
-                callConfig: dConfig.callConfig,
-                phase: dConfig.callConfig.needsPreOpsCall()
-                    ? uint8(ExecutionPhase.PreOps)
-                    : uint8(ExecutionPhase.UserOperation)
-            })
-        );
+        _setLock({
+            activeEnvironment: executionEnvironment,
+            callConfig: dConfig.callConfig,
+            phase: dConfig.callConfig.needsPreOpsCall() ? uint8(ExecutionPhase.PreOps) : uint8(ExecutionPhase.UserOperation)
+        });
     }
 
     modifier withLockPhase(ExecutionPhase executionPhase) {

--- a/src/contracts/atlas/Storage.sol
+++ b/src/contracts/atlas/Storage.sol
@@ -198,7 +198,7 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
     }
 
     function _isUnlocked() internal view returns (bool) {
-        return _tload(_T_LOCK_SLOT) == bytes32(0);
+        return _tload(_T_LOCK_SLOT) == bytes32(_UNLOCKED);
     }
 
     // ---------------------------------------------------- //
@@ -214,6 +214,10 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
             bytes32(uint256(uint160(activeEnvironment))) << 40 | bytes32(uint256(callConfig)) << 8
                 | bytes32(uint256(phase))
         );
+    }
+
+    function _releaseLock() internal {
+        _tstore(_T_LOCK_SLOT, bytes32(_UNLOCKED));
     }
 
     // Sets the Lock phase without changing the activeEnvironment or callConfig.

--- a/src/contracts/atlas/Storage.sol
+++ b/src/contracts/atlas/Storage.sol
@@ -31,14 +31,14 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
     uint256 public constant FIXED_GAS_OFFSET = AccountingMath._FIXED_GAS_OFFSET;
 
     // Transient storage slots
-    bytes32 private constant _T_LOCK_SLOT = keccak256("LOCK");
-    bytes32 private constant _T_SOLVER_LOCK_SLOT = keccak256("SOLVER_LOCK");
-    bytes32 private constant _T_SOLVER_TO_SLOT = keccak256("SOLVER_TO");
-    bytes32 private constant _T_CLAIMS_SLOT = keccak256("CLAIMS");
-    bytes32 private constant _T_FEES_SLOT = keccak256("FEES");
-    bytes32 private constant _T_WRITEOFFS_SLOT = keccak256("WRITEOFFS");
-    bytes32 private constant _T_WITHDRAWALS_SLOT = keccak256("WITHDRAWALS");
-    bytes32 private constant _T_DEPOSITS_SLOT = keccak256("DEPOSITS");
+    bytes32 private constant _T_LOCK_SLOT = keccak256("ATLAS_LOCK");
+    bytes32 private constant _T_SOLVER_LOCK_SLOT = keccak256("ATLAS_SOLVER_LOCK");
+    bytes32 private constant _T_SOLVER_TO_SLOT = keccak256("ATLAS_SOLVER_TO");
+    bytes32 private constant _T_CLAIMS_SLOT = keccak256("ATLAS_CLAIMS");
+    bytes32 private constant _T_FEES_SLOT = keccak256("ATLAS_FEES");
+    bytes32 private constant _T_WRITEOFFS_SLOT = keccak256("ATLAS_WRITEOFFS");
+    bytes32 private constant _T_WITHDRAWALS_SLOT = keccak256("ATLAS_WITHDRAWALS");
+    bytes32 private constant _T_DEPOSITS_SLOT = keccak256("ATLAS_DEPOSITS");
 
     // AtlETH storage
     uint256 internal S_totalSupply;
@@ -205,14 +205,14 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
     //                   Transient Setters                  //
     // ---------------------------------------------------- //
 
-    function _setLock(Lock memory newLock) internal {
+    function _setLock(address activeEnvironment, uint32 callConfig, uint8 phase) internal {
         // Pack the lock slot from the right:
         // [   56 bits   ][     160 bits      ][  32 bits   ][ 8 bits ]
         // [ unused bits ][ activeEnvironment ][ callConfig ][ phase  ]
         _tstore(
             _T_LOCK_SLOT,
-            bytes32(uint256(uint160(newLock.activeEnvironment))) << 40 | bytes32(uint256(newLock.callConfig)) << 8
-                | bytes32(uint256(newLock.phase))
+            bytes32(uint256(uint160(activeEnvironment))) << 40 | bytes32(uint256(callConfig)) << 8
+                | bytes32(uint256(phase))
         );
     }
 

--- a/src/contracts/types/AtlasConstants.sol
+++ b/src/contracts/types/AtlasConstants.sol
@@ -14,8 +14,7 @@ contract AtlasConstants {
 
     // Atlas constants
     uint256 internal constant _GAS_USED_DECIMALS_TO_DROP = 1000;
-    address internal constant _UNLOCKED = address(1);
-    uint256 internal constant _UNLOCKED_UINT = 1;
+    uint256 internal constant _UNLOCKED = 0;
 
     // Atlas constants used in `_bidFindingIteration()`
     uint256 internal constant _BITS_FOR_INDEX = 16;

--- a/src/contracts/types/LockTypes.sol
+++ b/src/contracts/types/LockTypes.sol
@@ -1,12 +1,6 @@
 //SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.25;
 
-struct Lock {
-    address activeEnvironment;
-    uint32 callConfig;
-    uint8 phase;
-}
-
 struct Context {
     bytes32 userOpHash; // not packed
     address executionEnvironment; // not packed

--- a/test/Permit69.t.sol
+++ b/test/Permit69.t.sol
@@ -356,11 +356,11 @@ contract MockAtlasForPermit69Tests is Atlas {
         address _activeEnvironment,
         uint32 callConfig
     ) public {
-        _setLock(Lock({
+        _setLock({
             activeEnvironment: _activeEnvironment,
             callConfig: callConfig,
             phase: uint8(ExecutionPhase.Uninitialized)
-        }));
+        });
     }
 
     function setPhase(ExecutionPhase _phase) public {

--- a/test/SafetyLocks.t.sol
+++ b/test/SafetyLocks.t.sol
@@ -27,7 +27,6 @@ contract MockSafetyLocks is SafetyLocks {
     }
 
     function buildEscrowLock(
-        DAppConfig calldata dConfig,
         address executionEnvironment,
         bytes32 userOpHash,
         address bundler,
@@ -38,7 +37,7 @@ contract MockSafetyLocks is SafetyLocks {
         pure
         returns (Context memory ctx)
     {
-        return _buildContext(dConfig, executionEnvironment, userOpHash, bundler, solverOpCount, isSimulation);
+        return _buildContext(executionEnvironment, userOpHash, bundler, solverOpCount, isSimulation);
     }
 
     function setLock(address _activeEnvironment) external {
@@ -102,10 +101,8 @@ contract SafetyLocksTest is Test {
     }
 
     function test_buildContext() public {
-        DAppConfig memory dConfig = DAppConfig({ to: address(10), callConfig: 0, bidToken: address(0), solverGasLimit: 1_000_000});
-
         safetyLocks.initializeLock(executionEnvironment, 0, 0);
-        Context memory ctx = safetyLocks.buildEscrowLock(dConfig, executionEnvironment, bytes32(0), address(0), 0, false);
+        Context memory ctx = safetyLocks.buildEscrowLock(executionEnvironment, bytes32(0), address(0), 0, false);
         assertEq(executionEnvironment, ctx.executionEnvironment);
     }
 }

--- a/test/SafetyLocks.t.sol
+++ b/test/SafetyLocks.t.sol
@@ -42,11 +42,11 @@ contract MockSafetyLocks is SafetyLocks {
     }
 
     function setLock(address _activeEnvironment) external {
-        _setLock(Lock({
+        _setLock({
             activeEnvironment: _activeEnvironment,
             phase: uint8(ExecutionPhase.Uninitialized),
             callConfig: uint32(0)
-        }));
+        });
     }
 
     function setClaims(uint256 _claims) external {

--- a/test/Storage.t.sol
+++ b/test/Storage.t.sol
@@ -126,7 +126,7 @@ contract StorageTest is BaseTest {
         assertEq(callConfig, 0, "callConfig should start at 0");
         assertEq(phase, 0, "phase should start at 0");
 
-        atlas.setLock(Lock(address(1), 2, 3));
+        atlas.setLock(address(1), 2, 3);
         (activeEnv, callConfig, phase) = atlas.lock();
 
         assertEq(activeEnv, address(1), "activeEnv should be 1");
@@ -144,7 +144,7 @@ contract StorageTest is BaseTest {
     function test_storage_transient_isUnlocked() public {
         assertEq(atlas.isUnlocked(), true, "isUnlocked should start as true");
 
-        atlas.setLock(Lock(address(1), 0, 0));
+        atlas.setLock(address(1), 0, 0);
         assertEq(atlas.isUnlocked(), false, "isUnlocked should be false");
 
         atlas.clearTransientStorage();
@@ -257,7 +257,7 @@ contract StorageTest is BaseTest {
         MockStorage mockStorage = new MockStorage(DEFAULT_ESCROW_DURATION, address(0), address(0), address(0));
         assertEq(mockStorage.activeEnvironment(), address(0), "activeEnvironment should start at 0");
 
-        mockStorage.setLock(Lock(address(1), 0, 0));
+        mockStorage.setLock(address(1), 0, 0);
         assertEq(mockStorage.activeEnvironment(), address(1), "activeEnvironment should be 1");
 
         mockStorage.clearTransientStorage();
@@ -268,7 +268,7 @@ contract StorageTest is BaseTest {
         MockStorage mockStorage = new MockStorage(DEFAULT_ESCROW_DURATION, address(0), address(0), address(0));
         assertEq(mockStorage.activeCallConfig(), 0, "activeCallConfig should start at 0");
 
-        mockStorage.setLock(Lock(address(0), 1, 0));
+        mockStorage.setLock(address(0), 1, 0);
         assertEq(mockStorage.activeCallConfig(), 1, "activeCallConfig should be 1");
 
         mockStorage.clearTransientStorage();
@@ -279,7 +279,7 @@ contract StorageTest is BaseTest {
         MockStorage mockStorage = new MockStorage(DEFAULT_ESCROW_DURATION, address(0), address(0), address(0));
         assertEq(mockStorage.phase(), 0, "phase should start at 0");
 
-        mockStorage.setLock(Lock(address(0), 0, 1));
+        mockStorage.setLock(address(0), 0, 1);
         assertEq(mockStorage.phase(), 1, "phase should be 1");
 
         mockStorage.clearTransientStorage();
@@ -334,13 +334,13 @@ contract MockStorage is Storage {
     }
 
     // Setter for the above 3 view functions
-    function setLock(Lock memory newLock) public {
-        _setLock(newLock);
+    function setLock(address activeEnv, uint32 callConfig, uint8 newPhase) public {
+        _setLock(activeEnv, callConfig, newPhase);
     }
 
     // To clear all transient storage vars
     function clearTransientStorage() public {
-        _setLock(Lock(address(0), 0, 0));
+        _setLock(address(0), 0, 0);
         _setSolverLock(0);
         _setSolverTo(address(0));
         _setClaims(0);

--- a/test/base/TestAtlas.sol
+++ b/test/base/TestAtlas.sol
@@ -20,7 +20,7 @@ contract TestAtlas is Atlas {
     // Public functions to expose internal transient helpers for testing
 
     function clearTransientStorage() public {
-        _setLock(Lock(address(0), 0, 0));
+        _setLock(address(0), 0, 0);
         _setSolverLock(0);
         _setSolverTo(address(0));
         _setClaims(0);
@@ -30,8 +30,8 @@ contract TestAtlas is Atlas {
         _setDeposits(0);
     }
 
-    function setLock(Lock memory newLock) public {
-        _setLock(newLock);
+    function setLock(address activeEnvironment, uint32 callConfig, uint8 phase) public {
+        _setLock(activeEnvironment, callConfig, phase);
     }
 
     function setLockPhase(ExecutionPhase newPhase) public {


### PR DESCRIPTION
Addresses https://github.com/FastLane-Labs/atlas-issues/issues/62

Changes:

- Lock is cleared at end of metacall in `_releaseLock()` to allow multiple metacalls in a single tx.
- All other transient storage vars are either set to zero or the appropriate init figure in `_initializeAccountingValues()`, to reset the accounting even in the case of multiple metacalls in a single tx.
- Lock struct removed, as we were mostly returning and working with the struct members individually anyway (activeEnvironment, callConfig, phase).
- Unused `_UNLOCKED_UINT` constant removed and `_UNLOCKED` constant used in more transient storage places for readability.
- "ATLAS_" prefix added to the hashed string which is used for the transient variable slot, to avoid collisions.
- Set phase in `ctx` and `lock` to `PreOps` during initialization as this value will be overwritten to either `PreOps` or `UserOperation` in the first call from Atlas to the DAppControl hook, so setting it conditionally before that is redundant.