### PR TITLE
feat: no surcharges applied if zero solvers

### DIFF
--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -80,7 +80,7 @@ contract Atlas is Escrow, Factory {
 
         // Initialize the environment lock and accounting values
         _setEnvironmentLock(_dConfig, _executionEnvironment);
-        _initializeAccountingValues(_gasMarker);
+        _initializeAccountingValues(_gasMarker, solverOps.length == 0);
 
         // userOpHash has already been calculated and verified in validateCalls at this point, so rather
         // than re-calculate it, we can simply take it from the dAppOp here. It's worth noting that this will

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -125,7 +125,7 @@ contract MockGasAccounting is TestAtlas, BaseTest {
     function initializeLock(address executionEnvironment, uint256 gasMarker) external payable {
         DAppConfig memory dConfig;
         _setEnvironmentLock(dConfig, executionEnvironment);
-        _initializeAccountingValues(gasMarker);
+        _initializeAccountingValues(gasMarker, false);
     }
 
     function increaseBondedBalance(address account, uint256 amount) external {
@@ -141,7 +141,7 @@ contract MockGasAccounting is TestAtlas, BaseTest {
     }
 
     function initializeAccountingValues(uint256 gasMarker) external {
-        _initializeAccountingValues(gasMarker);
+        _initializeAccountingValues(gasMarker, false);
     }
 
     // View functions


### PR DESCRIPTION
This is intended to partially address the UX issue of the bundler needing to send ETH as `msg.value` to pay the Atlas gas surcharge in some metacalls. Previously, this was needed to pay the surcharge in 2 scenarios:

1. When there are no solverOps at all in the metacall
2. When there are solverOps in the metacall, but all fail

This change fixes the issue but _only_ in scenario 1. This is done by never applying any surcharges (Atlas or bundler) throughout the metacall. This is a smaller change because we know from the start of the metacall if there are no solverOps (`solverOps.length == 0`). In this case we also save a bit of gas by skipping a lot of the calculation logic in `_adjustAccountingForFees()`. The result is that, if there are no solverOps, the bundler can do the metacall successfully without sending any `msg.value` ETH, as they are already paying the gas cost of the transaction.

This PR _does not_ resolve the UX issue in scenario 2 - if there are solverOps but all fail. That will involve a larger refactor because solvers are `_assigned()` the gas costs + surcharge as soon as they fail, and we cannot know at that time if a future solverOp during the metacall will succeed.

TODO:

- Test this new branch of behaviour (zero solvers = no surcharge taken) in unit tests
- Fix tests failing due to an expected increase in atlas gas surcharge during a zero solver metacall