### PR TITLE
Make public transient view fns internal

### DIFF
--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -85,9 +85,13 @@ abstract contract GasAccounting is SafetyLocks {
     /// than zero, shortfall returns 0 as there is no shortfall because the solver is in surplus.
     /// @return uint256 The current shortfall amount, or 0 if there is no shortfall.
     function shortfall() external view returns (uint256) {
-        uint256 _deficit = claims() + withdrawals() + fees() - writeoffs();
+        uint256 _currentDeficit = _deficit();
         uint256 _deposits = deposits();
-        return (_deficit > _deposits) ? (_deficit - _deposits) : 0;
+        return (_currentDeficit > _deposits) ? (_currentDeficit - _deposits) : 0;
+    }
+
+    function _deficit() internal view returns (uint256) {
+        return claims() + withdrawals() + fees() - writeoffs();
     }
 
     /// @notice Allows a solver to settle any outstanding ETH owed, either to repay gas used by their solverOp or to
@@ -118,7 +122,7 @@ abstract contract GasAccounting is SafetyLocks {
         // Solver can only approve up to their bonded balance, not more
         if (maxApprovedGasSpend > _bondedBalance) maxApprovedGasSpend = _bondedBalance;
 
-        uint256 _deductions = claims() + withdrawals() + fees() - writeoffs();
+        uint256 _deductions = _deficit();
         uint256 _additions = deposits() + msg.value;
 
         // Add msg.value to solver's deposits
@@ -405,9 +409,12 @@ abstract contract GasAccounting is SafetyLocks {
                 revert InsufficientTotalBalance(_amountSolverPays - _amountSolverReceives);
             }
 
-            uint256 _deficit = _assign(_winningSolver, _amountSolverPays - _amountSolverReceives, _adjustedClaims, true);
-            if (_deficit > claimsPaidToBundler) revert InsufficientTotalBalance(_deficit - claimsPaidToBundler);
-            claimsPaidToBundler -= _deficit;
+            uint256 _currentDeficit =
+                _assign(_winningSolver, _amountSolverPays - _amountSolverReceives, _adjustedClaims, true);
+            if (_currentDeficit > claimsPaidToBundler) {
+                revert InsufficientTotalBalance(_currentDeficit - claimsPaidToBundler);
+            }
+            claimsPaidToBundler -= _currentDeficit;
         } else {
             _credit(_winningSolver, _amountSolverReceives - _amountSolverPays, _adjustedClaims);
         }
@@ -454,6 +461,6 @@ abstract contract GasAccounting is SafetyLocks {
     /// correct.
     /// @return True if the balance is reconciled, false otherwise.
     function _isBalanceReconciled() internal view returns (bool) {
-        return deposits() >= claims() + withdrawals() + fees() - writeoffs();
+        return deposits() >= _deficit();
     }
 }

--- a/src/contracts/atlas/Storage.sol
+++ b/src/contracts/atlas/Storage.sol
@@ -128,26 +128,6 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
         return _isUnlocked();
     }
 
-    function claims() public view returns (uint256) {
-        return uint256(_tload(_T_CLAIMS_SLOT));
-    }
-
-    function fees() public view returns (uint256) {
-        return uint256(_tload(_T_FEES_SLOT));
-    }
-
-    function writeoffs() public view returns (uint256) {
-        return uint256(_tload(_T_WRITEOFFS_SLOT));
-    }
-
-    function withdrawals() public view returns (uint256) {
-        return uint256(_tload(_T_WITHDRAWALS_SLOT));
-    }
-
-    function deposits() public view returns (uint256) {
-        return uint256(_tload(_T_DEPOSITS_SLOT));
-    }
-
     /// @notice Returns information about the current state of the solver lock.
     /// @return currentSolver Address of the current solver.
     /// @return calledBack Boolean indicating whether the solver has called back via `reconcile`.
@@ -159,6 +139,26 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
     // ---------------------------------------------------- //
     //              Transient Internal Getters              //
     // ---------------------------------------------------- //
