### PR TITLE
Simplify callChainHash computation

### DIFF
--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -252,7 +252,7 @@ contract AtlasVerification is EIP712, NonceManager, DAppIntegration {
     {
         if (
             dConfig.callConfig.verifyCallChainHash()
-                && dAppOp.callChainHash != CallVerification.getCallChainHash(dConfig, userOp, solverOps)
+                && dAppOp.callChainHash != CallVerification.getCallChainHash(userOp, solverOps)
         ) return (ValidCallsResult.InvalidCallChainHash, false);
 
         if (dConfig.callConfig.allowsUserAuctioneer() && dAppOp.from == userOp.sessionKey) {

--- a/src/contracts/helpers/TxBuilder.sol
+++ b/src/contracts/helpers/TxBuilder.sol
@@ -123,11 +123,9 @@ contract TxBuilder {
         view
         returns (DAppOperation memory dAppOp)
     {
-        DAppConfig memory dConfig = IDAppControl(userOp.control).getDAppConfig(userOp);
-
         // generate userOpHash depending on CallConfig.trustedOpHash allowed or not
         bytes32 userOpHash = IAtlasVerification(verification).getUserOperationHash(userOp);
-        bytes32 callChainHash = CallVerification.getCallChainHash(dConfig, userOp, solverOps);
+        bytes32 callChainHash = CallVerification.getCallChainHash(userOp, solverOps);
 
         dAppOp = DAppOperation({
             from: governance,

--- a/src/contracts/libraries/CallVerification.sol
+++ b/src/contracts/libraries/CallVerification.sol
@@ -11,7 +11,6 @@ library CallVerification {
     using CallBits for uint32;
 
     function getCallChainHash(
-        DAppConfig memory dConfig,
         UserOperation memory userOp,
         SolverOperation[] memory solverOps
     )
@@ -19,15 +18,7 @@ library CallVerification {
         pure
         returns (bytes32 callSequenceHash)
     {
-        bytes memory callSequence;
-
-        if (dConfig.callConfig.needsPreOpsCall()) {
-            // Start with preOps call if preOps is needed
-            callSequence = abi.encodePacked(dConfig.to);
-        }
-
-        // Then user and solver call
-        callSequence = abi.encodePacked(callSequence, abi.encode(userOp), abi.encode(solverOps));
+        bytes memory callSequence = abi.encodePacked(abi.encode(userOp), abi.encode(solverOps));
         callSequenceHash = keccak256(callSequence);
     }
 }

--- a/test/AtlasVerification.t.sol
+++ b/test/AtlasVerification.t.sol
@@ -111,7 +111,7 @@ contract AtlasVerificationBase is AtlasBaseTest {
     }
 
     function validDAppOperation(DAppConfig memory config, UserOperation memory userOp, SolverOperation[] memory solverOps) public returns (DAppOperationBuilder) {
-        bytes32 callChainHash = CallVerification.getCallChainHash(config, userOp, solverOps);
+        bytes32 callChainHash = CallVerification.getCallChainHash(userOp, solverOps);
         return new DAppOperationBuilder()
             .withFrom(governanceEOA)
             .withTo(address(atlas))

--- a/test/Simulator.t.sol
+++ b/test/Simulator.t.sol
@@ -207,7 +207,7 @@ contract SimulatorTest is BaseTest {
     }
 
     function validDAppOperation(DAppConfig memory config, UserOperation memory userOp, SolverOperation[] memory solverOps) public returns (DAppOperationBuilder) {
-        bytes32 callChainHash = CallVerification.getCallChainHash(config, userOp, solverOps);
+        bytes32 callChainHash = CallVerification.getCallChainHash(userOp, solverOps);
         return new DAppOperationBuilder()
             .withFrom(governanceEOA)
             .withTo(address(atlas))

--- a/test/base/TestUtils.sol
+++ b/test/base/TestUtils.sol
@@ -76,7 +76,6 @@ library TestUtils {
     }
 
     function computeCallChainHash(
-        DAppConfig calldata dConfig,
         UserOperation calldata userOp,
         SolverOperation[] calldata solverOps
     )
@@ -84,15 +83,7 @@ library TestUtils {
         pure
         returns (bytes32 callSequenceHash)
     {
-        bytes memory callSequence;
-
-        if (dConfig.callConfig.needsPreOpsCall()) {
-            // Start with preOps call if preOps is needed
-            callSequence = abi.encodePacked(dConfig.to);
-        }
-
-        // Then user and solver call
-        callSequence = abi.encodePacked(callSequence, abi.encode(userOp), abi.encode(solverOps));
+        bytes memory callSequence = abi.encodePacked(abi.encode(userOp), abi.encode(solverOps));
         callSequenceHash = keccak256(callSequence);
     }
 }

--- a/test/base/builders/DAppOperationBuilder.sol
+++ b/test/base/builders/DAppOperationBuilder.sol
@@ -79,8 +79,7 @@ contract DAppOperationBuilder is Test {
         public
         returns (DAppOperationBuilder)
     {
-        DAppConfig memory dConfig = IDAppControl(useroperation.control).getDAppConfig(useroperation);
-        dappOperation.callChainHash = CallVerification.getCallChainHash(dConfig, useroperation, solverOperations);
+        dappOperation.callChainHash = CallVerification.getCallChainHash(useroperation, solverOperations);
         return this;
     }
 

--- a/test/libraries/CallVerification.t.sol
+++ b/test/libraries/CallVerification.t.sol
@@ -52,20 +52,19 @@ contract CallVerificationTest is Test {
         SolverOperation[] memory solverOps = new SolverOperation[](2);
         solverOps[0] = builderSolverOperation();
         solverOps[1] = builderSolverOperation();
-        this._testGetCallChainHash(dConfig, userOp, solverOps);
+        this._testGetCallChainHash(userOp, solverOps);
     }
 
     function _testGetCallChainHash(
-        DAppConfig calldata dConfig,
         UserOperation calldata userOp,
         SolverOperation[] calldata solverOps
     )
         external pure
     {
-        bytes32 callChainHash = CallVerification.getCallChainHash(dConfig, userOp, solverOps);
+        bytes32 callChainHash = CallVerification.getCallChainHash(userOp, solverOps);
         assertEq(
             callChainHash,
-            TestUtils.computeCallChainHash(dConfig, userOp, solverOps),
+            TestUtils.computeCallChainHash(userOp, solverOps),
             "callChainHash different to TestUtils reproduction"
         );
     }


### PR DESCRIPTION
Addresses https://github.com/FastLane-Labs/atlas-issues/issues/133

Remove the `needsPreOpsCall()` logic, as it's already reflected in `userOp.callConfig`.