### PR TITLE
FLOnline Reputation - track winning solver in PostOps

### DIFF
--- a/src/contracts/atlas/Factory.sol
+++ b/src/contracts/atlas/Factory.sol
@@ -62,7 +62,9 @@ abstract contract Factory {
     /// @param userOp The user operation containing details about the user and the DAppControl contract.
     /// @return executionEnvironment The address of the execution environment that was found or created.
     /// @return dConfig The DAppConfig for the execution environment, specifying how operations should be handled.
-    function _getOrCreateExecutionEnvironment(UserOperation calldata userOp)
+    function _getOrCreateExecutionEnvironment(
+        UserOperation calldata userOp
+    )
         internal
         returns (address executionEnvironment, DAppConfig memory dConfig)
     {

--- a/src/contracts/atlas/Storage.sol
+++ b/src/contracts/atlas/Storage.sol
@@ -87,7 +87,9 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
         return S_bondedTotalSupply;
     }
 
-    function accessData(address account)
+    function accessData(
+        address account
+    )
         external
         view
         returns (

--- a/src/contracts/common/ExecutionEnvironment.sol
+++ b/src/contracts/common/ExecutionEnvironment.sol
@@ -40,7 +40,9 @@ contract ExecutionEnvironment is Base {
     /// corresponding `preOpsCall` function.
     /// @param userOp The UserOperation struct.
     /// @return preOpsData Data to be passed to the next call phase.
-    function preOpsWrapper(UserOperation calldata userOp)
+    function preOpsWrapper(
+        UserOperation calldata userOp
+    )
         external
         validUser(userOp)
         onlyAtlasEnvironment
@@ -62,7 +64,9 @@ contract ExecutionEnvironment is Base {
     /// with `userOp.data` as calldata, depending on the the needsDelegateUser flag.
     /// @param userOp The UserOperation struct.
     /// @return returnData Data to be passed to the next call phase.
-    function userWrapper(UserOperation calldata userOp)
+    function userWrapper(
+        UserOperation calldata userOp
+    )
         external
         payable
         validUser(userOp)

--- a/src/contracts/dapp/DAppControl.sol
+++ b/src/contracts/dapp/DAppControl.sol
@@ -63,7 +63,9 @@ abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
     /// @notice The preOpsCall hook which may be called before the UserOperation is executed.
     /// @param userOp The UserOperation struct.
     /// @return data Data to be passed to the next call phase.
-    function preOpsCall(UserOperation calldata userOp)
+    function preOpsCall(
+        UserOperation calldata userOp
+    )
         external
         payable
         validControl
@@ -162,7 +164,9 @@ abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
     /// @notice Returns the DAppConfig struct of this DAppControl contract.
     /// @param userOp The UserOperation struct.
     /// @return dConfig The DAppConfig struct of this DAppControl contract.
-    function getDAppConfig(UserOperation calldata userOp)
+    function getDAppConfig(
+        UserOperation calldata userOp
+    )
         external
         view
         mustBeCalled

--- a/src/contracts/examples/ex-post-mev-example/V2ExPost.sol
+++ b/src/contracts/examples/ex-post-mev-example/V2ExPost.sol
@@ -37,7 +37,9 @@ contract V2ExPost is DAppControl {
 
     event GiftedGovernanceToken(address indexed user, address indexed token, uint256 amount);
 
-    constructor(address _atlas)
+    constructor(
+        address _atlas
+    )
         DAppControl(
             _atlas,
             msg.sender,

--- a/src/contracts/examples/fastlane-online/BaseStorage.sol
+++ b/src/contracts/examples/fastlane-online/BaseStorage.sol
@@ -17,6 +17,7 @@ contract BaseStorage {
     uint256 internal constant _CONGESTION_RAKE = 33_000;
     uint256 internal constant _CONGESTION_BASE = 100_000;
     bytes32 private constant _USER_LOCK_SLOT = keccak256("FLO_USER_LOCK");
+    bytes32 private constant _WINNING_SOLVER_SLOT = keccak256("FLO_WINNING_SOLVER");
 
     uint256 public rake = 0;
 
@@ -80,6 +81,10 @@ contract BaseStorage {
 
     function _getUserLock() internal view returns (address) {
         return address(uint160(uint256(_tload(_USER_LOCK_SLOT))));
+    }
+
+    function _setWinningSolver(address winningSolverFrom) internal {
+        _tstore(_WINNING_SOLVER_SLOT, bytes32(uint256(uint160(winningSolverFrom))));
     }
 
     function _tstore(bytes32 slot, bytes32 value) internal {

--- a/src/contracts/examples/fastlane-online/BaseStorage.sol
+++ b/src/contracts/examples/fastlane-online/BaseStorage.sol
@@ -87,6 +87,10 @@ contract BaseStorage {
         _tstore(_WINNING_SOLVER_SLOT, bytes32(uint256(uint160(winningSolverFrom))));
     }
 
+    function _getWinningSolver() internal view returns (address) {
+        return address(uint160(uint256(_tload(_WINNING_SOLVER_SLOT))));
+    }
+
     function _tstore(bytes32 slot, bytes32 value) internal {
         assembly {
             tstore(slot, value)

--- a/src/contracts/examples/fastlane-online/FastLaneControl.sol
+++ b/src/contracts/examples/fastlane-online/FastLaneControl.sol
@@ -22,7 +22,9 @@ interface ISolverGateway {
 }
 
 contract FastLaneOnlineControl is DAppControl, FastLaneOnlineErrors {
-    constructor(address _atlas)
+    constructor(
+        address _atlas
+    )
         DAppControl(
             _atlas,
             msg.sender,

--- a/src/contracts/examples/fastlane-online/IFastLaneOnline.sol
+++ b/src/contracts/examples/fastlane-online/IFastLaneOnline.sol
@@ -1,0 +1,66 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.25;
+
+import "src/contracts/types/UserOperation.sol";
+import "src/contracts/types/SolverOperation.sol";
+import { SwapIntent, BaselineCall, Reputation } from "src/contracts/examples/fastlane-online/FastLaneTypes.sol";
+
+interface IFastLaneOnline {
+    // User entrypoint
+
+    function fastOnlineSwap(UserOperation calldata userOp) external payable;
+
+    // Solver functions
+
+    function addSolverOp(UserOperation calldata userOp, SolverOperation calldata solverOp) external payable;
+
+    function refundCongestionBuyIns(SolverOperation calldata solverOp) external;
+
+    // DApp functions
+
+    function setWinningSolver(address winningSolver) external;
+
+    // Other functions
+
+    function makeThogardsWifeHappy() external;
+
+    // View Functions
+
+    function getUserOperationAndHash(
+        address swapper,
+        SwapIntent calldata swapIntent,
+        BaselineCall calldata baselineCall,
+        uint256 deadline,
+        uint256 gas,
+        uint256 maxFeePerGas
+    )
+        external
+        view
+        returns (UserOperation memory userOp, bytes32 userOpHash);
+
+    function getUserOpHash(
+        address swapper,
+        SwapIntent calldata swapIntent,
+        BaselineCall calldata baselineCall,
+        uint256 deadline,
+        uint256 gas,
+        uint256 maxFeePerGas
+    )
+        external
+        view
+        returns (bytes32 userOpHash);
+
+    function getUserOperation(
+        address swapper,
+        SwapIntent calldata swapIntent,
+        BaselineCall calldata baselineCall,
+        uint256 deadline,
+        uint256 gas,
+        uint256 maxFeePerGas
+    )
+        external
+        view
+        returns (UserOperation memory userOp);
+
+    function isUserNonceValid(address owner, uint256 nonce) external view returns (bool valid);
+}

--- a/src/contracts/examples/fastlane-online/OuterHelpers.sol
+++ b/src/contracts/examples/fastlane-online/OuterHelpers.sol
@@ -286,6 +286,9 @@ contract OuterHelpers is FastLaneOnlineInner {
             // winningSolver will be address(0) unless a winning solver fulfilled the swap intent.
             if (_solverFrom == _getWinningSolver()) {
                 S_solverReputations[_solverFrom].successCost += magnitude;
+                // break out of loop to avoid incrementing failureCost for solvers that did not execute due to being
+                // after the winning solver in the sorted array.
+                break;
             } else {
                 S_solverReputations[_solverFrom].failureCost += magnitude;
             }

--- a/src/contracts/examples/fastlane-online/OuterHelpers.sol
+++ b/src/contracts/examples/fastlane-online/OuterHelpers.sol
@@ -43,6 +43,12 @@ contract OuterHelpers is FastLaneOnlineInner {
     //              CONTROL-LOCAL FUNCTIONS                //
     //                 (not delegated)                     //
     /////////////////////////////////////////////////////////
+
+    function setWinningSolver(address winningSolver) external {
+        // TODO checks
+        _setWinningSolver(winningSolver);
+    }
+
     function getUserOperationAndHash(
         address swapper,
         SwapIntent calldata swapIntent,

--- a/src/contracts/examples/fastlane-online/OuterHelpers.sol
+++ b/src/contracts/examples/fastlane-online/OuterHelpers.sol
@@ -278,13 +278,14 @@ contract OuterHelpers is FastLaneOnlineInner {
 
     function _updateSolverReputation(SolverOperation[] memory solverOps, uint128 magnitude) internal {
         uint256 _length = solverOps.length;
+        address _winningSolver = _getWinningSolver();
         address _solverFrom;
 
         for (uint256 i; i < _length; i++) {
             _solverFrom = solverOps[i].from;
 
             // winningSolver will be address(0) unless a winning solver fulfilled the swap intent.
-            if (_solverFrom == _getWinningSolver()) {
+            if (_solverFrom == _winningSolver) {
                 S_solverReputations[_solverFrom].successCost += magnitude;
                 // break out of loop to avoid incrementing failureCost for solvers that did not execute due to being
                 // after the winning solver in the sorted array.

--- a/src/contracts/examples/fastlane-online/OuterHelpers.sol
+++ b/src/contracts/examples/fastlane-online/OuterHelpers.sol
@@ -276,21 +276,23 @@ contract OuterHelpers is FastLaneOnlineInner {
         return sortedSolverOps;
     }
 
-    function _updateSolverReputation(
-        SolverOperation[] memory solverOps,
-        uint128 magnitude,
-        bool solversSuccessful
-    )
-        internal
-    {
+    function _updateSolverReputation(SolverOperation[] memory solverOps, uint128 magnitude) internal {
         uint256 _length = solverOps.length;
+        address _solverFrom;
+
         for (uint256 i; i < _length; i++) {
-            if (solversSuccessful) {
-                S_solverReputations[solverOps[i].from].successCost += magnitude;
+            _solverFrom = solverOps[i].from;
+
+            // winningSolver will be address(0) unless a winning solver fulfilled the swap intent.
+            if (_solverFrom == _getWinningSolver()) {
+                S_solverReputations[_solverFrom].successCost += magnitude;
             } else {
-                S_solverReputations[solverOps[i].from].failureCost += magnitude;
+                S_solverReputations[_solverFrom].failureCost += magnitude;
             }
         }
+
+        // Clear winning solver, in case `fastOnlineSwap()` is called multiple times in the same tx.
+        _setWinningSolver(address(0));
     }
 
     //////////////////////////////////////////////

--- a/src/contracts/examples/fastlane-online/OuterHelpers.sol
+++ b/src/contracts/examples/fastlane-online/OuterHelpers.sol
@@ -51,7 +51,7 @@ contract OuterHelpers is FastLaneOnlineInner {
         // user and the FLOnline DAppControl.
 
         (address expectedCaller,,) = IAtlas(ATLAS).getExecutionEnvironment(_getUserLock(), CONTROL);
-        if (msg.sender == expectedCaller) {
+        if (msg.sender == expectedCaller && _getWinningSolver() == address(0)) {
             // Set winning solver in transient storage, to be used in `_updateSolverReputation()`
             _setWinningSolver(winningSolver);
         }

--- a/src/contracts/examples/fastlane-online/OuterHelpers.sol
+++ b/src/contracts/examples/fastlane-online/OuterHelpers.sol
@@ -214,7 +214,9 @@ contract OuterHelpers is FastLaneOnlineInner {
         netGasRefund = _grossGasRefund - _netRake;
     }
 
-    function _sortSolverOps(SolverOperation[] memory unsortedSolverOps)
+    function _sortSolverOps(
+        SolverOperation[] memory unsortedSolverOps
+    )
         internal
         pure
         returns (SolverOperation[] memory sortedSolverOps)

--- a/src/contracts/examples/fastlane-online/SolverGateway.sol
+++ b/src/contracts/examples/fastlane-online/SolverGateway.sol
@@ -84,7 +84,9 @@ contract SolverGateway is OuterHelpers {
         S_solverOpCache[_solverOpHash] = solverOp;
     }
 
-    function refundCongestionBuyIns(SolverOperation calldata solverOp)
+    function refundCongestionBuyIns(
+        SolverOperation calldata solverOp
+    )
         external
         withUserLock(solverOp.from)
         onlyAsControl
@@ -165,7 +167,9 @@ contract SolverGateway is OuterHelpers {
         S_solverOpHashes[userOpHash][replacedIndex] = solverOpHash;
     }
 
-    function _getSolverOps(bytes32 userOpHash)
+    function _getSolverOps(
+        bytes32 userOpHash
+    )
         internal
         view
         returns (SolverOperation[] memory solverOps, uint256 cumulativeGasReserved)

--- a/src/contracts/examples/gas-filler/Filler.sol
+++ b/src/contracts/examples/gas-filler/Filler.sol
@@ -269,7 +269,9 @@ contract Filler is DAppControl {
         delete prepaid;
     }
 
-    function _decodeRawData(bytes calldata data)
+    function _decodeRawData(
+        bytes calldata data
+    )
         internal
         pure
         returns (uint256 gasNeeded, ApprovalTx memory approvalTx)

--- a/src/contracts/examples/generalized-backrun/GeneralizedBackrunUserBundler.sol
+++ b/src/contracts/examples/generalized-backrun/GeneralizedBackrunUserBundler.sol
@@ -48,7 +48,9 @@ contract GeneralizedBackrunUserBundler is DAppControl {
     //      UserOpHash  SolverOpHash[]
     mapping(bytes32 => bytes32[]) public S_solverOpHashes;
 
-    constructor(address _atlas)
+    constructor(
+        address _atlas
+    )
         DAppControl(
             _atlas,
             msg.sender,
@@ -196,7 +198,9 @@ contract GeneralizedBackrunUserBundler is DAppControl {
         // TODO: add bundler subsidy capabilities for apps.
     }
 
-    function _getSolverOps(bytes32[] calldata solverOpHashes)
+    function _getSolverOps(
+        bytes32[] calldata solverOpHashes
+    )
         internal
         view
         returns (SolverOperation[] memory solverOps)

--- a/src/contracts/examples/intents-example/SwapIntentDAppControl.sol
+++ b/src/contracts/examples/intents-example/SwapIntentDAppControl.sol
@@ -40,7 +40,9 @@ contract SwapIntentDAppControl is DAppControl {
     uint256 public constant USER_CONDITION_GAS_LIMIT = 20_000;
     uint256 public constant MAX_USER_CONDITIONS = 5;
 
-    constructor(address _atlas)
+    constructor(
+        address _atlas
+    )
         DAppControl(
             _atlas,
             msg.sender,

--- a/src/contracts/examples/intents-example/V4SwapIntent.sol
+++ b/src/contracts/examples/intents-example/V4SwapIntent.sol
@@ -103,7 +103,9 @@ contract V4SwapIntentControl is DAppControl {
     }
 
     // selector 0x04e45aaf
-    function exactInputSingle(ExactInputSingleParams calldata params)
+    function exactInputSingle(
+        ExactInputSingleParams calldata params
+    )
         external
         payable
         verifyCall(params.tokenIn, params.tokenOut, params.amountIn)
@@ -131,7 +133,9 @@ contract V4SwapIntentControl is DAppControl {
     }
 
     // selector 0x5023b4df
-    function exactOutputSingle(ExactOutputSingleParams calldata params)
+    function exactOutputSingle(
+        ExactOutputSingleParams calldata params
+    )
         external
         payable
         verifyCall(params.tokenIn, params.tokenOut, params.amountInMaximum)

--- a/src/contracts/examples/oev-example/ChainlinkAtlasWrapper.sol
+++ b/src/contracts/examples/oev-example/ChainlinkAtlasWrapper.sol
@@ -172,7 +172,9 @@ contract ChainlinkAtlasWrapper is Ownable, IChainlinkAtlasWrapper {
     }
 
     // Pass-through call to base oracle's `getRoundData()` function
-    function getRoundData(uint80 _roundId)
+    function getRoundData(
+        uint80 _roundId
+    )
         external
         view
         override

--- a/src/contracts/examples/oev-example/ChainlinkDAppControl.sol
+++ b/src/contracts/examples/oev-example/ChainlinkDAppControl.sol
@@ -53,7 +53,9 @@ contract ChainlinkDAppControl is DAppControl {
     event SignerRemovedForBaseFeed(address indexed baseFeed, address indexed signer);
     event ObservationsQuorumSet(uint256 oldQuorum, uint256 newQuorum);
 
-    constructor(address _atlas)
+    constructor(
+        address _atlas
+    )
         DAppControl(
             _atlas,
             msg.sender,

--- a/src/contracts/examples/oev-example/ChainlinkDAppControlAlt.sol
+++ b/src/contracts/examples/oev-example/ChainlinkDAppControlAlt.sol
@@ -49,7 +49,9 @@ contract ChainlinkDAppControl is DAppControl {
     event SignerAddedForBaseFeed(address indexed baseFeed, address indexed signer);
     event SignerRemovedForBaseFeed(address indexed baseFeed, address indexed signer);
 
-    constructor(address _atlas)
+    constructor(
+        address _atlas
+    )
         DAppControl(
             _atlas,
             msg.sender,

--- a/src/contracts/examples/oev-example/IChainlinkAtlasWrapper.sol
+++ b/src/contracts/examples/oev-example/IChainlinkAtlasWrapper.sol
@@ -22,7 +22,9 @@ interface AggregatorV3Interface {
     // getRoundData and latestRoundData should both raise "No data present"
     // if they do not have data to report, instead of returning unset values
     // which could be misinterpreted as actual reported values.
-    function getRoundData(uint80 _roundId)
+    function getRoundData(
+        uint80 _roundId
+    )
         external
         view
         returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);

--- a/src/contracts/examples/v2-example/V2DAppControl.sol
+++ b/src/contracts/examples/v2-example/V2DAppControl.sol
@@ -51,7 +51,9 @@ contract V2DAppControl is DAppControl {
 
     event GiftedGovernanceToken(address indexed user, address indexed token, uint256 amount);
 
-    constructor(address _atlas)
+    constructor(
+        address _atlas
+    )
         DAppControl(
             _atlas,
             msg.sender,

--- a/src/contracts/helpers/Simulator.sol
+++ b/src/contracts/helpers/Simulator.sol
@@ -30,7 +30,9 @@ contract Simulator is AtlasErrors {
         atlas = _atlas;
     }
 
-    function simUserOperation(UserOperation calldata userOp)
+    function simUserOperation(
+        UserOperation calldata userOp
+    )
         external
         payable
         returns (bool success, Result simResult, uint256)

--- a/src/contracts/interfaces/IAtlas.sol
+++ b/src/contracts/interfaces/IAtlas.sol
@@ -79,7 +79,9 @@ interface IAtlas {
     function solverLockData() external view returns (address currentSolver, bool calledBack, bool fulfilled);
     function totalSupply() external view returns (uint256);
     function bondedTotalSupply() external view returns (uint256);
-    function accessData(address account)
+    function accessData(
+        address account
+    )
         external
         view
         returns (

--- a/src/contracts/interfaces/ISimulator.sol
+++ b/src/contracts/interfaces/ISimulator.sol
@@ -18,7 +18,9 @@ enum Result {
 }
 
 interface ISimulator {
-    function simUserOperation(UserOperation calldata userOp)
+    function simUserOperation(
+        UserOperation calldata userOp
+    )
         external
         payable
         returns (bool success, Result simResult, uint256);

--- a/test/FLOnline.t.sol
+++ b/test/FLOnline.t.sol
@@ -396,6 +396,21 @@ contract FastLaneOnlineTest is BaseTest {
         assertEq(flOnlineMock.getWinningSolver(), solverOneEOA, "winningSolver should be solverOneEOA");
     }
 
+    function testFLOnline_SetWinningSolver_DoesNotUpdateIfAlreadySet() public {
+        (address userEE,,) = atlas.getExecutionEnvironment(userEOA, address(flOnlineMock));
+        assertEq(flOnlineMock.getWinningSolver(), address(0), "winningSolver should start empty");
+
+        flOnlineMock.setUserLock(userEOA);
+        vm.prank(userEE);
+        flOnlineMock.setWinningSolver(solverOneEOA);
+        assertEq(flOnlineMock.getWinningSolver(), solverOneEOA, "winningSolver should be solverOneEOA");
+
+        // winningSolver already set, should not update
+        vm.prank(userEE);
+        flOnlineMock.setWinningSolver(address(1));
+        assertEq(flOnlineMock.getWinningSolver(), solverOneEOA, "winningSolver should still be solverOneEOA");
+    }
+
     // TODO add tests when solverOp is valid, but does not outperform baseline call, baseline call used instead
 
     // ---------------------------------------------------- //


### PR DESCRIPTION
Changes:

- Winning solver stored in transient storage in FLOnline
- `setWinningSolver()` can only be called by the Execution Environment associated with FLOnline x address in userLock
- No need to decode metacall return data to check if a solver was successful, can check winning solver is not `address(0)` instead. Should be slightly more gas efficient.
- `_updateSolverReputation()` only increments `successCost` for the winning solver of the metacall, for all other solvers `failureCost` is incremented.
- Refactored tests to conditionally check that all involved solvers' `successCost` and `failureCost` components of Reputation either increase or don't change across the metacall, depending on whether the solver won and if they were included in the final solverOps array.