### PR TITLE
chore: bump OpenZeppelin from v4.8 to v5.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
-	branch = release-v4.8
+	branch = release-v5.0
 [submodule "lib/solady"]
 	path = lib/solady
 	url = https://github.com/vectorized/solady

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -299,7 +299,7 @@ contract AtlasVerification is EIP712, NonceManager, DAppIntegration {
     /// @param solverOp The SolverOperation struct to verify.
     /// @return A boolean indicating if the signature is valid.
     function _verifySolverSignature(SolverOperation calldata solverOp) internal view returns (bool) {
-        (address _signer,) = _hashTypedDataV4(_getSolverOpHash(solverOp)).tryRecover(solverOp.signature);
+        (address _signer,,) = _hashTypedDataV4(_getSolverOpHash(solverOp)).tryRecover(solverOp.signature);
         return _signer == solverOp.from;
     }
 
@@ -417,7 +417,7 @@ contract AtlasVerification is EIP712, NonceManager, DAppIntegration {
     /// @param dAppOp The DAppOperation struct to verify.
     /// @return A boolean indicating if the signature is valid.
     function _verifyDAppSignature(DAppOperation calldata dAppOp) internal view returns (bool) {
-        (address _signer,) = _hashTypedDataV4(_getDAppOpHash(dAppOp)).tryRecover(dAppOp.signature);
+        (address _signer,,) = _hashTypedDataV4(_getDAppOpHash(dAppOp)).tryRecover(dAppOp.signature);
         return _signer == dAppOp.from;
     }
 

--- a/src/contracts/examples/oev-example/ChainlinkAtlasWrapper.sol
+++ b/src/contracts/examples/oev-example/ChainlinkAtlasWrapper.sol
@@ -35,12 +35,10 @@ contract ChainlinkAtlasWrapper is Ownable, IChainlinkAtlasWrapper {
 
     event TransmitterStatusChanged(address indexed transmitter, bool trusted);
 
-    constructor(address atlas, address baseChainlinkFeed, address _owner) {
+    constructor(address atlas, address baseChainlinkFeed, address _owner) Ownable(_owner) {
         ATLAS = atlas;
         BASE_FEED = AggregatorV2V3Interface(baseChainlinkFeed);
         DAPP_CONTROL = IChainlinkDAppControl(msg.sender); // Chainlink DAppControl is also wrapper factory
-
-        _transferOwnership(_owner);
     }
 
     // ---------------------------------------------------- //

--- a/src/contracts/examples/oev-example/ChainlinkAtlasWrapperAlt.sol
+++ b/src/contracts/examples/oev-example/ChainlinkAtlasWrapperAlt.sol
@@ -25,12 +25,10 @@ contract ChainlinkAtlasWrapper is Ownable {
 
     event SignerStatusChanged(address indexed account, bool isSigner);
 
-    constructor(address atlas, address baseChainlinkFeed, address _owner) {
+    constructor(address atlas, address baseChainlinkFeed, address _owner) Ownable(_owner) {
         ATLAS = atlas;
         BASE_FEED = IChainlinkFeed(baseChainlinkFeed);
         DAPP_CONTROL = IChainlinkDAppControl(msg.sender); // Chainlink DAppControl is also wrapper factory
-
-        _transferOwnership(_owner);
 
         // do a gas usage check on an invalid trasmitting address
         address _aggregator = BASE_FEED.aggregator();

--- a/src/contracts/examples/oev-example/ChainlinkDAppControl.sol
+++ b/src/contracts/examples/oev-example/ChainlinkDAppControl.sol
@@ -165,7 +165,7 @@ contract ChainlinkDAppControl is DAppControl {
         if (observations < observationsQuorum || observations > MAX_NUM_ORACLES) return false;
 
         for (uint256 i; i < observations; ++i) {
-            (address signer,) = ECDSA.tryRecover(reportHash, uint8(rawVs[i]) + 27, rs[i], ss[i]);
+            (address signer,,) = ECDSA.tryRecover(reportHash, uint8(rawVs[i]) + 27, rs[i], ss[i]);
             currentOracle = verificationVar.oracles[signer];
 
             // Signer must be pre-approved and only 1 observation per signer

--- a/src/contracts/helpers/DemoLendingProtocol.sol
+++ b/src/contracts/helpers/DemoLendingProtocol.sol
@@ -38,7 +38,7 @@ contract DemoLendingProtocol is Ownable {
     event Withdraw(address indexed account, uint256 amount);
     event Liquidation(address indexed account, address indexed recipient, uint256 amount);
 
-    constructor(address depositToken) Ownable() {
+    constructor(address depositToken) Ownable(msg.sender) {
         DEPOSIT_TOKEN = IERC20(depositToken);
     }
 

--- a/src/contracts/helpers/DemoToken.sol
+++ b/src/contracts/helpers/DemoToken.sol
@@ -7,7 +7,14 @@ import { Ownable } from "openzeppelin-contracts/contracts/access/Ownable.sol";
 contract Token is ERC20, Ownable {
     uint8 internal immutable _decimals;
 
-    constructor(string memory _name, string memory _symbol, uint8 __decimals) ERC20(_name, _symbol) Ownable() {
+    constructor(
+        string memory _name,
+        string memory _symbol,
+        uint8 __decimals
+    )
+        ERC20(_name, _symbol)
+        Ownable(msg.sender)
+    {
         _decimals = __decimals;
     }
 

--- a/src/contracts/helpers/DemoWETH.sol
+++ b/src/contracts/helpers/DemoWETH.sol
@@ -5,7 +5,7 @@ import { WETH } from "solady/tokens/WETH.sol";
 import { Ownable } from "openzeppelin-contracts/contracts/access/Ownable.sol";
 
 contract DemoWETH is WETH, Ownable {
-    constructor() WETH() Ownable() { }
+    constructor() WETH() Ownable(msg.sender) { }
 
     function mint(address to, uint256 amount) external onlyOwner {
         _mint(to, amount);

--- a/src/contracts/solver/src/BlindBackrun/BlindBackrun.sol
+++ b/src/contracts/solver/src/BlindBackrun/BlindBackrun.sol
@@ -33,7 +33,7 @@ contract BlindBackrun is Ownable {
         WETH_ADDRESS = _wethAddress;
     }
     */
-    constructor() { }
+    constructor() Ownable(msg.sender) { }
 
     /// @notice Executes an arbitrage transaction between two Uniswap V2 pairs.
     /// @notice Pair addresses need to be computed off-chain.

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -3,6 +3,8 @@ pragma solidity 0.8.25;
 
 import "forge-std/Test.sol";
 
+import { SafeCast } from "openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
+
 import { GasAccounting } from "src/contracts/atlas/GasAccounting.sol";
 import { AtlasEvents } from "src/contracts/types/AtlasEvents.sol";
 import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
@@ -936,7 +938,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
 
         // Testing uint112 boundary values for casting from uint256 to uint112 in _credit()
         uint256 overflowAmount = uint256(type(uint112).max) + 1;
-        vm.expectRevert("SafeCast: value doesn't fit in 112 bits");
+        vm.expectRevert(abi.encodeWithSelector(SafeCast.SafeCastOverflowedUintDowncast.selector, 112, overflowAmount));
         mockGasAccounting.credit(solverOp.from, overflowAmount);
     }
 

--- a/test/OEV.t.sol
+++ b/test/OEV.t.sol
@@ -250,9 +250,9 @@ contract OEVTest is BaseTest {
         assertEq(DAI.balanceOf(aaveGovEOA), 0, "Aave Gov should have 0 DAI");
 
         vm.startPrank(chainlinkGovEOA);
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, chainlinkGovEOA));
         chainlinkAtlasWrapper.withdrawETH(chainlinkGovEOA);
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, chainlinkGovEOA));
         chainlinkAtlasWrapper.withdrawERC20(address(DAI), chainlinkGovEOA);
         vm.stopPrank();
 
@@ -275,11 +275,11 @@ contract OEVTest is BaseTest {
 
         // Wrapper emits event on deployment to show ownership transfer
         vm.expectEmit(true, false, false, true);
-        emit Ownable.OwnershipTransferred(address(this), address(chainlinkAtlasWrapper.owner()));
+        emit Ownable.OwnershipTransferred(address(0), address(chainlinkAtlasWrapper.owner()));
         new ChainlinkAtlasWrapper(address(atlas), chainlinkETHUSD, aaveGovEOA);
 
         vm.prank(chainlinkGovEOA);
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, chainlinkGovEOA));
         chainlinkAtlasWrapper.setTransmitterStatus(mockEE, true);
 
         assertEq(chainlinkAtlasWrapper.transmitters(mockEE), false, "EE should not be trusted yet");

--- a/test/OEValt.t.sol
+++ b/test/OEValt.t.sol
@@ -236,9 +236,9 @@ contract OEVTest is BaseTest {
         assertEq(DAI.balanceOf(aaveGovEOA), 0, "Aave Gov should have 0 DAI");
 
         vm.startPrank(chainlinkGovEOA);
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, chainlinkGovEOA));
         chainlinkAtlasWrapper.withdrawETH(chainlinkGovEOA);
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, chainlinkGovEOA));
         chainlinkAtlasWrapper.withdrawERC20(address(DAI), chainlinkGovEOA);
         vm.stopPrank();
 
@@ -254,26 +254,6 @@ contract OEVTest is BaseTest {
         assertEq(DAI.balanceOf(address(chainlinkAtlasWrapper)), 0, "Wrapper should have 0 DAI");
         assertEq(aaveGovEOA.balance, startETH, "Aave Gov should have 10 ETH");
         assertEq(DAI.balanceOf(aaveGovEOA), startDai, "Aave Gov should have 5 DAI");
-    }
-
-    function testChainlinkAtlasWrapperOwnableFunctionsEvents_AltVersion() public {
-        // address mockEE = makeAddr("Mock EE");
-
-        // Wrapper emits event on deployment to show ownership transfer
-        vm.expectEmit(true, false, false, true);
-        emit Ownable.OwnershipTransferred(address(this), address(chainlinkAtlasWrapper.owner()));
-        new ChainlinkAtlasWrapper(address(atlas), chainlinkETHUSD, aaveGovEOA);
-
-        // vm.prank(chainlinkGovEOA);
-        // vm.expectRevert("Ownable: caller is not the owner");
-        // chainlinkAtlasWrapper.setTransmitterStatus(mockEE, true);
-
-        // assertEq(chainlinkAtlasWrapper.transmitters(mockEE), false, "EE should not be trusted yet");
-
-        // vm.prank(aaveGovEOA);
-        // chainlinkAtlasWrapper.setTransmitterStatus(mockEE, true);
-
-        // assertEq(chainlinkAtlasWrapper.transmitters(mockEE), true, "EE should be trusted now");
     }
 
     function testChainlinkAtlasWrapperTransmit_AltVersion_SkipCoverage() public {


### PR DESCRIPTION
The main reason for this is to switch to a version of OpenZeppelin contracts which use custom errors instead of revert strings to save contract size