### PR TITLE
Optimistically set `bundler` to `dAppOp.bundler` in sims

### DIFF
--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -60,11 +60,12 @@ contract Atlas is Escrow, Factory {
             : gasleft() + IL2GasCalculator(L2_GAS_CALCULATOR).initialGasUsed(msg.data.length);
 
         bool _isSimulation = msg.sender == SIMULATOR;
+        address _bundler = _isSimulation ? dAppOp.bundler : msg.sender;
 
         (address _executionEnvironment, DAppConfig memory _dConfig) = _getOrCreateExecutionEnvironment(userOp);
 
         ValidCallsResult _validCallsResult =
-            VERIFICATION.validateCalls(_dConfig, userOp, solverOps, dAppOp, msg.value, msg.sender, _isSimulation);
+            VERIFICATION.validateCalls(_dConfig, userOp, solverOps, dAppOp, msg.value, _bundler, _isSimulation);
         if (_validCallsResult != ValidCallsResult.Valid) {
             if (_isSimulation) revert VerificationSimFail(_validCallsResult);
 
@@ -84,7 +85,7 @@ contract Atlas is Escrow, Factory {
         // userOpHash has already been calculated and verified in validateCalls at this point, so rather
         // than re-calculate it, we can simply take it from the dAppOp here. It's worth noting that this will
         // be either a TRUSTED or DEFAULT hash, depending on the allowsTrustedOpHash setting.
-        try this.execute(_dConfig, userOp, solverOps, _executionEnvironment, msg.sender, dAppOp.userOpHash) returns (
+        try this.execute(_dConfig, userOp, solverOps, _executionEnvironment, _bundler, dAppOp.userOpHash) returns (
             Context memory ctx
         ) {
             // Gas Refund to sender only if execution is successful

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -85,9 +85,8 @@ contract Atlas is Escrow, Factory {
         // userOpHash has already been calculated and verified in validateCalls at this point, so rather
         // than re-calculate it, we can simply take it from the dAppOp here. It's worth noting that this will
         // be either a TRUSTED or DEFAULT hash, depending on the allowsTrustedOpHash setting.
-        try this.execute(_dConfig, userOp, solverOps, _executionEnvironment, _bundler, dAppOp.userOpHash) returns (
-            Context memory ctx
-        ) {
+        try this.execute(_dConfig, userOp, solverOps, _executionEnvironment, _bundler, dAppOp.userOpHash, _isSimulation)
+        returns (Context memory ctx) {
             // Gas Refund to sender only if execution is successful
             (uint256 _ethPaidToBundler, uint256 _netGasSurcharge) = _settle(ctx, _dConfig.solverGasLimit);
 
@@ -128,7 +127,8 @@ contract Atlas is Escrow, Factory {
         SolverOperation[] calldata solverOps,
         address executionEnvironment,
         address bundler,
-        bytes32 userOpHash
+        bytes32 userOpHash,
+        bool isSimulation
     )
         external
         payable
@@ -138,7 +138,7 @@ contract Atlas is Escrow, Factory {
         if (msg.sender != address(this)) revert InvalidAccess();
 
         // Build the context object
-        ctx = _buildContext(executionEnvironment, userOpHash, bundler, uint8(solverOps.length), bundler == SIMULATOR);
+        ctx = _buildContext(executionEnvironment, userOpHash, bundler, uint8(solverOps.length), isSimulation);
 
         bytes memory _returnData;
 

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -380,8 +380,8 @@ contract AtlasVerification is EIP712, NonceManager, DAppIntegration {
 
         // Check actual bundler matches the dApp's intended `dAppOp.bundler`
         // If bundler and auctioneer are the same address, this check is skipped
-        if (dAppOp.bundler != address(0) && msgSender != dAppOp.bundler) {
-            if (!_skipDAppOpChecks && !_isDAppSignatory(dAppOp.control, msgSender)) {
+        if (dAppOp.bundler != address(0) && msgSender != dAppOp.bundler && !isSimulation) {
+            if (!_isDAppSignatory(dAppOp.control, msgSender)) {
                 return ValidCallsResult.InvalidBundler;
             }
         }


### PR DESCRIPTION
Changes/Fixes:

- `_bundler()` helper in dapp logic used to return the Simulator address in sim mode. Now it optimistically assumes that the bundler will be correct (`dAppOp.bundler`), and sets `ctx.bundler = dAppOp.bundler` so that the dapp logic involving the `_bundler()` helper can be simulated. 
- `_verifyDApp()` used to return ValidCallsResult.InvalidBundler when called by the Simulator when the metacall expects to be called by a valid dapp signatory and an empty dAppOp.signature. Now this check for msgSender being a valid signatory is bypassed in sim mode.
- We also need to pass a new `bool isSimulation` param to `execute()` because it was previously using the bundler address to deduce whether the call was in sim mode or not. This is no longer accurate as that bundler address will no longer ever be the Simulator address. So an additional `isSimulation` param is needed.

Imo this solution is better than the one in https://github.com/FastLane-Labs/atlas/pull/394 (forwarding the Simulator caller and extracting that address to be used as the bundler) as simulations involving `_bundler()` in dapps will only work when a legitimate bundler is calling the Simulator. The solution here does not have that constraint.

Atlas is still under the contract size limit (by 76 bytes).