### PR TITLE
Lock Foundry version in CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly-0d8302880b79fa9c3c4aa52ab446583dece19a34 # 2024-08-29 release
 
       - name: Check formatting
         run: forge fmt --check
@@ -33,6 +35,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly-0d8302880b79fa9c3c4aa52ab446583dece19a34 # 2024-08-29 release
 
       - name: Install dependencies
         run: forge install
@@ -76,6 +80,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly-0d8302880b79fa9c3c4aa52ab446583dece19a34 # 2024-08-29 release
 
       - name: Install dependencies
         run: forge install

--- a/README.md
+++ b/README.md
@@ -113,3 +113,10 @@ The _borrow() function makes flash loans available from the Atlas Escrow balance
 ### Notes:
 
 Note that the auctioneer (typically the frontend) and/or the Operations relay may want to use a reputation system for solver bids to efficiently use the space in the solverOps[]. This isnt necessarily required - it's not an economic issue - it's just that it's important to be a good member of the ecosystem and not waste too much precious blockspace by filling it with probabalistic solver txs that have a low success rate but a high profit-to-cost ratio.
+
+### Development:
+
+Conflicts between `foundry`'s formatter versions can lead to CI/CD failure. Developers are advised to lock in their local `foundry` version to match the one used by this repository workflows, by running the following command:
+```
+foundryup -v nightly-0d8302880b79fa9c3c4aa52ab446583dece19a34
+```

--- a/foundry.toml
+++ b/foundry.toml
@@ -13,7 +13,7 @@
 
 [profile.ci]
   fuzz = { runs = 10_000 }
-  verbosity = 4
+  verbosity = 3
 
 [fmt]
   bracket_spacing = true

