### PR TITLE
Analytics: just track total value of solver gas spent

### DIFF
--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -275,8 +275,6 @@ abstract contract GasAccounting is SafetyLocks {
             _gasUsed += _getCalldataCost(solverOp.data.length);
         }
 
-        if (_gasUsed == 0) return; // to avoid dividing by zero in _updateAnalytics()
-
         // Calculate what the solver owes
         // NOTE: This will cause an error if you are simulating with a gasPrice of 0
         if (result.bundlersFault()) {
@@ -451,13 +449,8 @@ abstract contract GasAccounting is SafetyLocks {
             }
         }
 
-        // Keeps a running average of gas price of the solver's total gas used. In gwei.
-        aData.avgGasPrice = uint16(
-            ((aData.totalGasUsed * aData.avgGasPrice * _GAS_PRICE_DECIMALS_TO_DROP) + (gasUsed * tx.gasprice))
-                / (aData.totalGasUsed + gasUsed) / _GAS_PRICE_DECIMALS_TO_DROP
-        );
-
-        aData.totalGasUsed += uint48(gasUsed);
+        // Track total ETH value of gas spent by solver in metacalls. Measured in gwei (1e9 digits truncated).
+        aData.totalGasValueUsed += uint64(gasUsed * tx.gasprice / _GAS_VALUE_DECIMALS_TO_DROP);
     }
 
     /// @notice Calculates the gas cost of the calldata used to execute a SolverOperation.

--- a/src/contracts/atlas/Storage.sol
+++ b/src/contracts/atlas/Storage.sol
@@ -95,8 +95,7 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
             uint32 lastAccessedBlock,
             uint24 auctionWins,
             uint24 auctionFails,
