### PR TITLE
General Clean Up

### DIFF
--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -301,17 +301,6 @@ abstract contract Escrow is AtlETH {
             return (result, gasLimit); // gasLimit = 0
         }
 
-        if (solverOp.deadline != 0 && block.number > solverOp.deadline) {
-            result |= 1
-                << (
-                    dConfig.callConfig.allowsTrustedOpHash()
-                        ? uint256(SolverOutcome.DeadlinePassedAlt)
-                        : uint256(SolverOutcome.DeadlinePassed)
-                );
-
-            return (result, gasLimit); // gasLimit = 0
-        }
-
         gasLimit = AccountingMath.solverGasLimitScaledDown(solverOp.gas, dConfig.solverGasLimit) + _FASTLANE_GAS_BUFFER;
 
         uint256 _gasCost = (tx.gasprice * gasLimit) + _getCalldataCost(solverOp.data.length);

--- a/src/contracts/common/ExecutionBase.sol
+++ b/src/contracts/common/ExecutionBase.sol
@@ -47,7 +47,6 @@ contract Base {
             _solverIndex(),
             _solverCount(),
             _phase(),
-            uint8(0),
             _solverOutcome(),
             _bidFind(),
             _simulation(),
@@ -120,13 +119,11 @@ contract Base {
         }
     }
 
-    // EMPTY 8BIT PLACEHOLDER AT shr(248, calldataload(sub(calldatasize(), 51)))
-
     /// @notice Extracts and returns the lock state bitmap of the current metacall tx, from calldata.
     /// @return phase The lock state bitmap of the current metacall tx, in uint8 form.
     function _phase() internal pure returns (uint8 phase) {
         assembly {
-            phase := shr(248, calldataload(sub(calldatasize(), 52)))
+            phase := shr(248, calldataload(sub(calldatasize(), 51)))
         }
     }
 
