### PR TITLE
feat: base L2 gas calculator contract

### DIFF
--- a/src/contracts/gasCalculator/BaseGasCalculator.sol
+++ b/src/contracts/gasCalculator/BaseGasCalculator.sol
@@ -1,0 +1,44 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.25;
+
+import { IL2GasCalculator } from "src/contracts/interfaces/IL2GasCalculator.sol";
+
+/// @notice Implementation:
+/// https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/GasPriceOracle.sol
+/// @notice Deployment on Base: https://basescan.org/address/0x420000000000000000000000000000000000000f
+interface IGasPriceOracle {
+    function getL1FeeUpperBound(uint256 _unsignedTxSize) external view returns (uint256);
+}
+
+contract BaseGasCalculator is IL2GasCalculator {
+    uint256 public constant _CALLDATA_LENGTH_PREMIUM = 32; // TODO: copied value from Atlas, should it be different for
+        // Base?
+    uint256 internal constant _BASE_TRANSACTION_GAS_USED = 21_000;
+
+    address public immutable gasPriceOracle;
+
+    constructor(address _gasPriceOracle) {
+        gasPriceOracle = _gasPriceOracle;
+    }
+
+    /// @notice Calculate the cost of calldata in ETH on a L2 with a different fee structure than mainnet
+    /// @param calldataLength The length of the calldata in bytes
+    function getCalldataCost(uint256 calldataLength) external view override returns (uint256 calldataCost) {
+        // `getL1FeeUpperBound` returns the upper bound of the L1 fee in wei. It expects an unsigned transaction size in
+        // bytes, *not calldata length only*, which makes this function a rough estimate.
+
+        // Base execution cost.
+        calldataCost = calldataLength * _CALLDATA_LENGTH_PREMIUM * tx.gasprice;
+
+        // L1 data cost.
+        // `getL1FeeUpperBound` adds 68 to the size because it expects an unsigned transaction size.
+        // Remove 68 to the length to account for this.
+        calldataCost += IGasPriceOracle(gasPriceOracle).getL1FeeUpperBound(calldataLength - 68);
+    }
+
+    /// @notice Gets the cost of initial gas used for a transaction with a different calldata fee than mainnet
+    /// @param calldataLength The length of the calldata in bytes
+    function initialGasUsed(uint256 calldataLength) external pure override returns (uint256 gasUsed) {
+        return _BASE_TRANSACTION_GAS_USED + (calldataLength * _CALLDATA_LENGTH_PREMIUM);
+    }
+}

--- a/src/contracts/interfaces/IL2GasCalculator.sol
+++ b/src/contracts/interfaces/IL2GasCalculator.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.25;
 
 interface IL2GasCalculator {
     /// @notice Calculate the cost of calldata in ETH on a L2 with a different fee structure than mainnet
-    function getCalldataCost(uint256 length) external view returns (uint256 calldataCostETH);
+    function getCalldataCost(uint256 calldataLength) external view returns (uint256 calldataCost);
     /// @notice Gets the cost of initial gas used for a transaction with a different calldata fee than mainnet
     function initialGasUsed(uint256 calldataLength) external view returns (uint256 gasUsed);
 }

--- a/src/contracts/types/SolverOperation.sol
+++ b/src/contracts/types/SolverOperation.sol
@@ -6,8 +6,8 @@ bytes32 constant SOLVER_TYPEHASH = keccak256(
 );
 
 // NOTE: The calldata length of this SolverOperation struct is 608 bytes when the `data` field is excluded. This value
-// is stored in the `_SOLVER_OP_BASE_CALLDATA` constant in Storage.sol and must be kept up-to-date with any changes to
-// this struct.
+// is stored in the `_SOLVER_OP_BASE_CALLDATA` constant in AtlasConstants.sol and must be kept up-to-date with any
+// changes to this struct.
 struct SolverOperation {
     address from; // Solver address
     address to; // Atlas address


### PR DESCRIPTION
Gas calculator contract for Base blockchain.

It uses `GasPriceOracle` contract deployed at https://basescan.org/address/0x420000000000000000000000000000000000000f
Implementation: https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/GasPriceOracle.sol