### PR TITLE
FLOnline Native Token Support

### DIFF
--- a/src/contracts/examples/fastlane-online/FastLaneControl.sol
+++ b/src/contracts/examples/fastlane-online/FastLaneControl.sol
@@ -86,8 +86,8 @@ contract FastLaneOnlineControl is DAppControl, FastLaneOnlineErrors {
         }
 
         // Optimistically transfer the user's sell tokens to the solver.
-        if (_swapIntent.tokenUserBuys == _NATIVE_TOKEN) {
-            SafeTransferLib.safeTransferETH(solverOp.to, _swapIntent.amountUserSells);
+        if (_swapIntent.tokenUserSells == _NATIVE_TOKEN) {
+            SafeTransferLib.safeTransferETH(solverOp.solver, _swapIntent.amountUserSells);
         } else {
             SafeTransferLib.safeTransfer(_swapIntent.tokenUserSells, solverOp.solver, _swapIntent.amountUserSells);
         }

--- a/src/contracts/examples/fastlane-online/FastLaneControl.sol
+++ b/src/contracts/examples/fastlane-online/FastLaneControl.sol
@@ -22,6 +22,8 @@ interface ISolverGateway {
 }
 
 contract FastLaneOnlineControl is DAppControl, FastLaneOnlineErrors {
+    address internal constant _NATIVE_TOKEN = address(0);
+
     constructor(
         address _atlas
     )
@@ -84,7 +86,7 @@ contract FastLaneOnlineControl is DAppControl, FastLaneOnlineErrors {
         }
 
         // Optimistically transfer the user's sell tokens to the solver.
-        if (_swapIntent.tokenUserBuys == address(0)) {
+        if (_swapIntent.tokenUserBuys == _NATIVE_TOKEN) {
             SafeTransferLib.safeTransferETH(solverOp.to, _swapIntent.amountUserSells);
         } else {
             SafeTransferLib.safeTransfer(_swapIntent.tokenUserSells, solverOp.solver, _swapIntent.amountUserSells);
@@ -125,8 +127,8 @@ contract FastLaneOnlineControl is DAppControl, FastLaneOnlineErrors {
             revert FLOnlineControl_PostOpsCall_InsufficientBaseline();
         }
 
-        // Undo the token approval, if not gas token.
-        if (_swapIntent.tokenUserSells != address(0)) {
+        // Undo the token approval, if not native token.
+        if (_swapIntent.tokenUserSells != _NATIVE_TOKEN) {
             SafeTransferLib.safeApprove(_swapIntent.tokenUserSells, _baselineCall.to, 0);
         }
 
@@ -139,14 +141,14 @@ contract FastLaneOnlineControl is DAppControl, FastLaneOnlineErrors {
     //////////////////////////////////////////////
     function _sendTokensToUser(SwapIntent memory swapIntent) internal {
         // Transfer the buy token
-        if (swapIntent.tokenUserBuys == address(0)) {
+        if (swapIntent.tokenUserBuys == _NATIVE_TOKEN) {
             SafeTransferLib.safeTransferETH(_user(), address(this).balance);
         } else {
             SafeTransferLib.safeTransfer(swapIntent.tokenUserBuys, _user(), _getERC20Balance(swapIntent.tokenUserBuys));
         }
 
         // Transfer any surplus sell token
-        if (swapIntent.tokenUserSells == address(0)) {
+        if (swapIntent.tokenUserSells == _NATIVE_TOKEN) {
             SafeTransferLib.safeTransferETH(_user(), address(this).balance);
         } else {
             SafeTransferLib.safeTransfer(
@@ -163,13 +165,13 @@ contract FastLaneOnlineControl is DAppControl, FastLaneOnlineErrors {
         returns (uint256 received)
     {
         // Track the balance (count any previously-forwarded tokens)
-        uint256 _startingBalance = swapIntent.tokenUserBuys == address(0)
+        uint256 _startingBalance = swapIntent.tokenUserBuys == _NATIVE_TOKEN
             ? address(this).balance - msg.value
             : _getERC20Balance(swapIntent.tokenUserBuys);
 
-        // CASE not gas token
-        // NOTE: if gas token, pass as value
-        if (swapIntent.tokenUserSells != address(0)) {
+        // CASE not native token
+        // NOTE: if native token, pass as value
+        if (swapIntent.tokenUserSells != _NATIVE_TOKEN) {
             // Approve the router (NOTE that this approval happens either inside the try/catch and is reverted
             // or in the postOps hook where we cancel it afterwards.
             SafeTransferLib.safeApprove(swapIntent.tokenUserSells, baselineCall.to, swapIntent.amountUserSells);
@@ -181,7 +183,7 @@ contract FastLaneOnlineControl is DAppControl, FastLaneOnlineErrors {
         if (!_success) revert FLOnlineControl_BaselineSwap_BaselineCallFail();
 
         // Track the balance delta
-        uint256 _endingBalance = swapIntent.tokenUserBuys == address(0)
+        uint256 _endingBalance = swapIntent.tokenUserBuys == _NATIVE_TOKEN
             ? address(this).balance - msg.value
             : _getERC20Balance(swapIntent.tokenUserBuys);
 

--- a/src/contracts/examples/fastlane-online/FastLaneOnlineInner.sol
+++ b/src/contracts/examples/fastlane-online/FastLaneOnlineInner.sol
@@ -71,8 +71,8 @@ contract FastLaneOnlineInner is BaseStorage, FastLaneOnlineControl {
             revert FLOnlineInner_Swap_ControlNotBundler();
         }
 
-        // Transfer sell token if it isn't gastoken and validate value deposit if it is
-        if (swapIntent.tokenUserSells != address(0)) {
+        // Transfer sell token if it isn't native token and validate value deposit if it is
+        if (swapIntent.tokenUserSells != _NATIVE_TOKEN) {
             _transferUserERC20(swapIntent.tokenUserSells, address(this), swapIntent.amountUserSells);
         } else {
             // UserOp.value already passed to this contract - ensure that userOp.value matches sell amount

--- a/src/contracts/examples/fastlane-online/FastLaneOnlineInner.sol
+++ b/src/contracts/examples/fastlane-online/FastLaneOnlineInner.sol
@@ -88,7 +88,7 @@ contract FastLaneOnlineInner is BaseStorage, FastLaneOnlineControl {
         // Update the minAmountUserBuys with this value
         // NOTE: If all of the solvers fail to exceed this value, we'll redo this swap in the postOpsHook
         // and verify that the min amount is exceeded.
-        if (_baselineAmount >= swapIntent.minAmountUserBuys) {
+        if (_baselineAmount > swapIntent.minAmountUserBuys) {
             SwapIntent memory _swapIntent = swapIntent;
             _swapIntent.minAmountUserBuys = _baselineAmount;
             return (_swapIntent, baselineCall);

--- a/src/contracts/examples/fastlane-online/FastLaneOnlineOuter.sol
+++ b/src/contracts/examples/fastlane-online/FastLaneOnlineOuter.sol
@@ -87,8 +87,8 @@ contract FastLaneOnlineOuter is SolverGateway {
         (SwapIntent memory _swapIntent, BaselineCall memory _baselineCall) =
             abi.decode(userOp.data[4:], (SwapIntent, BaselineCall));
 
-        // Verify that if we're dealing with the native gas token that the balances add up
-        if (_swapIntent.tokenUserSells == address(0)) {
+        // Verify that if we're dealing with the native token that the balances add up
+        if (_swapIntent.tokenUserSells == _NATIVE_TOKEN) {
             if (msg.value < userOp.value) revert FLOnlineOuter_ValidateSwap_MsgValueTooLow();
             if (userOp.value < _swapIntent.amountUserSells) revert FLOnlineOuter_ValidateSwap_UserOpValueTooLow();
             if (userOp.value != _baselineCall.value) revert FLOnlineOuter_ValidateSwap_UserOpBaselineValueMismatch();

--- a/src/contracts/examples/fastlane-online/OuterHelpers.sol
+++ b/src/contracts/examples/fastlane-online/OuterHelpers.sol
@@ -66,13 +66,14 @@ contract OuterHelpers is FastLaneOnlineInner {
         BaselineCall calldata baselineCall,
         uint256 deadline,
         uint256 gas,
-        uint256 maxFeePerGas
+        uint256 maxFeePerGas,
+        uint256 msgValue
     )
         external
         view
         returns (UserOperation memory userOp, bytes32 userOpHash)
     {
-        userOp = _getUserOperation(swapper, swapIntent, baselineCall, deadline, gas, maxFeePerGas);
+        userOp = _getUserOperation(swapper, swapIntent, baselineCall, deadline, gas, maxFeePerGas, msgValue);
         userOpHash = _getUserOperationHash(userOp);
     }
 
@@ -82,14 +83,16 @@ contract OuterHelpers is FastLaneOnlineInner {
         BaselineCall calldata baselineCall,
         uint256 deadline,
         uint256 gas,
-        uint256 maxFeePerGas
+        uint256 maxFeePerGas,
+        uint256 msgValue
     )
         external
         view
         returns (bytes32 userOpHash)
     {
-        userOpHash =
-            _getUserOperationHash(_getUserOperation(swapper, swapIntent, baselineCall, deadline, gas, maxFeePerGas));
+        userOpHash = _getUserOperationHash(
+            _getUserOperation(swapper, swapIntent, baselineCall, deadline, gas, maxFeePerGas, msgValue)
+        );
     }
 
     function getUserOperation(
@@ -98,13 +101,14 @@ contract OuterHelpers is FastLaneOnlineInner {
         BaselineCall calldata baselineCall,
         uint256 deadline,
         uint256 gas,
-        uint256 maxFeePerGas
+        uint256 maxFeePerGas,
+        uint256 msgValue
     )
         external
         view
         returns (UserOperation memory userOp)
     {
-        userOp = _getUserOperation(swapper, swapIntent, baselineCall, deadline, gas, maxFeePerGas);
+        userOp = _getUserOperation(swapper, swapIntent, baselineCall, deadline, gas, maxFeePerGas, msgValue);
     }
 
     function makeThogardsWifeHappy() external onlyAsControl withUserLock(msg.sender) {
@@ -135,7 +139,8 @@ contract OuterHelpers is FastLaneOnlineInner {
         BaselineCall calldata baselineCall,
         uint256 deadline,
         uint256 gas,
-        uint256 maxFeePerGas
+        uint256 maxFeePerGas,
+        uint256 msgValue
     )
         internal
         view
@@ -148,7 +153,7 @@ contract OuterHelpers is FastLaneOnlineInner {
             maxFeePerGas: maxFeePerGas,
             nonce: _getNextUserNonce(swapper),
             deadline: deadline,
-            value: 0,
+            value: msgValue,
             dapp: CONTROL,
             control: CONTROL,
             callConfig: CALL_CONFIG,

--- a/src/contracts/types/AtlasErrors.sol
+++ b/src/contracts/types/AtlasErrors.sol
@@ -5,6 +5,7 @@ import "src/contracts/types/ValidCalls.sol";
 
 contract AtlasErrors {
     // Simulator
+    error SimulatorBalanceTooLow();
     error Unauthorized();
     error Unreachable();
     error NoAuctionWinner();

--- a/test/FLOnline.t.sol
+++ b/test/FLOnline.t.sol
@@ -133,10 +133,6 @@ contract FastLaneOnlineTest is BaseTest {
         });
     }
 
-    function testFLOnlineSwap_OneSolverFulfills_NativeIn_Success() public {
-        vm.skip(true);
-    }
-
     function testFLOnlineSwap_OneSolverFails_BaselineCallFulfills_Success() public {
         _setUpUser(defaultSwapIntent);
 
@@ -157,10 +153,6 @@ contract FastLaneOnlineTest is BaseTest {
             solverCount: 1,
             swapCallShouldSucceed: true
         });
-    }
-
-    function testFLOnlineSwap_OneSolverFails_BaselineCallFulfills_NativeIn_Success() public {
-        vm.skip(true);
     }
 
     function testFLOnlineSwap_OneSolverFails_BaselineCallReverts_Failure() public {
@@ -209,6 +201,29 @@ contract FastLaneOnlineTest is BaseTest {
                 minAmountUserBuys: 3000e18,
                 tokenUserSells: NATIVE_TOKEN,
                 amountUserSells: 1e18
+            })
+        );
+
+        // Check BaselineCall struct is formed correctly and can succeed, revert changes after
+        _doBaselineCallWithChecksThenRevertChanges({ shouldSucceed: true });
+
+        // Now fastOnlineSwap should succeed using BaselineCall for fulfillment, with gas + Atlas gas surcharge paid for
+        // by ETH sent as msg.value by user.
+        _doFastOnlineSwapWithChecks({
+            winningSolverEOA: address(0),
+            winningSolver: address(0), // No winning solver expected
+            solverCount: 0,
+            swapCallShouldSucceed: true
+        });
+    }
+
+    function testFLOnlineSwap_ZeroSolvers_BaselineCallFulfills_NativeOut_Success() public {
+        _setUpUser(
+            SwapIntent({
+                tokenUserBuys: NATIVE_TOKEN,
+                minAmountUserBuys: 1e18,
+                tokenUserSells: DAI_ADDRESS,
+                amountUserSells: 3200e18
             })
         );
 

--- a/test/FLOnline.t.sol
+++ b/test/FLOnline.t.sol
@@ -53,6 +53,7 @@ contract FastLaneOnlineTest is BaseTest {
     }
 
     uint256 constant ERR_MARGIN = 0.15e18; // 15% error margin
+    address internal constant NATIVE_TOKEN = address(0);
 
     IERC20 DAI = IERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);
     address DAI_ADDRESS = address(DAI);
@@ -624,6 +625,20 @@ contract FastLaneOnlineTest is BaseTest {
         newArgs.deadline = defaultDeadlineBlock;
         newArgs.gas = defaultGasLimit;
         newArgs.maxFeePerGas = defaultGasPrice;
+    }
+
+    // Supports native token swaps
+    function _setUpUser(SwapIntent memory swapIntent) internal {
+        // TODO in progress...
+
+        // User starts with 0 WETH (tokenUserBuys) and 3200 DAI (tokenUserSells)
+        deal(swapIntent.tokenUserBuys, userEOA, 0); // Burn user's WETH to start at 0
+        deal(swapIntent.tokenUserSells, userEOA, swapIntent.amountUserSells); // 3200 DAI
+        deal(userEOA, 1e18); // Give user 1 ETH to pay for gas (msg.value is 0.1 ETH per call by default)
+
+        // User approves Atlas to take their DAI to facilitate the swap
+        vm.prank(userEOA);
+        IERC20(swapIntent.tokenUserSells).approve(address(atlas), swapIntent.amountUserSells);
     }
 
     function _setUpSolver(address solverEOA, uint256 solverPK, uint256 bidAmount) internal returns (address) {

--- a/test/Simulator.t.sol
+++ b/test/Simulator.t.sol
@@ -26,9 +26,9 @@ import { SolverBase } from "src/contracts/solver/SolverBase.sol";
 
 
 contract SimulatorTest is BaseTest {
-
+    uint256 simBalanceBefore;
     DummyDAppControl dAppControl;
-
+    
     struct ValidCallsCall {
         UserOperation userOp;
         SolverOperation[] solverOps;
@@ -41,6 +41,7 @@ contract SimulatorTest is BaseTest {
     function setUp() public override {
         BaseTest.setUp();
         dAppControl = defaultDAppControl().buildAndIntegrate(atlasVerification);
+        simBalanceBefore = address(simulator).balance;
     }
 
     function test_simUserOperation_success_valid_SkipCoverage() public {
@@ -51,6 +52,20 @@ contract SimulatorTest is BaseTest {
         assertEq(success, true);
         assertTrue(uint(result) > uint(Result.UserOpSimFail)); // Actually fails with SolverSimFail here
         assertEq(validCallsResult, 0);
+        assertEq(address(simulator).balance, simBalanceBefore, "Balance should not change");
+    }
+
+    function test_simUserOperation_success_valid_UserOpValue_SkipCoverage() public {
+        UserOperation memory userOp = validUserOperation()
+            .withValue(1e18)
+            .signAndBuild(address(atlasVerification), userPK);
+
+        (bool success, Result result, uint256 validCallsResult) = simulator.simUserOperation(userOp);
+
+        assertEq(success, true);
+        assertTrue(uint(result) > uint(Result.UserOpSimFail)); // Actually fails with SolverSimFail here
+        assertEq(validCallsResult, 0);
+        assertEq(address(simulator).balance, simBalanceBefore, "Balance should not change");
     }
 
     function test_simUserOperation_fail_bubblesUpValidCallsResult() public {
@@ -60,6 +75,7 @@ contract SimulatorTest is BaseTest {
         assertEq(success, false);
         assertEq(uint(result), uint(Result.VerificationSimFail));
         assertEq(validCallsResult, uint256(ValidCallsResult.GasPriceHigherThanMax));
+        assertEq(address(simulator).balance, simBalanceBefore, "Balance should not change");
     }
 
     function test_simSolverCall_success_validSolverOutcome_SkipCoverage() public {
@@ -81,6 +97,31 @@ contract SimulatorTest is BaseTest {
         assertEq(success, true);
         assertEq(uint(result), uint(Result.SimulationPassed));
         assertEq(solverOutcomeResult, 0);
+        assertEq(address(simulator).balance, simBalanceBefore, "Balance should not change");
+    }
+
+    function test_simSolverCall_success_validSolverOutcome_UserOpValue_SkipCoverage() public {
+        vm.startPrank(solverOneEOA);
+        DummySolver solver = new DummySolver(WETH_ADDRESS, address(atlas));
+        atlas.bond(1e18);
+        vm.stopPrank();
+
+        UserOperation memory userOp = validUserOperation()
+            .withValue(1e18)
+            .signAndBuild(address(atlasVerification), userPK);
+        SolverOperation[] memory solverOps = new SolverOperation[](1);
+        solverOps[0] = validSolverOperation(userOp)
+            .withSolver(address(solver))
+            .withData(abi.encodeWithSelector(solver.solverFunc.selector))
+            .signAndBuild(address(atlasVerification), solverOnePK);
+        DAppOperation memory dAppOp = validDAppOperation(userOp, solverOps).build();
+
+        (bool success, Result result, uint256 solverOutcomeResult) = simulator.simSolverCall(userOp, solverOps[0], dAppOp);
+
+        assertEq(success, true);
+        assertEq(uint(result), uint(Result.SimulationPassed));
+        assertEq(solverOutcomeResult, 0);
+        assertEq(address(simulator).balance, simBalanceBefore, "Balance should not change");
     }
 
     function test_simSolverCall_fail_bubblesUpSolverOutcomeResult_SkipCoverage() public {
@@ -102,6 +143,7 @@ contract SimulatorTest is BaseTest {
         assertEq(success, false);
         assertEq(uint(result), uint(Result.SolverSimFail));
         assertEq(solverOutcomeResult, 1 << uint256(SolverOutcome.InsufficientEscrow));
+        assertEq(address(simulator).balance, simBalanceBefore, "Balance should not change");
     }
 
     function test_simSolverCalls_success_validSolverOutcome_SkipCoverage() public {
@@ -123,6 +165,31 @@ contract SimulatorTest is BaseTest {
         assertEq(success, true);
         assertEq(uint(result), uint(Result.SimulationPassed));
         assertEq(solverOutcomeResult, 0);
+        assertEq(address(simulator).balance, simBalanceBefore, "Balance should not change");
+    }
+
+    function test_simSolverCalls_success_validSolverOutcome_UserOpValue_SkipCoverage() public {
+        vm.startPrank(solverOneEOA);
+        DummySolver solver = new DummySolver(WETH_ADDRESS, address(atlas));
+        atlas.bond(1e18);
+        vm.stopPrank();
+
+        UserOperation memory userOp = validUserOperation()
+            .withValue(1e18)
+            .signAndBuild(address(atlasVerification), userPK);
+        SolverOperation[] memory solverOps = new SolverOperation[](1);
+        solverOps[0] = validSolverOperation(userOp)
+            .withSolver(address(solver))
+            .withData(abi.encodeWithSelector(solver.solverFunc.selector))
+            .signAndBuild(address(atlasVerification), solverOnePK);
+        DAppOperation memory dAppOp = validDAppOperation(userOp, solverOps).build();
+
+        (bool success, Result result, uint256 solverOutcomeResult) = simulator.simSolverCalls(userOp, solverOps, dAppOp);
+
+        assertEq(success, true);
+        assertEq(uint(result), uint(Result.SimulationPassed));
+        assertEq(solverOutcomeResult, 0);
+        assertEq(address(simulator).balance, simBalanceBefore, "Balance should not change");
     }
 
     function test_simSolverCalls_fail_noSolverOps() public {
@@ -135,6 +202,7 @@ contract SimulatorTest is BaseTest {
         assertEq(success, false);
         assertEq(uint(result), uint(Result.Unknown)); // Should return Unknown if no solverOps given
         assertEq(solverOutcomeResult, uint256(type(SolverOutcome).max) + 1);
+        assertEq(address(simulator).balance, simBalanceBefore, "Balance should not change");
     }
 
     function test_simSolverCalls_fail_bubblesUpSolverOutcomeResult_SkipCoverage() public {
@@ -156,7 +224,39 @@ contract SimulatorTest is BaseTest {
         assertEq(success, false);
         assertEq(uint(result), uint(Result.SolverSimFail));
         assertEq(solverOutcomeResult, 1 << uint256(SolverOutcome.InsufficientEscrow));
+        assertEq(address(simulator).balance, simBalanceBefore, "Balance should not change");
     }
+
+    // Deployer Function Tests
+
+    function test_simulator_setAtlas() public {
+        assertEq(simulator.atlas(), address(atlas));
+
+        vm.expectRevert(AtlasErrors.Unauthorized.selector);
+        simulator.setAtlas(address(0));
+        assertEq(simulator.atlas(), address(atlas), "Should revert if not deployer");
+        
+        vm.prank(payee);
+        simulator.setAtlas(address(123));
+        assertEq(simulator.atlas(), address(123), "Should set new atlas address");
+    }
+
+    function test_simulator_withdrawETH() public {
+        address recipient = makeAddr("LuckyRecipient");
+        uint256 recipientBalanceBefore = address(recipient).balance;
+        simBalanceBefore = address(simulator).balance;
+        
+
+        vm.expectRevert(AtlasErrors.Unauthorized.selector);
+        simulator.withdrawETH(recipient);
+        assertEq(address(simulator).balance, simBalanceBefore, "Should revert if caller not deployer");
+
+        vm.prank(payee);
+        simulator.withdrawETH(recipient);
+        assertEq(address(simulator).balance, 0, "Should withdraw all balance");
+        assertEq(address(recipient).balance, recipientBalanceBefore + simBalanceBefore, "Should send balance to recipient");
+    }
+
 
     // Test Helpers
 

--- a/test/base/BaseTest.t.sol
+++ b/test/base/BaseTest.t.sol
@@ -102,6 +102,8 @@ contract BaseTest is Test, TestConstants {
         sorter = new Sorter(address(atlas));
         govBurner = new GovernanceBurner();
 
+        vm.deal(address(simulator), 1000e18); // to allow userOp.value > 0 sims
+
         vm.stopPrank();
         vm.startPrank(governanceEOA);
 


### PR DESCRIPTION
Changes:

- Changes in https://github.com/FastLane-Labs/atlas/pull/407 to allow Simulator to support metacalls with `userOp.value`
- Small fixes in FLOnline contracts to allow native token swaps
- Added tests (all passing) for all configs of native token swaps through FLOnline:
  - Native -> ERC20
  - ERC20 -> Native
  - ERC20 -> ERC20
  - No solvers (baseline call fulfils)
  - Solver fulfils
- Large refactor of general test structure, helpers support more test configs