### PR TITLE
fix: conditionally forward `returnData` to solvers

### DIFF
--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -609,8 +609,8 @@ abstract contract Escrow is AtlETH {
                     solverOp.bidToken,
                     bidAmount,
                     solverOp.data,
-                    // Only pass the returnData to solver if it came from userOp call and not from preOps call.
-                    _activeCallConfig().needsUserReturnData() ? returnData : new bytes(0)
+                    // Only pass the returnData (either from userOp or preOps) if the dApp requires it
+                    _activeCallConfig().forwardReturnData() ? returnData : new bytes(0)
                 )
             )
         );

--- a/src/contracts/solver/SolverBase.sol
+++ b/src/contracts/solver/SolverBase.sol
@@ -42,7 +42,7 @@ contract SolverBase is ISolverContract {
         address bidToken,
         uint256 bidAmount,
         bytes calldata solverOpData,
-        bytes calldata
+        bytes calldata forwardedData
     )
         external
         payable

--- a/test/base/DummyDAppControl.sol
+++ b/test/base/DummyDAppControl.sol
@@ -14,6 +14,13 @@ library CallConfigBuilder {
 }
 
 contract DummyDAppControl is DAppControl {
+    bool public preOpsShouldRevert;
+    bool public userOpShouldRevert;
+    bool public preSolverShouldRevert;
+    bool public postSolverShouldRevert;
+    bool public allocateValueShouldRevert;
+    bool public postOpsShouldRevert;
+
     event MEVPaymentSuccess(address bidToken, uint256 bidAmount);
 
     constructor(
@@ -78,7 +85,7 @@ contract DummyDAppControl is DAppControl {
             return;
         }
 
-        (bool shouldRevert) = abi.decode(data, (bool));
+        bool shouldRevert = DummyDAppControl(CONTROL).allocateValueShouldRevert();
         require(!shouldRevert, "_allocateValueCall revert requested");
         emit MEVPaymentSuccess(bidToken, winningAmount);
     }
@@ -96,5 +103,31 @@ contract DummyDAppControl is DAppControl {
     function userOperationCall(bool shouldRevert, uint256 returnValue) public pure returns (uint256) {
         require(!shouldRevert, "userOperationCall revert requested");
         return returnValue;
+    }
+
+    // Revert settings
+
+    function setPreOpsShouldRevert(bool _preOpsShouldRevert) public {
+        preOpsShouldRevert = _preOpsShouldRevert;
+    }
+
+    function setUserOpShouldRevert(bool _userOpShouldRevert) public {
+        userOpShouldRevert = _userOpShouldRevert;
+    }
+
+    function setPreSolverShouldRevert(bool _preSolverShouldRevert) public {
+        preSolverShouldRevert = _preSolverShouldRevert;
+    }
+
+    function setPostSolverShouldRevert(bool _postSolverShouldRevert) public {
+        postSolverShouldRevert = _postSolverShouldRevert;
+    }
+
+    function setAllocateValueShouldRevert(bool _allocateValueShouldRevert) public {
+        allocateValueShouldRevert = _allocateValueShouldRevert;
+    }
+
+    function setPostOpsShouldRevert(bool _postOpsShouldRevert) public {
+        postOpsShouldRevert = _postOpsShouldRevert;
     }
 }


### PR DESCRIPTION
Changes:

- Before, `returnData` was always being forwarded to solvers if it was returned from the `UserOp` but not the `PreOps` phase. However the correct behaviour here is to forward the `returnData` (regardless of if it was returned in `UserOp` or `PreOps` phase), only if the DAppControl's CallConfig sets `forwardReturnData = true`. Otherwise `returnData` is not forwarded to solvers. This intended behaviour has been implemented.