### PR TITLE
refactor: deploy script to use `block.chainid` to detect chain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,3 @@ BSC_RPC_URL=https://bsc-rpc.publicnode.com
 ETHERSCAN_API_KEY=XXXXXXXX
 POLYGONSCAN_API_KEY=XXXXXXXX
 BSCSCAN_API_KEY=XXXXXXXX
-
-# NOTE: Set chain pref here AND in the --rpc-url flag in the forge command
-# Options: SEPOLIA, MAINNET, AMOY, POLYGON, BSC, LOCAL, HOSTED_ANVIL
-DEPLOY_TO=POLYGON

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -10,7 +10,7 @@ This is a guide to getting the Atlas smart contracts deployed on an EVM chain.
 git checkout dca0b9946e8f59347610cd24a0bca5e84ddea00e
 ```
 
-2. Set up your `.env` file with the variables relevant to the chain to which you are trying to deploy. Note: the `GOV_PRIVATE_KEY` is the private key to the public address from which the contracts will be deployed. You must also set the `DEPLOY_TO` variable to a valid chain option: `SEPOLIA`, `MAINNET`, `AMOY`, `POLYGON`, or `LOCAL`. In this example we would be deploying to Polygon mainnet. Check out the [Wallet List docs](https://github.com/FastLane-Labs/knowledge-base/blob/main/playbooks/wallets/wallet_list.md) if in doubt about which address to deploy from.
+2. Set up your `.env` file with the variables relevant to the chain to which you are trying to deploy. Note: the `GOV_PRIVATE_KEY` is the private key to the public address from which the contracts will be deployed. Check out the [Wallet List docs](https://github.com/FastLane-Labs/knowledge-base/blob/main/playbooks/wallets/wallet_list.md) if in doubt about which address to deploy from.
 
 ```bash
 MAINNET_RPC_URL=https://eth-mainnet.g.alchemy.com/v2/XXXXXXXXXXXXXXXXXXXX
@@ -21,8 +21,6 @@ ETHERSCAN_API_KEY=XXXXXXXXXXXXXXXXXXXX
 POLYGONSCAN_API_KEY=XXXXXXXXXXXXXXXXXXXX
 
 GOV_PRIVATE_KEY=0x123456789...
-
-DEPLOY_TO=POLYGON
 ```
 
 3. Run the deployment script in simulation mode to verify everything works. Note: exclude the `--broadcast` flag to run the script in simulation mode. See Foundry's [script command options](https://book.getfoundry.sh/reference/cli/forge/script).
@@ -37,7 +35,7 @@ source .env && forge script script/deploy-atlas.s.sol:DeployAtlasScript --rpc-ur
 source .env && forge script script/deploy-atlas.s.sol:DeployAtlasScript --rpc-url ${POLYGON_RPC_URL} --legacy --broadcast --etherscan-api-key ${POLYGONSCAN_API_KEY} --verify
 ```
 
-If all goes well, the script will output the addresses of the deployed contracts, and handle verification through Etherscan or Polygonscan automatically. These addresses will also be saved in the `deployments.json` file.
+If all goes well, the script will output the addresses of the deployed contracts, and handle verification through Etherscan or Polygonscan automatically. These addresses will also be saved in the `deployments.json` file. NOTE: the chain in `deployments.json` is detected using `block.chainid`, and is thus dependent on specifying the correct `--rpc-url` when running the deployment script.
 
 ## DAppControl Deployment Process
 

