### PR TITLE
add a bundler whitelist

### DIFF
--- a/src/contracts/examples/redstone-oev/RedstoneAdapterAtlasWrapper.sol
+++ b/src/contracts/examples/redstone-oev/RedstoneAdapterAtlasWrapper.sol
@@ -34,8 +34,8 @@ contract RedstoneAdapterAtlasWrapper is Ownable, MergedSinglePriceFeedAdapterWit
 
     uint256 public constant MAX_HISTORICAL_FETCH_ITERATIONS = 5;
 
-    address[] public authorisedSigners;
-    address[] public authorisedUpdaters;
+    address[] public authorisedSigners; // authorised signers who sign the datapoints
+    address[] public authorisedUpdaters; // authorised `msg.sender`s of `updateDataFeedsValues` (execution environments of the userOps)
 
     uint256 public BASE_FEED_DELAY = 4; //seconds
 
@@ -115,17 +115,6 @@ contract RedstoneAdapterAtlasWrapper is Ownable, MergedSinglePriceFeedAdapterWit
                 authorisedSigners.pop();
                 break;
             }
-        }
-    }
-
-    function requireMinIntervalBetweenUpdatesPassed() private view {
-        uint256 currentBlockTimestamp = getBlockTimestamp();
-        uint256 blockTimestampFromLatestUpdate = getBlockTimestampFromLatestUpdate();
-        uint256 minIntervalBetweenUpdates = getMinIntervalBetweenUpdates();
-        if (currentBlockTimestamp < blockTimestampFromLatestUpdate + minIntervalBetweenUpdates) {
-            revert MinIntervalBetweenUpdatesHasNotPassedYet(
-                currentBlockTimestamp, blockTimestampFromLatestUpdate, minIntervalBetweenUpdates
-            );
         }
     }
 

--- a/src/contracts/examples/redstone-oev/RedstoneAdapterAtlasWrapper.sol
+++ b/src/contracts/examples/redstone-oev/RedstoneAdapterAtlasWrapper.sol
@@ -35,7 +35,8 @@ contract RedstoneAdapterAtlasWrapper is Ownable, MergedSinglePriceFeedAdapterWit
     uint256 public constant MAX_HISTORICAL_FETCH_ITERATIONS = 5;
 
     address[] public authorisedSigners; // authorised signers who sign the datapoints
-    address[] public authorisedUpdaters; // authorised `msg.sender`s of `updateDataFeedsValues` (execution environments of the userOps)
+    address[] public authorisedUpdaters; // authorised `msg.sender`s of `updateDataFeedsValues` (execution environments
+        // of the userOps)
 
     uint256 public BASE_FEED_DELAY = 4; //seconds
 

--- a/src/contracts/examples/redstone-oev/RedstoneDAppControl.sol
+++ b/src/contracts/examples/redstone-oev/RedstoneDAppControl.sol
@@ -21,7 +21,7 @@ contract RedstoneDAppControl is DAppControl {
 
     mapping(address redstoneAtlasAdapter => bool isAdapter) public isRedstoneAdapter;
 
-    mapping (address bundler => bool isWhitelisted) public bundlerWhitelist;
+    mapping(address bundler => bool isWhitelisted) public bundlerWhitelist;
     uint32 public NUM_WHITELISTED_BUNDLERS = 0;
 
     constructor(
@@ -86,7 +86,6 @@ contract RedstoneDAppControl is DAppControl {
     // ---------------------------------------------------- //
     //                  Atlas Hook Overrides                //
     // ---------------------------------------------------- //
-
 
     function _preOpsCall(UserOperation calldata) internal view override returns (bytes memory) {
         if (NUM_WHITELISTED_BUNDLERS > 0 && !bundlerWhitelist[_bundler()]) revert OnlyWhitelistedBundlerAllowed();

--- a/src/contracts/examples/redstone-oev/RedstoneDAppControl.sol
+++ b/src/contracts/examples/redstone-oev/RedstoneDAppControl.sol
@@ -13,12 +13,16 @@ contract RedstoneDAppControl is DAppControl {
     error InvalidRedstoneAdapter();
     error FailedToAllocateOEV();
     error OnlyGovernance();
+    error OnlyWhitelistedBundlerAllowed();
 
     uint256 private bundlerOEVPercent = 5;
 
     event NewRedstoneAtlasAdapterCreated(address indexed wrapper, address indexed owner, address indexed baseFeed);
 
     mapping(address redstoneAtlasAdapter => bool isAdapter) public isRedstoneAdapter;
+
+    mapping (address bundler => bool isWhitelisted) public bundlerWhitelist;
+    uint32 public NUM_WHITELISTED_BUNDLERS = 0;
 
     constructor(
         address _atlas
@@ -29,7 +33,7 @@ contract RedstoneDAppControl is DAppControl {
             CallConfig({
                 userNoncesSequential: false,
                 dappNoncesSequential: false,
-                requirePreOps: false,
+                requirePreOps: true,
                 trackPreOpsReturnData: false,
                 trackUserReturnData: true,
                 delegateUser: false,
@@ -56,6 +60,20 @@ contract RedstoneDAppControl is DAppControl {
         bundlerOEVPercent = _percent;
     }
 
+    function addBundlerToWhitelist(address bundler) external onlyGov {
+        if (!bundlerWhitelist[bundler]) {
+            bundlerWhitelist[bundler] = true;
+            NUM_WHITELISTED_BUNDLERS++;
+        }
+    }
+
+    function removeBundlerFromWhitelist(address bundler) external onlyGov {
+        if (bundlerWhitelist[bundler]) {
+            bundlerWhitelist[bundler] = false;
+            NUM_WHITELISTED_BUNDLERS--;
+        }
+    }
+
     function _onlyGov() internal view {
         if (msg.sender != governance) revert OnlyGovernance();
     }
@@ -69,7 +87,16 @@ contract RedstoneDAppControl is DAppControl {
     //                  Atlas Hook Overrides                //
     // ---------------------------------------------------- //
 
+
+    function _preOpsCall(UserOperation calldata) internal view override returns (bytes memory) {
+        if (NUM_WHITELISTED_BUNDLERS > 0 && !bundlerWhitelist[_bundler()]) revert OnlyWhitelistedBundlerAllowed();
+        bytes memory emptyData;
+        return emptyData;
+    }
+
     function _allocateValueCall(address, uint256 bidAmount, bytes calldata data) internal virtual override {
+        if (bidAmount == 0) return;
+
         uint256 oevForBundler = bidAmount * bundlerOEVPercent / 100;
         uint256 oevForSolver = bidAmount - oevForBundler;
 


### PR DESCRIPTION
Add a bundler whitelist in `RedstoneDAppControl`. Check is being made is `preOpsCall`.

There are now three auth params - 
1. Bundler - checked by dapp control in preOpsCall hook.
2. Execution Environment (Updater) - checked by wrappedAdapter 
3. User (signer of datapoints in UserOp) - checked by wrappedAdapter

All three bypass if their whitelists are empty.