### PR TITLE
chore: update Atlas license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -12,11 +12,7 @@ Licensor:             Fastlane Labs
 Licensed Work:        Atlas Protocol
                       The Licensed Work is (c) 2024 Fastlane Labs
 
-Additional Use Grant: Any uses listed and defined at
-                      atlas-license.fastlane.finance
-
-Change Date:          The earlier of 2026-07-01 or a date specified at
-                      atlas-license.fastlane.finance
+Change Date:          2026-07-01
 
 Change License:       GNU General Public License v2.0 or later
 

--- a/LICENSE
+++ b/LICENSE
@@ -9,14 +9,14 @@ Parameters
 
 Licensor:             Fastlane Labs
 
-Licensed Work:        FastLane Protocol
-                      The Licensed Work is (c) 2023 Fastlane Labs
+Licensed Work:        Atlas Protocol
+                      The Licensed Work is (c) 2024 Fastlane Labs
 
 Additional Use Grant: Any uses listed and defined at
-                      fastlane-protocol-license.fastlane.finance
+                      atlas-license.fastlane.finance
 
-Change Date:          The earlier of 2025-07-01 or a date specified at
-                      fastlane-protocol-license.fastlane.finance
+Change Date:          The earlier of 2026-07-01 or a date specified at
+                      atlas-license.fastlane.finance
 
 Change License:       GNU General Public License v2.0 or later
 


### PR DESCRIPTION
Changes:

- Remove license details URL (doesn't exist)
- Date of license change set to 2026-07-01