### PR TITLE
fix: allocateValue success reflected in `ctx.paymentsSuccessful`

### DIFF
--- a/src/contracts/common/ExecutionEnvironment.sol
+++ b/src/contracts/common/ExecutionEnvironment.sol
@@ -226,6 +226,9 @@ contract ExecutionEnvironment is Base {
     /// @param bidToken The address of the token used for the winning SolverOperation's bid.
     /// @param bidAmount The winning bid amount.
     /// @param allocateData Data returned from the previous call phase.
+    /// @return allocateValueSucceeded Boolean indicating whether the allocateValue delegatecall succeeded (true) or
+    /// reverted (false). This is useful when allowAllocateValueFailure is set to true, the failure is caught here, but
+    /// we still need to communicate to Atlas that the hook did not succeed.
     function allocateValue(
         address bidToken,
         uint256 bidAmount,
@@ -233,6 +236,7 @@ contract ExecutionEnvironment is Base {
     )
         external
         onlyAtlasEnvironment
+        returns (bool allocateValueSucceeded)
     {
         allocateData = _forward(abi.encodeCall(IDAppControl.allocateValueCall, (bidToken, bidAmount, allocateData)));
 
@@ -243,6 +247,8 @@ contract ExecutionEnvironment is Base {
         if (_balance > 0) {
             IAtlas(ATLAS).contribute{ value: _balance }();
         }
+
+        return _success;
     }
 
     ///////////////////////////////////////

--- a/src/contracts/interfaces/IExecutionEnvironment.sol
+++ b/src/contracts/interfaces/IExecutionEnvironment.sol
@@ -29,7 +29,13 @@ interface IExecutionEnvironment {
         external
         returns (SolverTracker memory);
 
-    function allocateValue(address bidToken, uint256 bidAmount, bytes memory returnData) external;
+    function allocateValue(
+        address bidToken,
+        uint256 bidAmount,
+        bytes memory returnData
+    )
+        external
+        returns (bool allocateValueSucceeded);
 
     function getUser() external pure returns (address user);
     function getControl() external pure returns (address control);


### PR DESCRIPTION
Follow up to this the PR addressing this issue https://github.com/FastLane-Labs/atlas-issues/issues/107

Changes:

- We need to make sure `ctx.paymentsSuccessful` accurately reflects if allocateValue failed or not, even if we allow the failure in call config settings and therefore catch the revert. This is now done by returning `bool success` from the allocateValue hook in EE.