### PR TITLE
Add `avgGasPrice` to analytics

### DIFF
--- a/src/contracts/atlas/Storage.sol
+++ b/src/contracts/atlas/Storage.sol
@@ -90,7 +90,14 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
     function accessData(address account)
         external
         view
-        returns (uint112 bonded, uint32 lastAccessedBlock, uint24 auctionWins, uint24 auctionFails, uint64 totalGasUsed)
+        returns (
+            uint112 bonded,
+            uint32 lastAccessedBlock,
+            uint24 auctionWins,
+            uint24 auctionFails,
+            uint48 totalGasUsed,
+            uint16 avgGasPrice
+        )
     {
         EscrowAccountAccessData memory _aData = S_accessData[account];
 
@@ -99,6 +106,7 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
         auctionWins = _aData.auctionWins;
         auctionFails = _aData.auctionFails;
         totalGasUsed = _aData.totalGasUsed;
+        avgGasPrice = _aData.avgGasPrice;
     }
 
     function solverOpHashes(bytes32 opHash) external view returns (bool) {

--- a/src/contracts/interfaces/IAtlas.sol
+++ b/src/contracts/interfaces/IAtlas.sol
@@ -78,7 +78,14 @@ interface IAtlas {
     function accessData(address account)
         external
         view
-        returns (uint112 bonded, uint32 lastAccessedBlock, uint24 auctionWins, uint24 auctionFails, uint64 totalGasUsed);
+        returns (
+            uint112 bonded,
+            uint32 lastAccessedBlock,
+            uint24 auctionWins,
+            uint24 auctionFails,
+            uint48 totalGasUsed,
+            uint16 avgGasPrice
+        );
     function solverOpHashes(bytes32 opHash) external view returns (bool);
     function lock() external view returns (address activeEnvironment, uint32 callConfig, uint8 phase);
     function solverLock() external view returns (uint256);

--- a/src/contracts/types/AtlasConstants.sol
+++ b/src/contracts/types/AtlasConstants.sol
@@ -13,7 +13,7 @@ contract AtlasConstants {
     // ------------------------------------------------------- //
 
     // Atlas constants
-    uint256 internal constant _GAS_USED_DECIMALS_TO_DROP = 1000;
+    uint256 internal constant _GAS_PRICE_DECIMALS_TO_DROP = 1e9; // measured in gwei
     uint256 internal constant _UNLOCKED = 0;
 
     // Atlas constants used in `_bidFindingIteration()`

--- a/src/contracts/types/EscrowTypes.sol
+++ b/src/contracts/types/EscrowTypes.sol
@@ -12,7 +12,8 @@ struct EscrowAccountAccessData {
     uint32 lastAccessedBlock;
     uint24 auctionWins;
     uint24 auctionFails;
-    uint64 totalGasUsed;
+    uint48 totalGasUsed;
+    uint16 avgGasPrice; // measured in gwei
 }
 
 // Additional struct to avoid Stack Too Deep while tracking variables related to the solver call.

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -895,6 +895,10 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         assertEq(auctionFails, 1, "auctionFails should be incremented by 1");
         assertEq(totalGasUsed, assignedAmount * 2, "totalGasUsed not as expected");
         assertEq(avgGasPriceInGwei, expectedAvgGasPrice / ONE_GWEI, "avgGasPrice should change to expectedAvgGasPrice");
+
+        // Should be able to calculate total gas cost spent by solver
+        uint256 expectedTotalGasCost = (assignedAmount * startGasPrice) + (assignedAmount * endGasPrice);
+        assertEq(totalGasUsed * avgGasPriceInGwei * ONE_GWEI, expectedTotalGasCost, "totalGasCost should be equal to expectedTotalGasCost");
     }
 
     function test_assign_overflow_reverts() public {

--- a/test/Storage.t.sol
+++ b/test/Storage.t.sol
@@ -59,36 +59,39 @@ contract StorageTest is BaseTest {
 
     function test_storage_view_accessData() public {
         uint256 depositAmount = 1e18;
-        (uint256 bonded, uint256 lastAccessedBlock, uint256 auctionWins, uint256 auctionFails, uint256 totalGasUsed) = atlas.accessData(userEOA);
+        (uint256 bonded, uint256 lastAccessedBlock, uint256 auctionWins, uint256 auctionFails, uint256 totalGasUsed, uint256 avgGasPrice) = atlas.accessData(userEOA);
 
         assertEq(bonded, 0, "user bonded should start as 0");
         assertEq(lastAccessedBlock, 0, "user lastAccessedBlock should start as 0");
         assertEq(auctionWins, 0, "user auctionWins should start as 0");
         assertEq(auctionFails, 0, "user auctionFails should start as 0");
         assertEq(totalGasUsed, 0, "user totalGasUsed should start as 0");
+        assertEq(avgGasPrice, 0, "user avgGasPrice should start as 0");
 
         vm.deal(userEOA, depositAmount);
         vm.prank(userEOA);
         atlas.depositAndBond{value: depositAmount}(depositAmount);
 
-        (bonded, lastAccessedBlock, auctionWins, auctionFails, totalGasUsed) = atlas.accessData(userEOA);
+        (bonded, lastAccessedBlock, auctionWins, auctionFails, totalGasUsed, avgGasPrice) = atlas.accessData(userEOA);
 
         assertEq(bonded, depositAmount, "user bonded should be equal to depositAmount");
         assertEq(lastAccessedBlock, 0, "user lastAccessedBlock should still be 0");
         assertEq(auctionWins, 0, "user auctionWins should still be 0");
         assertEq(auctionFails, 0, "user auctionFails should still be 0");
         assertEq(totalGasUsed, 0, "user totalGasUsed should still be 0");
+        assertEq(avgGasPrice, 0, "user avgGasPrice should still be 0");
 
         vm.prank(userEOA);
         atlas.unbond(depositAmount);
 
-        (bonded, lastAccessedBlock, auctionWins, auctionFails, totalGasUsed) = atlas.accessData(userEOA);
+        (bonded, lastAccessedBlock, auctionWins, auctionFails, totalGasUsed, avgGasPrice) = atlas.accessData(userEOA);
 
         assertEq(bonded, 0, "user bonded should be 0 again");
         assertEq(lastAccessedBlock, block.number, "user lastAccessedBlock should be equal to block.number");
         assertEq(auctionWins, 0, "user auctionWins should still be 0");
         assertEq(auctionFails, 0, "user auctionFails should still be 0");
         assertEq(totalGasUsed, 0, "user totalGasUsed should still be 0");
+        assertEq(avgGasPrice, 0, "user avgGasPrice should still be 0");
     }
 
     function test_storage_view_solverOpHashes() public {


### PR DESCRIPTION
Changes:

- Added `avgGasPrice` as a uint16 field to the `EscrowAccountAccessData` struct, for solver gas usage analytics. This is measured in Gwei, i.e. `tx.gasprice / 1_000_000_000`. The max value that can be stored in a uint16 is 65535 which should be more than enough for an _average_ gas price used by a solver in all their Atlas transactions, in _gwei_.
- Added an early revert if `gasUsed == 0` in `_handleSolverAccounting()` to ensure we never divide by zero when calculating `avgGasPrice` in `_updateAnalytics()`. No changes needed in `_settle()` as the `gasUsed` figure assigned there can never be zero. 
- Changed the `totalGasUsed` field of the `EscrowAccountAccessData` struct from `uint64` to `uint48`. This allows us to still pack all fields including the new `avgGasPrice` into a single slot. `type(uint48).max = 281474976710655` which should be more than enough to store  the cumulative gas used by a solver, or assigned to a solver, in Atlas transactions. To put that in perspective, if the average metacall results in 2 million gas being assigned to a solver, this variable will not overflow even after 140 million metacalls assigned to that same solver. 
- Removed truncating decimals of `totalGasUsed`. As shown above, we are not at risk of overflowing, so no need to truncate `totalGasUsed`.

These two fields (`avgGasPrice` and `totalGasUsed`) can be used to calculate total ETH spent on gas during Atlas metacalls by a particular solver as `avgGasPrice * totalGasUsed * 1_000_000_000`.