### PR TITLE
Move generic checks at the dAppControl level

### DIFF
--- a/src/contracts/common/ExecutionBase.sol
+++ b/src/contracts/common/ExecutionBase.sol
@@ -7,6 +7,7 @@ import { IAtlas } from "src/contracts/interfaces/IAtlas.sol";
 import { ExecutionPhase } from "src/contracts/types/LockTypes.sol";
 import { SAFE_USER_TRANSFER, SAFE_DAPP_TRANSFER } from "src/contracts/libraries/SafetyBits.sol";
 import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
+import "src/contracts/types/SolverOperation.sol";
 
 contract Base {
     address public immutable ATLAS;
@@ -23,6 +24,18 @@ contract Base {
 
     modifier onlyAtlasEnvironment() {
         _onlyAtlasEnvironment();
+        _;
+    }
+
+    modifier validSolver(SolverOperation calldata solverOp) {
+        address solverContract = solverOp.solver;
+        if (solverContract == ATLAS || solverContract == _control() || solverContract == address(this)) {
+            revert AtlasErrors.InvalidSolver();
+        }
+        // Verify that the dAppControl contract matches the solver's expectations
+        if (solverOp.control != _control()) {
+            revert AtlasErrors.AlteredControl();
+        }
         _;
     }
 

--- a/src/contracts/common/ExecutionEnvironment.sol
+++ b/src/contracts/common/ExecutionEnvironment.sol
@@ -31,17 +31,6 @@ contract ExecutionEnvironment is Base {
         _;
     }
 
-    modifier validSolver(SolverOperation calldata solverOp) {
-        if (solverOp.solver == ATLAS || solverOp.solver == _control() || solverOp.solver == address(this)) {
-            revert AtlasErrors.InvalidSolver();
-        }
-        // Verify that the DAppControl contract matches the solver's expectations
-        if (solverOp.control != _control()) {
-            revert AtlasErrors.AlteredControl();
-        }
-        _;
-    }
-
     //////////////////////////////////
     ///    CORE CALL FUNCTIONS     ///
     //////////////////////////////////

--- a/src/contracts/dapp/DAppControl.sol
+++ b/src/contracts/dapp/DAppControl.sol
@@ -57,6 +57,14 @@ abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
         _;
     }
 
+    modifier validSolverContract(SolverOperation memory solverOp) {
+        address solverContract = solverOp.solver;
+        if (solverContract == address(this) || solverContract == _control() || solverContract == ATLAS) {
+            revert AtlasErrors.InvalidSolverContract();
+        }
+        _;
+    }
+
     // Reverts if phase in Atlas is not the specified phase.
     // This is required to prevent reentrancy in hooks from other hooks in different phases.
     modifier onlyPhase(ExecutionPhase phase) {
@@ -95,6 +103,7 @@ abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
         external
         payable
         validControl
+        validSolverContract(solverOp)
         onlyAtlasEnvironment
         onlyPhase(ExecutionPhase.PreSolver)
     {
@@ -112,6 +121,7 @@ abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
         external
         payable
         validControl
+        validSolverContract(solverOp)
         onlyAtlasEnvironment
         onlyPhase(ExecutionPhase.PostSolver)
     {

--- a/src/contracts/dapp/DAppControl.sol
+++ b/src/contracts/dapp/DAppControl.sol
@@ -57,14 +57,6 @@ abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
         _;
     }
 
-    modifier validSolverContract(SolverOperation memory solverOp) {
-        address solverContract = solverOp.solver;
-        if (solverContract == address(this) || solverContract == _control() || solverContract == ATLAS) {
-            revert AtlasErrors.InvalidSolverContract();
-        }
-        _;
-    }
-
     // Reverts if phase in Atlas is not the specified phase.
     // This is required to prevent reentrancy in hooks from other hooks in different phases.
     modifier onlyPhase(ExecutionPhase phase) {
@@ -103,7 +95,7 @@ abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
         external
         payable
         validControl
-        validSolverContract(solverOp)
+        validSolver(solverOp)
         onlyAtlasEnvironment
         onlyPhase(ExecutionPhase.PreSolver)
     {
@@ -121,7 +113,7 @@ abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
         external
         payable
         validControl
-        validSolverContract(solverOp)
+        validSolver(solverOp)
         onlyAtlasEnvironment
         onlyPhase(ExecutionPhase.PostSolver)
     {

--- a/src/contracts/examples/intents-example/SwapIntentDAppControl.sol
+++ b/src/contracts/examples/intents-example/SwapIntentDAppControl.sol
@@ -130,15 +130,10 @@ contract SwapIntentDAppControl is DAppControl {
     * @return true if the transfer was successful, false otherwise
     */
     function _preSolverCall(SolverOperation calldata solverOp, bytes calldata returnData) internal override {
-        address solverTo = solverOp.solver;
-        if (solverTo == address(this) || solverTo == _control() || solverTo == ATLAS) {
-            revert();
-        }
-
         SwapData memory swapData = abi.decode(returnData, (SwapData));
 
         // Optimistically transfer to the solver contract the tokens that the user is selling
-        _transferUserERC20(swapData.tokenUserSells, solverTo, swapData.amountUserSells);
+        _transferUserERC20(swapData.tokenUserSells, solverOp.solver, swapData.amountUserSells);
 
         return; // success
     }

--- a/src/contracts/examples/intents-example/SwapIntentInvertBidDAppControl.sol
+++ b/src/contracts/examples/intents-example/SwapIntentInvertBidDAppControl.sol
@@ -117,10 +117,6 @@ contract SwapIntentInvertBidDAppControl is DAppControl {
     */
     function _preSolverCall(SolverOperation calldata solverOp, bytes calldata returnData) internal override {
         address solverTo = solverOp.solver;
-        if (solverTo == address(this) || solverTo == _control() || solverTo == ATLAS) {
-            revert("Invalid solver address - solverOp.solver cannot be execution environment, dapp control or atlas");
-        }
-
         SwapIntent memory swapData = abi.decode(returnData, (SwapIntent));
 
         // The solver must be bidding less than the intent's maxAmountUserSells

--- a/src/contracts/examples/v4-example/V4DAppControl.sol
+++ b/src/contracts/examples/v4-example/V4DAppControl.sol
@@ -104,10 +104,6 @@ contract V4DAppControl is DAppControl {
 
         require(!_currentKey.initialized, "ERR-H09 AlreadyInitialized");
 
-        // Verify that the swapper went through the FastLane Atlas MEV Auction
-        // and that DAppControl supplied a valid signature
-        require(msg.sender == ATLAS, "ERR-H00 InvalidCaller");
-
         (IPoolManager.PoolKey memory key, IPoolManager.SwapParams memory params) =
             abi.decode(userOp.data[4:], (IPoolManager.PoolKey, IPoolManager.SwapParams));
 

--- a/src/contracts/types/AtlasErrors.sol
+++ b/src/contracts/types/AtlasErrors.sol
@@ -117,6 +117,7 @@ contract AtlasErrors {
     error BothUserAndDAppNoncesCannotBeSequential();
     error BothPreOpsAndUserReturnDataCannotBeTracked();
     error InvalidControl();
+    error InvalidSolverContract();
     error NoDelegatecall();
     error MustBeDelegatecalled();
     error OnlyAtlas();

--- a/src/contracts/types/AtlasErrors.sol
+++ b/src/contracts/types/AtlasErrors.sol
@@ -117,7 +117,6 @@ contract AtlasErrors {
     error BothUserAndDAppNoncesCannotBeSequential();
     error BothPreOpsAndUserReturnDataCannotBeTracked();
     error InvalidControl();
-    error InvalidSolverContract();
     error NoDelegatecall();
     error MustBeDelegatecalled();
     error OnlyAtlas();


### PR DESCRIPTION
Addresses https://github.com/FastLane-Labs/atlas-issues/issues/122

Move the `solverOp.solver` validity check at the `dAppControl` level, in a modifier, applied to `preSolverCall()` and `postSolverCall()`.

Remove the `ATLAS` address check in `V4DAppControl._preOpsCall()`, as this is already enforced at the `dAppControl` level in the `onlyAtlasEnvironment` modifier.