### PR TITLE
move hashLock and initialized to transient storage at predefined slots

### DIFF
--- a/src/contracts/examples/v4-example/UniV4Hook.sol
+++ b/src/contracts/examples/v4-example/UniV4Hook.sol
@@ -75,6 +75,11 @@ contract UniV4Hook is V4DAppControl {
 
         ExecutionPhase currentPhase = ExecutionPhase(_phase());
 
+        bytes32 hashLock;
+        assembly {
+            hashLock := tload(transient_slot_hashLock.slot)
+        }
+
         if (currentPhase == ExecutionPhase.UserOperation) {
             // Case: User call
             // Sender = ExecutionEnvironment

--- a/src/contracts/examples/v4-example/V4DAppControl.sol
+++ b/src/contracts/examples/v4-example/V4DAppControl.sol
@@ -211,7 +211,7 @@ contract V4DAppControl is DAppControl {
         require(address(this) == hook, "ERR-H00 InvalidCallee");
         require(hook == _control(), "ERR-H01 InvalidCaller");
         require(_phase() == uint8(ExecutionPhase.PreOps), "ERR-H02 InvalidLockStage");
-        
+
         bytes32 hashLock;
         assembly {
             hashLock := tload(transient_slot_hashLock.slot)


### PR DESCRIPTION
Moved `initialized` and `hashLock`  in `V4DAppControl` to transient storage. 

To address https://github.com/FastLane-Labs/atlas-issues/issues/126