### PR TITLE
FLOnline: SolverGateway Calculation Fixes

### DIFF
--- a/src/contracts/examples/fastlane-online/FastLaneOnlineErrors.sol
+++ b/src/contracts/examples/fastlane-online/FastLaneOnlineErrors.sol
@@ -26,7 +26,7 @@ contract FastLaneOnlineErrors {
     error SolverGateway_AddSolverOp_SolverMustBeSender();
     error SolverGateway_AddSolverOp_BidTooHigh();
     error SolverGateway_AddSolverOp_SimulationFail();
-    error SolverGateway_AddSolverOp_ValueTooLow();
+    error SolverGateway_AddSolverOp_ScoreTooLow();
 
     error SolverGateway_RefundCongestionBuyIns_DeadlineNotPassed();
 

--- a/src/contracts/examples/fastlane-online/SolverGateway.sol
+++ b/src/contracts/examples/fastlane-online/SolverGateway.sol
@@ -220,12 +220,10 @@ contract SolverGateway is OuterHelpers {
 
         // Check can be grokked more easily in the following format:
         //      solverOpScore     _cumulativeScore (unweighted)
-        // if  -------------- >=  ------------------------------
-        //      solverOpGas          _cumulativeGasReserved
+        // if  -------------- >  ------------------------------ * 2
+        //      solverOpGas              totalGas
 
-        // If new solverOp has same or better score/gas ratio than the average score/gas ratio of solverOps so far,
-        // include it.
-        if (_score * _cumulativeGasReserved >= _cumulativeScore * solverOp.gas) {
+        if (_score * userOp.gas > _cumulativeScore * solverOp.gas * 2) {
             if (_cumulativeGasReserved + USER_GAS_BUFFER + solverOp.gas < userOp.gas) {
                 // If enough gas in metacall limit to fit new solverOp, add as new.
                 return (true, false, 0);
@@ -234,8 +232,8 @@ contract SolverGateway is OuterHelpers {
                 return (false, true, _replacedIndex);
             }
         }
-        // If the new solverOp has a lower score/gas ratio than the average score/gas ratio of solverOps so far, don't
-        // include it at all. This will result in a SolverGateway_AddSolverOp_ScoreTooLow error in `addSolverOp()`.
+        // If the new solverOp's score/gas ratio is too low, don't include it at all. This will result in a
+        // SolverGateway_AddSolverOp_ScoreTooLow error in `addSolverOp()`.
         return (false, false, 0);
     }
 

--- a/src/contracts/examples/fastlane-online/SolverGateway.sol
+++ b/src/contracts/examples/fastlane-online/SolverGateway.sol
@@ -221,16 +221,17 @@ contract SolverGateway is OuterHelpers {
         );
 
         // Check can be grokked more easily in the following format:
-        //      solverOpScore    _cumulativeScore (unweighted)
-        // if  -------------- >  ------------------------------
-        //      solverOpGas             totalGas
+        //      solverOpScore     _cumulativeScore (unweighted)
+        // if  -------------- >=  ------------------------------
+        //      solverOpGas          _cumulativeGasReserved
 
         console.log("Score comp:");
-        console.log("LHS:", _score * userOp.gas);
+        console.log("LHS:", _score * _cumulativeGasReserved);
         console.log("RHS:", _cumulativeScore * solverOp.gas);
 
-        // If new solverOp has better score/gas ratio than the average score/gas ratio of solverOps so far, include it.
-        if (_score * userOp.gas > _cumulativeScore * solverOp.gas) {
+        // If new solverOp has same or better score/gas ratio than the average score/gas ratio of solverOps so far,
+        // include it.
+        if (_score * _cumulativeGasReserved >= _cumulativeScore * solverOp.gas) {
             console.log("Gas comp:");
             console.log("LHS:", _cumulativeGasReserved + USER_GAS_BUFFER + solverOp.gas);
             console.log("RHS:", userOp.gas);

--- a/src/contracts/examples/fastlane-online/SolverGateway.sol
+++ b/src/contracts/examples/fastlane-online/SolverGateway.sol
@@ -1,8 +1,6 @@
 //SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.25;
 
-import "forge-std/Test.sol"; // TODO remove
-
 // Base Imports
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
@@ -225,17 +223,9 @@ contract SolverGateway is OuterHelpers {
         // if  -------------- >=  ------------------------------
         //      solverOpGas          _cumulativeGasReserved
 
-        console.log("Score comp:");
-        console.log("LHS:", _score * _cumulativeGasReserved);
-        console.log("RHS:", _cumulativeScore * solverOp.gas);
-
         // If new solverOp has same or better score/gas ratio than the average score/gas ratio of solverOps so far,
         // include it.
         if (_score * _cumulativeGasReserved >= _cumulativeScore * solverOp.gas) {
-            console.log("Gas comp:");
-            console.log("LHS:", _cumulativeGasReserved + USER_GAS_BUFFER + solverOp.gas);
-            console.log("RHS:", userOp.gas);
-
             if (_cumulativeGasReserved + USER_GAS_BUFFER + solverOp.gas < userOp.gas) {
                 // If enough gas in metacall limit to fit new solverOp, add as new.
                 return (true, false, 0);

--- a/test/FLOnline.t.sol
+++ b/test/FLOnline.t.sol
@@ -44,6 +44,7 @@ contract FastLaneOnlineTest is BaseTest {
         Reputation solverOneRep;
         Reputation solverTwoRep;
         Reputation solverThreeRep;
+        Reputation solverFourRep;
     }
 
     // defaults to true when solver calls `addSolverOp()`, set to false if the solverOp is expected to not be included
@@ -53,6 +54,7 @@ contract FastLaneOnlineTest is BaseTest {
         bool solverOne;
         bool solverTwo;
         bool solverThree;
+        bool solverFour;
     }
 
     uint256 constant ERR_MARGIN = 0.15e18; // 15% error margin
@@ -621,16 +623,7 @@ contract FastLaneOnlineTest is BaseTest {
         flOnline.addSolverOp(args.userOp, solverOp);
     }
 
-    function testFLOnline_addSolverOp_NoInclusion_Fails() public {
-        vm.skip(true);
-        // Should trigger the revert where pushAsNew = false and replaceExisting = false
-    }
-
     function testFLOnline_addSolverOp_ThreeNew() public {
-        // TODO to fix:
-        // - remove the * 2 part of evalForInclusion formula (not using ex post bids)
-        // - denominator in evalForInclusion formula should be _cumulativeGasReserved, not totalGas
-
         _setUpUser(defaultSwapIntent);
         uint256 buyInAmount = 1e17;
         deal(solverOneEOA, buyInAmount);
@@ -683,12 +676,76 @@ contract FastLaneOnlineTest is BaseTest {
         );
     }
 
-    function testFLOnline_addSolverOp_TwoNew_OneReplace() public {
-        vm.skip(true);
+    function testFLOnline_addSolverOp_ThreeNew_FourthBidsHigher_ReplacesFirst() public {
+        // Similar to test above, but here the 4th solver will not fit into the userOp.gas limit imposed on the
+        // metacall. When it has a higher congestion buy-in than the others it should replace solverOp1.
+        _setUpUser(defaultSwapIntent);
+        uint256 buyInAmount = 1e17;
+        deal(solverOneEOA, buyInAmount);
+        deal(solverTwoEOA, buyInAmount);
+        deal(solverThreeEOA, buyInAmount);
+        deal(solverFourEOA, buyInAmount * 2); // double normal buy-in
+
+        bytes32[] memory solverOpHashes = flOnline.solverOpHashes(args.userOpHash);
+        assertEq(solverOpHashes.length, 0, "solverOpHashes should start empty");
+
+        SolverOperation memory solverOp1 = _setUpSolver(solverOneEOA, solverOnePK, goodSolverBidETH, buyInAmount);
+        SolverOperation memory solverOp2 = _setUpSolver(solverTwoEOA, solverTwoPK, goodSolverBidETH, buyInAmount);
+        SolverOperation memory solverOp3 = _setUpSolver(solverThreeEOA, solverThreePK, goodSolverBidETH, buyInAmount);
+
+        solverOpHashes = flOnline.solverOpHashes(args.userOpHash);
+        assertEq(solverOpHashes.length, 3, "solverOpHashes should have 3 elements");
+        assertEq(solverOpHashes[0], keccak256(abi.encode(solverOp1)), "solverOpHashes[0] should be keccak(solverOp1)");
+        assertEq(solverOpHashes[1], keccak256(abi.encode(solverOp2)), "solverOpHashes[1] should be keccak(solverOp2)");
+        assertEq(solverOpHashes[2], keccak256(abi.encode(solverOp3)), "solverOpHashes[2] should be keccak(solverOp3)");
+        assertEq(flOnline.aggCongestionBuyIn(args.userOpHash), 3 * buyInAmount, "total buy in expected buyInAmountx3");
+
+        // Now add 4th solverOp with higher congestion buy-in - should replace 1st solverOp
+        SolverOperation memory solverOp4 = _setUpSolver(solverFourEOA, solverFourPK, goodSolverBidETH, buyInAmount * 2);
+
+        solverOpHashes = flOnline.solverOpHashes(args.userOpHash);
+        assertEq(solverOpHashes.length, 3, "solverOpHashes should still have 3 elements");
+        assertEq(solverOpHashes[0], keccak256(abi.encode(solverOp4)), "solverOpHashes[0] should be keccak(solverOp4)");
+        assertEq(solverOpHashes[1], keccak256(abi.encode(solverOp2)), "solverOpHashes[1] should be keccak(solverOp2)");
+        assertEq(solverOpHashes[2], keccak256(abi.encode(solverOp3)), "solverOpHashes[2] should be keccak(solverOp3)");
+        assertEq(flOnline.aggCongestionBuyIn(args.userOpHash), 4 * buyInAmount, "total buy in expected buyInAmountx4");
     }
 
-    function testFLOnline_EvaluateForInclusion() public {
-        vm.skip(true);
+    function testFLOnline_addSolverOp_ThreeNew_FourthBidsLower_Fails() public {
+        // Similar to test above, but here the 4th solver sends a lower congestion buy-in, does not get included at all,
+        // and addSolverOp reverts.
+        _setUpUser(defaultSwapIntent);
+        uint256 buyInAmount = 1e17;
+        deal(solverOneEOA, buyInAmount);
+        deal(solverTwoEOA, buyInAmount);
+        deal(solverThreeEOA, buyInAmount);
+        deal(solverFourEOA, buyInAmount / 2); // half normal buy-in
+
+        bytes32[] memory solverOpHashes = flOnline.solverOpHashes(args.userOpHash);
+        assertEq(solverOpHashes.length, 0, "solverOpHashes should start empty");
+
+        SolverOperation memory solverOp1 = _setUpSolver(solverOneEOA, solverOnePK, goodSolverBidETH, buyInAmount);
+        SolverOperation memory solverOp2 = _setUpSolver(solverTwoEOA, solverTwoPK, goodSolverBidETH, buyInAmount);
+        SolverOperation memory solverOp3 = _setUpSolver(solverThreeEOA, solverThreePK, goodSolverBidETH, buyInAmount);
+
+        solverOpHashes = flOnline.solverOpHashes(args.userOpHash);
+        assertEq(solverOpHashes.length, 3, "solverOpHashes should have 3 elements");
+        assertEq(solverOpHashes[0], keccak256(abi.encode(solverOp1)), "solverOpHashes[0] should be keccak(solverOp1)");
+        assertEq(solverOpHashes[1], keccak256(abi.encode(solverOp2)), "solverOpHashes[1] should be keccak(solverOp2)");
+        assertEq(solverOpHashes[2], keccak256(abi.encode(solverOp3)), "solverOpHashes[2] should be keccak(solverOp3)");
+        assertEq(flOnline.aggCongestionBuyIn(args.userOpHash), 3 * buyInAmount, "total buy in expected buyInAmountx3");
+
+        // Now add 4th solverOp with lower congestion buy-in - should fail
+        bytes4 expectedErr = FastLaneOnlineErrors.SolverGateway_AddSolverOp_ScoreTooLow.selector;
+        _setUpSolver(solverFourEOA, solverFourPK, goodSolverBidETH, buyInAmount / 2, expectedErr);
+
+        // Registered solverOp state same as before 4th solver attempt
+        solverOpHashes = flOnline.solverOpHashes(args.userOpHash);
+        assertEq(solverOpHashes.length, 3, "solverOpHashes should have 3 elements");
+        assertEq(solverOpHashes[0], keccak256(abi.encode(solverOp1)), "solverOpHashes[0] should be keccak(solverOp1)");
+        assertEq(solverOpHashes[1], keccak256(abi.encode(solverOp2)), "solverOpHashes[1] should be keccak(solverOp2)");
+        assertEq(solverOpHashes[2], keccak256(abi.encode(solverOp3)), "solverOpHashes[2] should be keccak(solverOp3)");
+        assertEq(flOnline.aggCongestionBuyIn(args.userOpHash), 3 * buyInAmount, "total buy in expected buyInAmountx3");
     }
 
     // ---------------------------------------------------- //

--- a/test/FLOnline.t.sol
+++ b/test/FLOnline.t.sol
@@ -499,10 +499,7 @@ contract FastLaneOnlineTest is BaseTest {
         address solver1 = _setUpSolver(solverOneEOA, solverOnePK, goodSolverBidETH);
         address solver2 = _setUpSolver(solverTwoEOA, solverTwoPK, goodSolverBidETH + 1e17);
         address solver3 = _setUpSolver(solverThreeEOA, solverThreePK, goodSolverBidETH + 2e17);
-
-        // solverOne does not get included in the sovlerOps array
-        attempted.solverOne = false;
-        // solverTwo and solverThree will be attempted but fail
+        // all 3 solvers will be included and attempted but fail
 
         // Check BaselineCall struct is formed correctly and can succeed, revert changes after
         _doBaselineCallWithChecksThenRevertChanges({ shouldSucceed: true });

--- a/test/base/BaseTest.t.sol
+++ b/test/base/BaseTest.t.sol
@@ -43,6 +43,9 @@ contract BaseTest is Test, TestConstants {
     uint256 public solverThreePK = 55_555;
     address public solverThreeEOA = vm.addr(solverThreePK);
 
+    uint256 public solverFourPK = 66_666;
+    address public solverFourEOA = vm.addr(solverFourPK);
+
     uint256 public userPK = 44_444;
     address public userEOA = vm.addr(userPK);
 


### PR DESCRIPTION
Changes:

- It looks like `* 2` in the `_evaluateForInclusion()` calculations was due to the use of `exPostBids` in the first version of FLOnline. We no longer use `exPostBids` so solverOp gas is only spent once per solverOp per metacall, and not twice. NOTE: in final version of this PR, the `* 2` is only removed from the gas comparison, but not the score comparison. See Slack discussion.
- Reverted change: ~`_cumulativeGasReserved` may be a more appropriate denominator in the score comparison in `_evaluateForInclusion()`, as we are then comparing new solverOp effectiveness per unit gas it uses, to the average solverOp effectiveness per unit gas used across all currently included solverOps. In other words, new solverOp's score/gas ratio needs to match or beat the average of current solverOps, to be included (either as an additional solverOp, or by replacing the solverOp with the weakest score). The previous denominator was the entire gas limit for the metacall, which included the user's swap and any overhead, which lowered this benchmark ratio to beat.~