--- a/script/base/deploy-base.s.sol
+++ b/script/base/deploy-base.s.sol
@@ -33,31 +33,52 @@ contract DeployBaseScript is Script {
 
     Utilities public u;
 
+    // Uses block.chainid to determine current chain to update deployments.json
     function _getDeployChain() internal view returns (string memory) {
-        // OPTIONS: LOCAL, SEPOLIA, MAINNET
-        string memory deployChain = vm.envString("DEPLOY_TO");
-        if (
-            keccak256(bytes(deployChain)) == keccak256(bytes("LOCAL"))
-                || keccak256(bytes(deployChain)) == keccak256(bytes("SEPOLIA"))
-                || keccak256(bytes(deployChain)) == keccak256(bytes("MAINNET"))
-                || keccak256(bytes(deployChain)) == keccak256(bytes("AMOY"))
-                || keccak256(bytes(deployChain)) == keccak256(bytes("POLYGON"))
-                || keccak256(bytes(deployChain)) == keccak256(bytes("BSC"))
-        ) {
-            return deployChain;
+        uint256 chainId = block.chainid;
+
+        if (chainId == 31_337) {
+            return "LOCAL";
+        } else if (chainId == 1) {
+            return "MAINNET";
+        } else if (chainId == 42) {
+            return "SEPOLIA";
+        } else if (chainId == 17_000) {
+            return "HOLESKY";
+        } else if (chainId == 137) {
+            return "POLYGON";
+        } else if (chainId == 80_002) {
+            return "AMOY";
+        } else if (chainId == 56) {
+            return "BSC";
+        } else if (chainId == 97) {
+            return "BSC TESTNET";
+        } else if (chainId == 10) {
+            return "OP MAINNET";
+        } else if (chainId == 11_155_420) {
+            return "OP SEPOLIA";
+        } else if (chainId == 42_161) {
+            return "ARBITRUM";
+        } else if (chainId == 421_614) {
+            return "ARBITRUM SEPOLIA";
+        } else if (chainId == 8453) {
+            return "BASE";
+        } else if (chainId == 84_532) {
+            return "BASE SEPOLIA";
+        } else {
+            revert("Error: Chain ID not recognized");
         }
-        revert("Error: Set DEPLOY_TO in .env to LOCAL, SEPOLIA, MAINNET, AMOY, POLYGON, or BSC");
     }
 
     // NOTE: When handling JSON with StdJson, prefix keys with '.' e.g. '.ATLAS'
     // These 2 functions abstract away the '.' thing though.
-    // Just pass in a key like 'ATLAS' and set DEPLOY_TO in .env to LOCAL, SEPOLIA, or MAINNET
+    // Pass in a key like 'ATLAS', and the current chain will be detected via `block.chainid` in `_getDeployChain()`
     function _getAddressFromDeploymentsJson(string memory key) internal view returns (address) {
         string memory root = vm.projectRoot();
         string memory path = string.concat(root, "/deployments.json");
         string memory json = vm.readFile(path);
 
-        // Read target chain from DEPLOY_TO in .env and use to form full key
+        // Get target chain using `block.chainid` and use to form full key
         string memory fullKey = string.concat(".", _getDeployChain(), ".", key);
 
         // console.log("Getting", fullKey, "from deployments.json");
@@ -70,7 +91,7 @@ contract DeployBaseScript is Script {
         string memory root = vm.projectRoot();
         string memory path = string.concat(root, "/deployments.json");
 
-        // Read target chain from DEPLOY_TO in .env and use to form full key
+        // Get target chain using `block.chainid` and use to form full key
         string memory fullKey = string.concat(".", _getDeployChain(), ".", key);
 
         // console.log(string.concat("Writing \t\t'", fullKey), "': '", addr, "'\t\t to deployments.json");

--- a/script/deploy-solver.s.sol
+++ b/script/deploy-solver.s.sol
@@ -15,7 +15,7 @@ contract DeploySimpleRFQSolverScript is DeployBaseScript {
         uint256 deployerPrivateKey = vm.envUint("SOLVER1_PRIVATE_KEY");
         address deployer = vm.addr(deployerPrivateKey);
         address atlasAddress = _getAddressFromDeploymentsJson("ATLAS");
-        address wethAddress = u.getUsefulContractAddress(vm.envString("DEPLOY_TO"), "WETH");
+        address wethAddress = u.getUsefulContractAddress(_getDeployChain(), "WETH");
 
         console.log("Deployer address: \t\t\t\t", deployer);
         console.log("Using Atlas address: \t\t\t\t", atlasAddress);


### PR DESCRIPTION
Removed the need to update `DEPLOY_TO` in the `.env` each time we change chain we deploy to. Now the chain updated in `deployments.json` is determined by `block.chainid`, so will depend on the RPC URL used.