@@ -134,7 +131,7 @@ contract Base {
     /// @return solverCount The number of solverOps in the current metacall tx.
     function _solverCount() internal pure returns (uint8 solverCount) {
         assembly {
-            solverCount := shr(248, calldataload(sub(calldatasize(), 53)))
+            solverCount := shr(248, calldataload(sub(calldatasize(), 52)))
         }
     }
 
@@ -143,7 +140,7 @@ contract Base {
     /// @return solverIndex The count of executed solverOps in the current metacall tx.
     function _solverIndex() internal pure returns (uint8 solverIndex) {
         assembly {
-            solverIndex := shr(248, calldataload(sub(calldatasize(), 54)))
+            solverIndex := shr(248, calldataload(sub(calldatasize(), 53)))
         }
     }
 
@@ -153,7 +150,7 @@ contract Base {
     /// step in the current metacall tx.
     function _paymentsSuccessful() internal pure returns (bool paymentsSuccessful) {
         assembly {
-            paymentsSuccessful := shr(248, calldataload(sub(calldatasize(), 55)))
+            paymentsSuccessful := shr(248, calldataload(sub(calldatasize(), 54)))
         }
     }
 
@@ -163,7 +160,7 @@ contract Base {
     /// current metacall tx.
     function _solverSuccessful() internal pure returns (bool solverSuccessful) {
         assembly {
-            solverSuccessful := shr(248, calldataload(sub(calldatasize(), 56)))
+            solverSuccessful := shr(248, calldataload(sub(calldatasize(), 55)))
         }
     }
 
@@ -174,7 +171,7 @@ contract Base {
     /// @return bundler The current value of the bundler of the current metacall tx.
     function _bundler() internal pure returns (address bundler) {
         assembly {
-            bundler := shr(96, calldataload(sub(calldatasize(), 76)))
+            bundler := shr(96, calldataload(sub(calldatasize(), 75)))
         }
     }
 

--- a/src/contracts/common/ExecutionBase.sol
+++ b/src/contracts/common/ExecutionBase.sol
@@ -123,28 +123,24 @@ contract Base {
     // EMPTY 8BIT PLACEHOLDER AT shr(248, calldataload(sub(calldatasize(), 51)))
 
     /// @notice Extracts and returns the lock state bitmap of the current metacall tx, from calldata.
-    /// @return phase The lock state bitmap of the current metacall tx, in uint16 form.
+    /// @return phase The lock state bitmap of the current metacall tx, in uint8 form.
     function _phase() internal pure returns (uint8 phase) {
         assembly {
             phase := shr(248, calldataload(sub(calldatasize(), 52)))
         }
     }
 
-    /// @notice Extracts and returns the call count of the current metacall tx, from calldata.
-    /// @dev Call count is calculated as number of solverOps + 3. This represents 1 call for preOps, userOp, and postOps
-    /// each, then 1 call for each of the solverOps.
-    /// @return solverCount The call count of the current metacall tx.
+    /// @notice Extracts and returns the number of solverOps in the current metacall tx, from calldata.
+    /// @return solverCount The number of solverOps in the current metacall tx.
     function _solverCount() internal pure returns (uint8 solverCount) {
         assembly {
             solverCount := shr(248, calldataload(sub(calldatasize(), 53)))
         }
     }
 
-    /// @notice Extracts and returns the call index of the current metacall tx, from calldata.
-    /// @dev Call index is the index of the current call within the total calls (see `_solverCount()`) of a metacall tx.
-    /// I.e. preOpsCall has an index of 0, userOp has an index of 1, the first solverOp has an index of 2, subsequent
-    /// solverOps have indices of 3, 4, 5, etc, and postOpsCall has an index of `solverCount - 1`.
-    /// @return solverIndex The call index of the current metacall tx.
+    /// @notice Extracts and returns the number of executed solverOps in the current metacall tx, from calldata.
+    /// @dev Solver index is incremented as Atlas iterates through the solverOps array during execution.
+    /// @return solverIndex The count of executed solverOps in the current metacall tx.
     function _solverIndex() internal pure returns (uint8 solverIndex) {
         assembly {
             solverIndex := shr(248, calldataload(sub(calldatasize(), 54)))

--- a/src/contracts/libraries/SafetyBits.sol
+++ b/src/contracts/libraries/SafetyBits.sol
@@ -18,16 +18,15 @@ uint8 constant SAFE_DAPP_TRANSFER = uint8(
 );
 
 library SafetyBits {
-    function setAndPack(Context memory self, ExecutionPhase phase) internal pure returns (bytes memory packedKey) {
+    function setAndPack(Context memory self, ExecutionPhase phase) internal pure returns (bytes memory packedCtx) {
         self.phase = uint8(phase);
-        packedKey = abi.encodePacked(
+        packedCtx = abi.encodePacked(
             self.bundler,
             self.solverSuccessful,
             self.paymentsSuccessful,
             self.solverIndex,
             self.solverCount,
             uint8(phase),
-            uint8(0),
             self.solverOutcome,
             self.bidFind,
             self.isSimulation,

--- a/test/ExecutionBase.t.sol
+++ b/test/ExecutionBase.t.sol
@@ -38,7 +38,7 @@ contract ExecutionBaseTest is BaseTest {
 
         bytes memory expected = bytes.concat(randomData, firstSet, secondSet);
 
-        bytes memory data = abi.encodeWithSelector(MockExecutionEnvironment.forward.selector, randomData);
+        bytes memory data = abi.encodeCall(MockExecutionEnvironment.forward, randomData);
         executeForwardCase(phase, "forward", data, _ctx, expected);
     }
 
@@ -59,6 +59,12 @@ contract ExecutionBaseTest is BaseTest {
         (, bytes memory result) = address(mockExecutionEnvironment).call(data);
         result = abi.decode(result, (bytes));
 
+        console.log("Expected:");
+        console.logBytes(expected);
+
+        console.log("Result:");
+        console.logBytes(result);
+
         assertEq(result, expected, testName);
     }
 
@@ -68,17 +74,17 @@ contract ExecutionBaseTest is BaseTest {
         returns (bytes memory firstSet, Context memory _ctx)
     {
         _ctx = Context({
-            executionEnvironment: address(0),
-            userOpHash: bytes32(0),
-            bundler: address(0),
+            executionEnvironment: address(123),
+            userOpHash: bytes32(uint256(456)),
+            bundler: address(789),
             solverSuccessful: false,
             paymentsSuccessful: true,
-            solverIndex: 0,
-            solverCount: 1,
+            solverIndex: 7,
+            solverCount: 11,
             phase: uint8(_phase),
             solverOutcome: 2,
             bidFind: true,
-            isSimulation: true,
+            isSimulation: false,
             callDepth: 1
         });
 
@@ -88,8 +94,7 @@ contract ExecutionBaseTest is BaseTest {
             _ctx.paymentsSuccessful,
             _ctx.solverIndex,
             _ctx.solverCount,
-            uint8(_ctx.phase),
-            uint8(0),
+            _ctx.phase,
             _ctx.solverOutcome,
             _ctx.bidFind,
             _ctx.isSimulation,


### PR DESCRIPTION
Addresses:

- https://github.com/FastLane-Labs/atlas-issues/issues/130
- https://github.com/FastLane-Labs/atlas-issues/issues/132
- https://github.com/FastLane-Labs/atlas-issues/issues/121


Changes:

- solver's gasLimit is no longer passed to `solverCall()` as an arg, but still limits gas of entire `solverCall()` call
- remove deadline check in `_validateSolverOpGasAndValue()` as same check is done in `_validateSolverOpDeadline()`
- remove placeholder `uint8(0)` that was included in the packedCtx in the Atlas -> EE calldata