--- a/src/contracts/atlas/Factory.sol
+++ b/src/contracts/atlas/Factory.sol
@@ -70,9 +70,7 @@ abstract contract Factory {
     /// @param userOp The user operation containing details about the user and the DAppControl contract.
     /// @return executionEnvironment The address of the execution environment that was found or created.
     /// @return dConfig The DAppConfig for the execution environment, specifying how operations should be handled.
-    function _getOrCreateExecutionEnvironment(
-        UserOperation calldata userOp
-    )
+    function _getOrCreateExecutionEnvironment(UserOperation calldata userOp)
         internal
         returns (address executionEnvironment, DAppConfig memory dConfig)
     {

--- a/src/contracts/atlas/Storage.sol
+++ b/src/contracts/atlas/Storage.sol
@@ -87,9 +87,7 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
         return S_bondedTotalSupply;
     }
 
-    function accessData(
-        address account
-    )
+    function accessData(address account)
         external
         view
         returns (

--- a/src/contracts/common/ExecutionEnvironment.sol
+++ b/src/contracts/common/ExecutionEnvironment.sol
@@ -40,9 +40,7 @@ contract ExecutionEnvironment is Base {
     /// corresponding `preOpsCall` function.
     /// @param userOp The UserOperation struct.
     /// @return preOpsData Data to be passed to the next call phase.
-    function preOpsWrapper(
-        UserOperation calldata userOp
-    )
+    function preOpsWrapper(UserOperation calldata userOp)
         external
         validUser(userOp)
         onlyAtlasEnvironment
@@ -64,9 +62,7 @@ contract ExecutionEnvironment is Base {
     /// with `userOp.data` as calldata, depending on the the needsDelegateUser flag.
     /// @param userOp The UserOperation struct.
     /// @return returnData Data to be passed to the next call phase.
-    function userWrapper(
-        UserOperation calldata userOp
-    )
+    function userWrapper(UserOperation calldata userOp)
         external
         payable
         validUser(userOp)

--- a/src/contracts/dapp/DAppControl.sol
+++ b/src/contracts/dapp/DAppControl.sol
@@ -63,9 +63,7 @@ abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
     /// @notice The preOpsCall hook which may be called before the UserOperation is executed.
     /// @param userOp The UserOperation struct.
     /// @return data Data to be passed to the next call phase.
-    function preOpsCall(
-        UserOperation calldata userOp
-    )
+    function preOpsCall(UserOperation calldata userOp)
         external
         payable
         validControl
@@ -164,9 +162,7 @@ abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
     /// @notice Returns the DAppConfig struct of this DAppControl contract.
     /// @param userOp The UserOperation struct.
     /// @return dConfig The DAppConfig struct of this DAppControl contract.
-    function getDAppConfig(
-        UserOperation calldata userOp
-    )
+    function getDAppConfig(UserOperation calldata userOp)
         external
         view
         mustBeCalled

--- a/src/contracts/examples/ex-post-mev-example/V2ExPost.sol
+++ b/src/contracts/examples/ex-post-mev-example/V2ExPost.sol
@@ -37,9 +37,7 @@ contract V2ExPost is DAppControl {
 
     event GiftedGovernanceToken(address indexed user, address indexed token, uint256 amount);
 
-    constructor(
-        address _atlas
-    )
+    constructor(address _atlas)
         DAppControl(
             _atlas,
             msg.sender,

--- a/src/contracts/examples/fastlane-online/FastLaneControl.sol
+++ b/src/contracts/examples/fastlane-online/FastLaneControl.sol
@@ -24,9 +24,7 @@ interface ISolverGateway {
 contract FastLaneOnlineControl is DAppControl, FastLaneOnlineErrors {
     address internal constant _NATIVE_TOKEN = address(0);
 
-    constructor(
-        address _atlas
-    )
+    constructor(address _atlas)
         DAppControl(
             _atlas,
             msg.sender,

--- a/src/contracts/examples/fastlane-online/OuterHelpers.sol
+++ b/src/contracts/examples/fastlane-online/OuterHelpers.sol
@@ -224,9 +224,7 @@ contract OuterHelpers is FastLaneOnlineInner {
         netGasRefund = _grossGasRefund - _netRake;
     }
 
-    function _sortSolverOps(
-        SolverOperation[] memory unsortedSolverOps
-    )
+    function _sortSolverOps(SolverOperation[] memory unsortedSolverOps)
         internal
         pure
         returns (SolverOperation[] memory sortedSolverOps)

--- a/src/contracts/examples/fastlane-online/SolverGateway.sol
+++ b/src/contracts/examples/fastlane-online/SolverGateway.sol
@@ -93,9 +93,7 @@ contract SolverGateway is OuterHelpers {
         S_solverOpCache[_solverOpHash] = solverOp;
     }
 
-    function refundCongestionBuyIns(
-        SolverOperation calldata solverOp
-    )
+    function refundCongestionBuyIns(SolverOperation calldata solverOp)
         external
         withUserLock(solverOp.from)
         onlyAsControl
@@ -176,9 +174,7 @@ contract SolverGateway is OuterHelpers {
         S_solverOpHashes[userOpHash][replacedIndex] = solverOpHash;
     }
 
-    function _getSolverOps(
-        bytes32 userOpHash
-    )
+    function _getSolverOps(bytes32 userOpHash)
         internal
         view
         returns (SolverOperation[] memory solverOps, uint256 cumulativeGasReserved)

--- a/src/contracts/examples/gas-filler/Filler.sol
+++ b/src/contracts/examples/gas-filler/Filler.sol
@@ -269,9 +269,7 @@ contract Filler is DAppControl {
         delete prepaid;
     }
 
-    function _decodeRawData(
-        bytes calldata data
-    )
+    function _decodeRawData(bytes calldata data)
         internal
         pure
         returns (uint256 gasNeeded, ApprovalTx memory approvalTx)

--- a/src/contracts/examples/generalized-backrun/GeneralizedBackrunUserBundler.sol
+++ b/src/contracts/examples/generalized-backrun/GeneralizedBackrunUserBundler.sol
@@ -48,9 +48,7 @@ contract GeneralizedBackrunUserBundler is DAppControl {
     //      UserOpHash  SolverOpHash[]
     mapping(bytes32 => bytes32[]) public S_solverOpHashes;
 
-    constructor(
-        address _atlas
-    )
+    constructor(address _atlas)
         DAppControl(
             _atlas,
             msg.sender,
@@ -198,9 +196,7 @@ contract GeneralizedBackrunUserBundler is DAppControl {
         // TODO: add bundler subsidy capabilities for apps.
     }
 
-    function _getSolverOps(
-        bytes32[] calldata solverOpHashes
-    )
+    function _getSolverOps(bytes32[] calldata solverOpHashes)
         internal
         view
         returns (SolverOperation[] memory solverOps)

--- a/src/contracts/examples/intents-example/SwapIntentDAppControl.sol
+++ b/src/contracts/examples/intents-example/SwapIntentDAppControl.sol
@@ -40,9 +40,7 @@ contract SwapIntentDAppControl is DAppControl {
     uint256 public constant USER_CONDITION_GAS_LIMIT = 20_000;
     uint256 public constant MAX_USER_CONDITIONS = 5;
 
-    constructor(
-        address _atlas
-    )
+    constructor(address _atlas)
         DAppControl(
             _atlas,
             msg.sender,

--- a/src/contracts/examples/intents-example/V4SwapIntent.sol
+++ b/src/contracts/examples/intents-example/V4SwapIntent.sol
@@ -103,9 +103,7 @@ contract V4SwapIntentControl is DAppControl {
     }
 
     // selector 0x04e45aaf
-    function exactInputSingle(
-        ExactInputSingleParams calldata params
-    )
+    function exactInputSingle(ExactInputSingleParams calldata params)
         external
         payable
         verifyCall(params.tokenIn, params.tokenOut, params.amountIn)
@@ -133,9 +131,7 @@ contract V4SwapIntentControl is DAppControl {
     }
 
     // selector 0x5023b4df
-    function exactOutputSingle(
-        ExactOutputSingleParams calldata params
-    )
+    function exactOutputSingle(ExactOutputSingleParams calldata params)
         external
         payable
         verifyCall(params.tokenIn, params.tokenOut, params.amountInMaximum)

--- a/src/contracts/examples/oev-example/ChainlinkAtlasWrapper.sol
+++ b/src/contracts/examples/oev-example/ChainlinkAtlasWrapper.sol
@@ -170,9 +170,7 @@ contract ChainlinkAtlasWrapper is Ownable, IChainlinkAtlasWrapper {
     }
 
     // Pass-through call to base oracle's `getRoundData()` function
-    function getRoundData(
-        uint80 _roundId
-    )
+    function getRoundData(uint80 _roundId)
         external
         view
         override

--- a/src/contracts/examples/oev-example/ChainlinkDAppControl.sol
+++ b/src/contracts/examples/oev-example/ChainlinkDAppControl.sol
@@ -53,9 +53,7 @@ contract ChainlinkDAppControl is DAppControl {
     event SignerRemovedForBaseFeed(address indexed baseFeed, address indexed signer);
     event ObservationsQuorumSet(uint256 oldQuorum, uint256 newQuorum);
 
-    constructor(
-        address _atlas
-    )
+    constructor(address _atlas)
         DAppControl(
             _atlas,
             msg.sender,

--- a/src/contracts/examples/oev-example/ChainlinkDAppControlAlt.sol
+++ b/src/contracts/examples/oev-example/ChainlinkDAppControlAlt.sol
@@ -49,9 +49,7 @@ contract ChainlinkDAppControl is DAppControl {
     event SignerAddedForBaseFeed(address indexed baseFeed, address indexed signer);
     event SignerRemovedForBaseFeed(address indexed baseFeed, address indexed signer);
 
-    constructor(
-        address _atlas
-    )
+    constructor(address _atlas)
         DAppControl(
             _atlas,
             msg.sender,

--- a/src/contracts/examples/oev-example/IChainlinkAtlasWrapper.sol
+++ b/src/contracts/examples/oev-example/IChainlinkAtlasWrapper.sol
@@ -22,9 +22,7 @@ interface AggregatorV3Interface {
     // getRoundData and latestRoundData should both raise "No data present"
     // if they do not have data to report, instead of returning unset values
     // which could be misinterpreted as actual reported values.
-    function getRoundData(
-        uint80 _roundId
-    )
+    function getRoundData(uint80 _roundId)
         external
         view
         returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);

--- a/src/contracts/examples/v2-example/V2DAppControl.sol
+++ b/src/contracts/examples/v2-example/V2DAppControl.sol
@@ -51,9 +51,7 @@ contract V2DAppControl is DAppControl {
 
     event GiftedGovernanceToken(address indexed user, address indexed token, uint256 amount);
 
-    constructor(
-        address _atlas
-    )
+    constructor(address _atlas)
         DAppControl(
             _atlas,
             msg.sender,

--- a/src/contracts/helpers/Simulator.sol
+++ b/src/contracts/helpers/Simulator.sol
@@ -27,9 +27,7 @@ contract Simulator is AtlasErrors {
         deployer = msg.sender;
     }
 
-    function simUserOperation(
-        UserOperation calldata userOp
-    )
+    function simUserOperation(UserOperation calldata userOp)
         external
         payable
         returns (bool success, Result simResult, uint256)

--- a/src/contracts/interfaces/IAtlas.sol
+++ b/src/contracts/interfaces/IAtlas.sol
@@ -84,9 +84,7 @@ interface IAtlas {
     function solverLockData() external view returns (address currentSolver, bool calledBack, bool fulfilled);
     function totalSupply() external view returns (uint256);
     function bondedTotalSupply() external view returns (uint256);
-    function accessData(
-        address account
-    )
+    function accessData(address account)
         external
         view
         returns (

--- a/src/contracts/interfaces/ISimulator.sol
+++ b/src/contracts/interfaces/ISimulator.sol
@@ -18,9 +18,7 @@ enum Result {
 }
 
 interface ISimulator {
-    function simUserOperation(
-        UserOperation calldata userOp
-    )
+    function simUserOperation(UserOperation calldata userOp)
         external
         payable
         returns (bool success, Result simResult, uint256);


### PR DESCRIPTION
This should avoid the constantly failing `forge fmt` check in our CI/CD due to frequent changes to Foundry's formatter. Also ran `forge fmt` to lint contracts with latest Foundry linter rules. 