### PR TITLE
_getAndApproveUserERC20 helper function in ExecutionBase

### DIFF
--- a/src/contracts/common/ExecutionBase.sol
+++ b/src/contracts/common/ExecutionBase.sol
@@ -1,6 +1,7 @@
 //SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.25;
 
+import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import { IAtlas } from "src/contracts/interfaces/IAtlas.sol";
 
@@ -279,5 +280,20 @@ contract ExecutionBase is Base {
         }
 
         return false;
+    }
+
+    /// @notice Transfers ERC20 tokens from the user of the current metacall tx, via Atlas, to the current
+    /// ExecutionEnvironment, and approves the destination address to spend the tokens from the ExecutionEnvironment.
+    /// @param token The address of the ERC20 token contract.
+    /// @param amount The amount of tokens to transfer and approve.
+    /// @param destination The address approved to spend the tokens from the ExecutionEnvironment.
+    function _getAndApproveUserERC20(address token, uint256 amount, address destination) internal {
+        if (token == address(0) || amount == 0) return;
+
+        // Pull tokens from user to ExecutionEnvironment
+        _transferUserERC20(token, address(this), amount);
+
+        // Approve destination to spend the tokens from ExecutionEnvironment
+        SafeTransferLib.safeApprove(token, destination, amount);
     }
 }

--- a/src/contracts/examples/intents-example/SwapIntentInvertBidDAppControl.sol
+++ b/src/contracts/examples/intents-example/SwapIntentInvertBidDAppControl.sol
@@ -127,10 +127,8 @@ contract SwapIntentInvertBidDAppControl is DAppControl {
         require(solverOp.bidAmount <= swapData.maxAmountUserSells, "SwapIntentInvertBid: BidTooHigh");
 
         if (_solverBidRetrievalRequired) {
-            // Optimistically transfer to the execution environment the amount that the solver is invert bidding
-            _transferUserERC20(swapData.tokenUserSells, address(this), solverOp.bidAmount);
-            // Approve the solver to retrieve the bid amount from ee
-            SafeTransferLib.safeApprove(swapData.tokenUserSells, solverTo, solverOp.bidAmount);
+            // Pull the tokens from the user and approve the solver to spend them
+            _getAndApproveUserERC20(swapData.tokenUserSells, solverOp.bidAmount, solverTo);
         } else {
             // Optimistically transfer to the solver contract the amount that the solver is invert bidding
             _transferUserERC20(swapData.tokenUserSells, solverTo, solverOp.bidAmount);

--- a/src/contracts/examples/v2-example-router/V2RewardDAppControl.sol
+++ b/src/contracts/examples/v2-example-router/V2RewardDAppControl.sol
@@ -151,13 +151,8 @@ contract V2RewardDAppControl is DAppControl {
         // The current hook is delegatecalled, so we need to call the userOp.control to access the mappings
         (address tokenSold, uint256 amountSold) = V2RewardDAppControl(userOp.control).getTokenSold(userOp.data);
 
-        if (tokenSold != address(0)) {
-            // Transfer tokens from user to ExecutionEnvironment
-            _transferUserERC20(tokenSold, address(this), amountSold);
-
-            // Approve UniswapV2Router02 to spend the tokens from ExecutionEnvironment
-            SafeTransferLib.safeApprove(tokenSold, uniswapV2Router02, amountSold);
-        }
+        // Pull the tokens from the user and approve UniswapV2Router02 to spend them
+        _getAndApproveUserERC20(tokenSold, amountSold, uniswapV2Router02);
 
         // Return tokenSold for the _postOpsCall hook to be able to refund dust
         return abi.encode(tokenSold);


### PR DESCRIPTION
Addresses https://github.com/FastLane-Labs/atlas-issues/issues/125

Introduce the `_getAndApproveUserERC20()` helper function in `ExecutionBase` for dAppControls to be able to pull user tokens to the EE and approve a destination address to spend those tokens in a single call.