### PR TITLE
Remove `getBidValue()` from Atlas and Sorter

### DIFF
--- a/src/contracts/examples/gas-filler/Filler.sol
+++ b/src/contracts/examples/gas-filler/Filler.sol
@@ -147,9 +147,7 @@ contract Filler is DAppControl {
     }
 
     function getBidValue(SolverOperation calldata solverOp) public pure override returns (uint256) {
-        // NOTE: This is just for sorting
-        // Invert the amounts - less = more.
-        return type(uint256).max - solverOp.bidAmount;
+        return solverOp.bidAmount;
     }
 
     ///////////////////// DAPP STUFF ///////////////////////

--- a/src/contracts/helpers/Sorter.sol
+++ b/src/contracts/helpers/Sorter.sol
@@ -142,8 +142,7 @@ contract Sorter is AtlasConstants {
                 solverOps[i].userOpHash == userOpHash && _verifyBidFormat(bidToken, solverOps[i])
                     && _verifySolverEligibility(dConfig, userOp, solverOps[i])
             ) {
-                sortingData[i] =
-                    SortingData({ amount: IDAppControl(dConfig.to).getBidValue(solverOps[i]), valid: true });
+                sortingData[i] = SortingData({ amount: solverOps[i].bidAmount, valid: true });
             } else {
                 sortingData[i] = SortingData({ amount: 0, valid: false });
                 unchecked {


### PR DESCRIPTION
Addresses this audit issue https://github.com/spearbit-audits/review-fastlane/issues/172
And follows on from discussion and decisions here https://github.com/FastLane-Labs/atlas/pull/361#issuecomment-2227095681