+
+    function claims() internal view returns (uint256) {
+        return uint256(_tload(_T_CLAIMS_SLOT));
+    }
+
+    function fees() internal view returns (uint256) {
+        return uint256(_tload(_T_FEES_SLOT));
+    }
+
+    function writeoffs() internal view returns (uint256) {
+        return uint256(_tload(_T_WRITEOFFS_SLOT));
+    }
+
+    function withdrawals() internal view returns (uint256) {
+        return uint256(_tload(_T_WITHDRAWALS_SLOT));
+    }
+
+    function deposits() internal view returns (uint256) {
+        return uint256(_tload(_T_DEPOSITS_SLOT));
+    }
 
     function _lock() internal view returns (address activeEnvironment, uint32 callConfig, uint8 phase) {
         bytes32 _lockData = _tload(_T_LOCK_SLOT);

--- a/src/contracts/interfaces/IAtlas.sol
+++ b/src/contracts/interfaces/IAtlas.sol
@@ -82,11 +82,6 @@ interface IAtlas {
     function solverOpHashes(bytes32 opHash) external view returns (bool);
     function lock() external view returns (address activeEnvironment, uint32 callConfig, uint8 phase);
     function solverLock() external view returns (uint256);
-    function claims() external view returns (uint256);
-    function fees() external view returns (uint256);
-    function writeoffs() external view returns (uint256);
-    function withdrawals() external view returns (uint256);
-    function deposits() external view returns (uint256);
     function cumulativeSurcharge() external view returns (uint256);
     function surchargeRecipient() external view returns (address);
     function pendingSurchargeRecipient() external view returns (address);

--- a/test/SafetyLocks.t.sol
+++ b/test/SafetyLocks.t.sol
@@ -87,6 +87,28 @@ contract MockSafetyLocks is SafetyLocks {
     function solverTo() external view returns (address) {
         return _solverTo();
     }
+
+    // View functions
+
+    function getClaims() external view returns (uint256) {
+        return claims();
+    }
+
+    function getFees() external view returns (uint256) {
+        return fees();
+    }
+
+    function getWriteoffs() external view returns (uint256) {
+        return writeoffs();
+    }
+
+    function getWithdrawals() external view returns (uint256) {
+        return withdrawals();
+    }
+
+    function getDeposits() external view returns (uint256) {
+        return deposits();
+    }
 }
 
 contract SafetyLocksTest is Test {
@@ -136,7 +158,7 @@ contract SafetyLocksTest is Test {
 
         safetyLocks.setClaims(newClaims);
 
-        uint256 claims = safetyLocks.claims();
+        uint256 claims = safetyLocks.getClaims();
         assertEq(claims, newClaims);
     }
 
@@ -145,7 +167,7 @@ contract SafetyLocksTest is Test {
 
         safetyLocks.setWithdrawals(newWithdrawals);
 
-        uint256 withdrawals = safetyLocks.withdrawals();
+        uint256 withdrawals = safetyLocks.getWithdrawals();
         assertEq(withdrawals, newWithdrawals);
     }
 
@@ -154,7 +176,7 @@ contract SafetyLocksTest is Test {
 
         safetyLocks.setDeposits(newDeposits);
 
-        uint256 deposits = safetyLocks.deposits();
+        uint256 deposits = safetyLocks.getDeposits();
         assertEq(deposits, newDeposits);
     }
 
@@ -163,7 +185,7 @@ contract SafetyLocksTest is Test {
 
         safetyLocks.setFees(newFees);
 
-        uint256 fees = safetyLocks.fees();
+        uint256 fees = safetyLocks.getFees();
         assertEq(fees, newFees);
     }
 
@@ -172,7 +194,7 @@ contract SafetyLocksTest is Test {
 
         safetyLocks.setWriteoffs(newWriteoffs);
 
-        uint256 writeoffs = safetyLocks.writeoffs();
+        uint256 writeoffs = safetyLocks.getWriteoffs();
         assertEq(writeoffs, newWriteoffs);
     }
 
@@ -223,11 +245,11 @@ contract SafetyLocksTest is Test {
         safetyLocks.setSolverLock(0x456);
 
         (address activeEnv, uint32 callConfig, uint8 phase) = safetyLocks.lock();
-        uint256 claims = safetyLocks.claims();
-        uint256 withdrawals = safetyLocks.withdrawals();
-        uint256 deposits = safetyLocks.deposits();
-        uint256 fees = safetyLocks.fees();
-        uint256 writeoffs = safetyLocks.writeoffs();
+        uint256 claims = safetyLocks.getClaims();
+        uint256 withdrawals = safetyLocks.getWithdrawals();
+        uint256 deposits = safetyLocks.getDeposits();
+        uint256 fees = safetyLocks.getFees();
+        uint256 writeoffs = safetyLocks.getWriteoffs();
         (address solverTo,,) = safetyLocks.solverLockData();
 
         assertEq(safetyLocks.isUnlocked(), false);

--- a/test/Storage.t.sol
+++ b/test/Storage.t.sol
@@ -193,53 +193,53 @@ contract StorageTest is BaseTest {
     }
 
     function test_storage_transient_claims() public {
-        assertEq(atlas.claims(), 0, "claims should start at 0");
+        assertEq(atlas.getClaims(), 0, "claims should start at 0");
 
         atlas.setClaims(100);
-        assertEq(atlas.claims(), 100, "claims should be 100");
+        assertEq(atlas.getClaims(), 100, "claims should be 100");
 
         atlas.clearTransientStorage();
-        assertEq(atlas.claims(), 0, "claims should be 0 again");
+        assertEq(atlas.getClaims(), 0, "claims should be 0 again");
     }
 
     function test_storage_transient_fees() public {
-        assertEq(atlas.fees(), 0, "fees should start at 0");
+        assertEq(atlas.getFees(), 0, "fees should start at 0");
 
         atlas.setFees(100);
-        assertEq(atlas.fees(), 100, "fees should be 100");
+        assertEq(atlas.getFees(), 100, "fees should be 100");
 
         atlas.clearTransientStorage();
-        assertEq(atlas.fees(), 0, "fees should be 0 again");
+        assertEq(atlas.getFees(), 0, "fees should be 0 again");
     }
 
     function test_storage_transient_writeoffs() public {
-        assertEq(atlas.writeoffs(), 0, "writeoffs should start at 0");
+        assertEq(atlas.getWriteoffs(), 0, "writeoffs should start at 0");
 
         atlas.setWriteoffs(100);
-        assertEq(atlas.writeoffs(), 100, "writeoffs should be 100");
+        assertEq(atlas.getWriteoffs(), 100, "writeoffs should be 100");
 
         atlas.clearTransientStorage();
-        assertEq(atlas.writeoffs(), 0, "writeoffs should be 0 again");
+        assertEq(atlas.getWriteoffs(), 0, "writeoffs should be 0 again");
     }
 
     function test_storage_transient_withdrawals() public {
-        assertEq(atlas.withdrawals(), 0, "withdrawals should start at 0");
+        assertEq(atlas.getWithdrawals(), 0, "withdrawals should start at 0");
 
         atlas.setWithdrawals(100);
-        assertEq(atlas.withdrawals(), 100, "withdrawals should be 100");
+        assertEq(atlas.getWithdrawals(), 100, "withdrawals should be 100");
 
         atlas.clearTransientStorage();
-        assertEq(atlas.withdrawals(), 0, "withdrawals should be 0 again");
+        assertEq(atlas.getWithdrawals(), 0, "withdrawals should be 0 again");
     }
 
     function test_storage_transient_deposits() public {
-        assertEq(atlas.deposits(), 0, "deposits should start at 0");
+        assertEq(atlas.getDeposits(), 0, "deposits should start at 0");
 
         atlas.setDeposits(100);
-        assertEq(atlas.deposits(), 100, "deposits should be 100");
+        assertEq(atlas.getDeposits(), 100, "deposits should be 100");
 
         atlas.clearTransientStorage();
-        assertEq(atlas.deposits(), 0, "deposits should be 0 again");
+        assertEq(atlas.getDeposits(), 0, "deposits should be 0 again");
     }
 
     function test_storage_transient_solverTo() public {
@@ -348,5 +348,27 @@ contract MockStorage is Storage {
         _setWriteoffs(0);
         _setWithdrawals(0);
         _setDeposits(0);
+    }
+
+    // View functions
+
+    function getClaims() external view returns (uint256) {
+        return claims();
+    }
+
+    function getFees() external view returns (uint256) {
+        return fees();
+    }
+
+    function getWriteoffs() external view returns (uint256) {
+        return writeoffs();
+    }
+
+    function getWithdrawals() external view returns (uint256) {
+        return withdrawals();
+    }
+
+    function getDeposits() external view returns (uint256) {
+        return deposits();
     }
 }

--- a/test/base/TestAtlas.sol
+++ b/test/base/TestAtlas.sol
@@ -65,4 +65,26 @@ contract TestAtlas is Atlas {
     function setDeposits(uint256 newDeposits) public {
         _setDeposits(newDeposits);
     }
+
+    // View functions
+
+    function getClaims() external view returns (uint256) {
+        return claims();
+    }
+
+    function getFees() external view returns (uint256) {
+        return fees();
+    }
+
+    function getWriteoffs() external view returns (uint256) {
+        return writeoffs();
+    }
+
+    function getWithdrawals() external view returns (uint256) {
+        return withdrawals();
+    }
+
+    function getDeposits() external view returns (uint256) {
+        return deposits();
+    }
 }


### PR DESCRIPTION
Saves about 250 bytes of contract size. Needed to make space for the last remaining PRs.

Also addresses https://github.com/spearbit-audits/review-fastlane/issues/20