### PR TITLE
refactor: DAppControl to reuse validateCallConfig from AtlasVerification

### DIFF
--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -210,6 +210,13 @@ contract AtlasVerification is EIP712, NonceManager, DAppIntegration {
         }
     }
 
+    /// @notice External function to call the internal _verifyCallConfig function
+    /// @param callConfig The call configuration struct to verify.
+    /// @return The result of the ValidCalls check, in enum ValidCallsResult form.
+    function verifyCallConfig(uint32 callConfig) external returns (ValidCallsResult) {
+        return _verifyCallConfig(callConfig);
+    }
+
     /// @notice The _verifyCallConfig internal function verifies the validity of the call configuration.
     /// @param callConfig The call configuration to verify.
     /// @return The result of the ValidCalls check, in enum ValidCallsResult form.

--- a/src/contracts/dapp/DAppControl.sol
+++ b/src/contracts/dapp/DAppControl.sol
@@ -11,6 +11,7 @@ import "src/contracts/types/ConfigTypes.sol";
 import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 import { AtlasEvents } from "src/contracts/types/AtlasEvents.sol";
 import { IAtlas } from "src/contracts/interfaces/IAtlas.sol";
+import { ValidCallsResult } from "src/contracts/types/ValidCalls.sol";
 import { IAtlasVerification } from "src/contracts/interfaces/IAtlasVerification.sol";
 
 /// @title DAppControl
@@ -29,21 +30,10 @@ abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
     address public pendingGovernance;
 
     constructor(address atlas, address initialGovernance, CallConfig memory callConfig) ExecutionBase(atlas) {
-        if (callConfig.userNoncesSequential && callConfig.dappNoncesSequential) {
-            // Max one of user or dapp nonces can be sequential, not both
-            revert AtlasErrors.BothUserAndDAppNoncesCannotBeSequential();
-        }
-        if (callConfig.trackPreOpsReturnData && callConfig.trackUserReturnData) {
-            // Max one of preOps or userOp return data can be tracked, not both
-            revert AtlasErrors.BothPreOpsAndUserReturnDataCannotBeTracked();
-        }
-        if (callConfig.invertBidValue && callConfig.exPostBids) {
-            // If both invertBidValue and exPostBids are true, solver's retreived bid cannot be determined
-            revert AtlasErrors.InvertBidValueCannotBeExPostBids();
-        }
-        CALL_CONFIG = CallBits.encodeCallConfig(callConfig);
-        CONTROL = address(this);
         ATLAS_VERIFICATION = IAtlas(atlas).VERIFICATION();
+        CALL_CONFIG = CallBits.encodeCallConfig(callConfig);
+        _validateCallConfig(CALL_CONFIG);
+        CONTROL = address(this);
 
         governance = initialGovernance;
     }
@@ -195,6 +185,20 @@ abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
     /// @return The address of the current governance account of this DAppControl contract.
     function getDAppSignatory() external view mustBeCalled returns (address) {
         return governance;
+    }
+
+    function _validateCallConfig(uint32 callConfig) internal view {
+        ValidCallsResult result = IAtlasVerification(ATLAS_VERIFICATION).verifyCallConfig(callConfig);
+
+        if (result == ValidCallsResult.InvalidCallConfig) {
+            revert AtlasErrors.BothPreOpsAndUserReturnDataCannotBeTracked();
+        }
+        if (result == ValidCallsResult.BothUserAndDAppNoncesCannotBeSequential) {
+            revert AtlasErrors.BothUserAndDAppNoncesCannotBeSequential();
+        }
+        if (result == ValidCallsResult.InvertBidValueCannotBeExPostBids) {
+            revert AtlasErrors.InvertBidValueCannotBeExPostBids();
+        }
     }
 
     /// @notice Starts the transfer of governance to a new address. Only callable by the current governance address.

--- a/src/contracts/interfaces/IAtlasVerification.sol
+++ b/src/contracts/interfaces/IAtlasVerification.sol
@@ -31,6 +31,7 @@ interface IAtlasVerification {
         external
         view
         returns (uint256 result);
+    function verifyCallConfig(uint32 callConfig) external view returns (ValidCallsResult);
     function getUserOperationHash(UserOperation calldata userOp) external view returns (bytes32 hash);
     function getUserOperationPayload(UserOperation calldata userOp) external view returns (bytes32 payload);
     function getSolverPayload(SolverOperation calldata solverOp) external view returns (bytes32 payload);

--- a/test/DAppIntegration.t.sol
+++ b/test/DAppIntegration.t.sol
@@ -30,8 +30,7 @@ contract DAppIntegrationTest is Test {
         vm.startPrank(atlasDeployer);
 
         // Deploy ExecutionEnvironment with a salt
-        bytes32 salt = keccak256(abi.encodePacked(block.chainid, address(this), "AtlasFactory 1.0"));
-        ExecutionEnvironment execEnvTemplate = new ExecutionEnvironment{ salt: salt }(address(this));
+        ExecutionEnvironment execEnvTemplate = new ExecutionEnvironment(expectedAtlasAddr);
 
         // Compute expected addresses for Atlas and AtlasVerification
         address expectedAtlasAddr = vm.computeCreateAddress(atlasDeployer, vm.getNonce(atlasDeployer) + 1);

--- a/test/DAppIntegration.t.sol
+++ b/test/DAppIntegration.t.sol
@@ -28,13 +28,11 @@ contract DAppIntegrationTest is Test {
 
     function setUp() public {
         vm.startPrank(atlasDeployer);
+        
+        // Compute expected addresses for Atlas
+        address expectedAtlasAddr = vm.computeCreateAddress(atlasDeployer, vm.getNonce(atlasDeployer) + 2);
 
-        // Deploy ExecutionEnvironment with a salt
         ExecutionEnvironment execEnvTemplate = new ExecutionEnvironment(expectedAtlasAddr);
-
-        // Compute expected addresses for Atlas and AtlasVerification
-        address expectedAtlasAddr = vm.computeCreateAddress(atlasDeployer, vm.getNonce(atlasDeployer) + 1);
-        address expectedAtlasVerificationAddr = vm.computeCreateAddress(atlasDeployer, vm.getNonce(atlasDeployer) + 2);
 
         // Deploy the AtlasVerification contract
         atlasVerification = new AtlasVerification(expectedAtlasAddr);
@@ -47,6 +45,8 @@ contract DAppIntegrationTest is Test {
             executionTemplate: address(execEnvTemplate),
             initialSurchargeRecipient: atlasDeployer
         });
+
+        assertEq(address(atlas), expectedAtlasAddr, "Atlas address should be as expected");
 
         // Deploy the MockDAppIntegration contract
         dAppIntegration = new MockDAppIntegration(address(atlas));


### PR DESCRIPTION
Audit Issue: https://github.com/FastLane-Labs/atlas-issues/issues/115

Changes:
- reuse AtlasVerification `_validateCallConfig` functionality