-            uint48 totalGasUsed,
-            uint16 avgGasPrice
+            uint64 totalGasValueUsed
         )
     {
         EscrowAccountAccessData memory _aData = S_accessData[account];
@@ -105,8 +104,7 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
         lastAccessedBlock = _aData.lastAccessedBlock;
         auctionWins = _aData.auctionWins;
         auctionFails = _aData.auctionFails;
-        totalGasUsed = _aData.totalGasUsed;
-        avgGasPrice = _aData.avgGasPrice;
+        totalGasValueUsed = _aData.totalGasValueUsed;
     }
 
     function solverOpHashes(bytes32 opHash) external view returns (bool) {

--- a/src/contracts/interfaces/IAtlas.sol
+++ b/src/contracts/interfaces/IAtlas.sol
@@ -83,8 +83,7 @@ interface IAtlas {
             uint32 lastAccessedBlock,
             uint24 auctionWins,
             uint24 auctionFails,
-            uint48 totalGasUsed,
-            uint16 avgGasPrice
+            uint64 totalGasValueUsed
         );
     function solverOpHashes(bytes32 opHash) external view returns (bool);
     function lock() external view returns (address activeEnvironment, uint32 callConfig, uint8 phase);

--- a/src/contracts/types/AtlasConstants.sol
+++ b/src/contracts/types/AtlasConstants.sol
@@ -13,7 +13,7 @@ contract AtlasConstants {
     // ------------------------------------------------------- //
 
     // Atlas constants
-    uint256 internal constant _GAS_PRICE_DECIMALS_TO_DROP = 1e9; // measured in gwei
+    uint256 internal constant _GAS_VALUE_DECIMALS_TO_DROP = 1e9; // measured in gwei
     uint256 internal constant _UNLOCKED = 0;
 
     // Atlas constants used in `_bidFindingIteration()`

--- a/src/contracts/types/EscrowTypes.sol
+++ b/src/contracts/types/EscrowTypes.sol
@@ -12,8 +12,7 @@ struct EscrowAccountAccessData {
     uint32 lastAccessedBlock;
     uint24 auctionWins;
     uint24 auctionFails;
-    uint48 totalGasUsed;
-    uint16 avgGasPrice; // measured in gwei
+    uint64 totalGasValueUsed; // The cumulative ETH value spent on gas in metacalls. Measured in gwei.
 }
 
 // Additional struct to avoid Stack Too Deep while tracking variables related to the solver call.

--- a/test/Storage.t.sol
+++ b/test/Storage.t.sol
@@ -59,39 +59,36 @@ contract StorageTest is BaseTest {
 
     function test_storage_view_accessData() public {
         uint256 depositAmount = 1e18;
-        (uint256 bonded, uint256 lastAccessedBlock, uint256 auctionWins, uint256 auctionFails, uint256 totalGasUsed, uint256 avgGasPrice) = atlas.accessData(userEOA);
+        (uint256 bonded, uint256 lastAccessedBlock, uint256 auctionWins, uint256 auctionFails, uint256 totalGasValueUsed) = atlas.accessData(userEOA);
 
         assertEq(bonded, 0, "user bonded should start as 0");
         assertEq(lastAccessedBlock, 0, "user lastAccessedBlock should start as 0");
         assertEq(auctionWins, 0, "user auctionWins should start as 0");
         assertEq(auctionFails, 0, "user auctionFails should start as 0");
-        assertEq(totalGasUsed, 0, "user totalGasUsed should start as 0");
-        assertEq(avgGasPrice, 0, "user avgGasPrice should start as 0");
+        assertEq(totalGasValueUsed, 0, "user totalGasValueUsed should start as 0");
 
         vm.deal(userEOA, depositAmount);
         vm.prank(userEOA);
         atlas.depositAndBond{value: depositAmount}(depositAmount);
 
-        (bonded, lastAccessedBlock, auctionWins, auctionFails, totalGasUsed, avgGasPrice) = atlas.accessData(userEOA);
+        (bonded, lastAccessedBlock, auctionWins, auctionFails, totalGasValueUsed) = atlas.accessData(userEOA);
 
         assertEq(bonded, depositAmount, "user bonded should be equal to depositAmount");
         assertEq(lastAccessedBlock, 0, "user lastAccessedBlock should still be 0");
         assertEq(auctionWins, 0, "user auctionWins should still be 0");
         assertEq(auctionFails, 0, "user auctionFails should still be 0");
-        assertEq(totalGasUsed, 0, "user totalGasUsed should still be 0");
-        assertEq(avgGasPrice, 0, "user avgGasPrice should still be 0");
+        assertEq(totalGasValueUsed, 0, "user totalGasValueUsed should still be 0");
 
         vm.prank(userEOA);
         atlas.unbond(depositAmount);
 
-        (bonded, lastAccessedBlock, auctionWins, auctionFails, totalGasUsed, avgGasPrice) = atlas.accessData(userEOA);
+        (bonded, lastAccessedBlock, auctionWins, auctionFails, totalGasValueUsed) = atlas.accessData(userEOA);
 
         assertEq(bonded, 0, "user bonded should be 0 again");
         assertEq(lastAccessedBlock, block.number, "user lastAccessedBlock should be equal to block.number");
         assertEq(auctionWins, 0, "user auctionWins should still be 0");
         assertEq(auctionFails, 0, "user auctionFails should still be 0");
-        assertEq(totalGasUsed, 0, "user totalGasUsed should still be 0");
-        assertEq(avgGasPrice, 0, "user avgGasPrice should still be 0");
+        assertEq(totalGasValueUsed, 0, "user totalGasValueUsed should still be 0");
     }
 
     function test_storage_view_solverOpHashes() public {


### PR DESCRIPTION
Follow-up PR to discussion in https://github.com/FastLane-Labs/atlas/pull/389

Changes:

- Reverts back to tracking one variable relating to gas usage per solver. But now it should accurately reflect the total _value_ of the gas spent by a solver across all Atlas metacalls in which they were involved, as opposed to before these 2 PRs, where we were just tracking the gas used (without a dimension of the cost of that gas).
- Gwei (1e9 digits) chosen as the truncation/precision level. Can be adjusted easily before we merge this if decided though.
- Atlas is back under the contract size limit (by 86 bytes).