### PR TITLE
chore: all imports use absolute path

### DIFF
--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -4,8 +4,6 @@ pragma solidity 0.8.25;
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 import { LibSort } from "solady/utils/LibSort.sol";
 
-import { IDAppControl } from "../interfaces/IDAppControl.sol";
-
 import { Escrow } from "./Escrow.sol";
 import { Factory } from "./Factory.sol";
 
@@ -19,6 +17,7 @@ import "src/contracts/types/ValidCalls.sol";
 import { CallBits } from "src/contracts/libraries/CallBits.sol";
 import { SafetyBits } from "src/contracts/libraries/SafetyBits.sol";
 import { IL2GasCalculator } from "src/contracts/interfaces/IL2GasCalculator.sol";
+import { IDAppControl } from "src/contracts/interfaces/IDAppControl.sol";
 
 /// @title Atlas V1
 /// @author FastLane Labs

--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -6,7 +6,7 @@ import { IExecutionEnvironment } from "src/contracts/interfaces/IExecutionEnviro
 import { IAtlas } from "src/contracts/interfaces/IAtlas.sol";
 import { ISolverContract } from "src/contracts/interfaces/ISolverContract.sol";
 import { IAtlasVerification } from "src/contracts/interfaces/IAtlasVerification.sol";
-import { IDAppControl } from "../interfaces/IDAppControl.sol";
+import { IDAppControl } from "src/contracts/interfaces/IDAppControl.sol";
 
 import { SafeCall } from "src/contracts/libraries/SafeCall/SafeCall.sol";
 import { EscrowBits } from "src/contracts/libraries/EscrowBits.sol";

--- a/src/contracts/dapp/ControlTemplate.sol
+++ b/src/contracts/dapp/ControlTemplate.sol
@@ -1,9 +1,9 @@
 //SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.25;
 
-import "../types/SolverOperation.sol";
-import "../types/UserOperation.sol";
-import "../types/ConfigTypes.sol";
+import "src/contracts/types/SolverOperation.sol";
+import "src/contracts/types/UserOperation.sol";
+import "src/contracts/types/ConfigTypes.sol";
 import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 
 abstract contract DAppControlTemplate {

--- a/src/contracts/helpers/Simulator.sol
+++ b/src/contracts/helpers/Simulator.sol
@@ -1,19 +1,19 @@
 //SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.25;
 
-import { IAtlas } from "../interfaces/IAtlas.sol";
+import { IAtlas } from "src/contracts/interfaces/IAtlas.sol";
 
 import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 
-import "../types/SolverOperation.sol";
-import "../types/UserOperation.sol";
-import "../types/LockTypes.sol";
-import "../types/DAppOperation.sol";
-import "../types/ConfigTypes.sol";
-import "../types/ValidCalls.sol";
-import "../types/EscrowTypes.sol";
+import "src/contracts/types/SolverOperation.sol";
+import "src/contracts/types/UserOperation.sol";
+import "src/contracts/types/LockTypes.sol";
+import "src/contracts/types/DAppOperation.sol";
+import "src/contracts/types/ConfigTypes.sol";
+import "src/contracts/types/ValidCalls.sol";
+import "src/contracts/types/EscrowTypes.sol";
 
 import { Result } from "src/contracts/interfaces/ISimulator.sol";
 

--- a/src/contracts/helpers/Sorter.sol
+++ b/src/contracts/helpers/Sorter.sol
@@ -1,17 +1,18 @@
 //SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.25;
 
-import { IAtlas } from "../interfaces/IAtlas.sol";
-import { IDAppControl } from "../interfaces/IDAppControl.sol";
+import { IAtlas } from "src/contracts/interfaces/IAtlas.sol";
+import { IDAppControl } from "src/contracts/interfaces/IDAppControl.sol";
+import { IAtlasVerification } from "src/contracts/interfaces/IAtlasVerification.sol";
+
 import { CallBits } from "src/contracts/libraries/CallBits.sol";
 import { AccountingMath } from "src/contracts/libraries/AccountingMath.sol";
-import { CallVerification } from "../libraries/CallVerification.sol";
-import { IAtlasVerification } from "../interfaces/IAtlasVerification.sol";
-import { AtlasConstants } from "../types/AtlasConstants.sol";
+import { CallVerification } from "src/contracts/libraries/CallVerification.sol";
+import { AtlasConstants } from "src/contracts/types/AtlasConstants.sol";
 
-import "../types/SolverOperation.sol";
-import "../types/UserOperation.sol";
-import "../types/ConfigTypes.sol";
+import "src/contracts/types/SolverOperation.sol";
+import "src/contracts/types/UserOperation.sol";
+import "src/contracts/types/ConfigTypes.sol";
 
 contract Sorter is AtlasConstants {
     using CallBits for uint32;

--- a/src/contracts/helpers/TxBuilder.sol
+++ b/src/contracts/helpers/TxBuilder.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import { IDAppControl } from "../interfaces/IDAppControl.sol";
-import { IAtlas } from "../interfaces/IAtlas.sol";
-import { IAtlasVerification } from "../interfaces/IAtlasVerification.sol";
+import { IDAppControl } from "src/contracts/interfaces/IDAppControl.sol";
+import { IAtlas } from "src/contracts/interfaces/IAtlas.sol";
+import { IAtlasVerification } from "src/contracts/interfaces/IAtlasVerification.sol";
 
-import "../types/SolverOperation.sol";
-import "../types/UserOperation.sol";
-import "../types/ConfigTypes.sol";
-import "../types/DAppOperation.sol";
+import "src/contracts/types/SolverOperation.sol";
+import "src/contracts/types/UserOperation.sol";
+import "src/contracts/types/ConfigTypes.sol";
+import "src/contracts/types/DAppOperation.sol";
 
-import { CallVerification } from "../libraries/CallVerification.sol";
-import { CallBits } from "../libraries/CallBits.sol";
+import { CallVerification } from "src/contracts/libraries/CallVerification.sol";
+import { CallBits } from "src/contracts/libraries/CallBits.sol";
 
 import "forge-std/Test.sol";
 

--- a/src/contracts/interfaces/IAtlasVerification.sol
+++ b/src/contracts/interfaces/IAtlasVerification.sol
@@ -1,12 +1,12 @@
 //SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.25;
 
-import "../types/UserOperation.sol";
-import "../types/ConfigTypes.sol";
-import "../types/DAppOperation.sol";
-import "../types/SolverOperation.sol";
-import "../types/EscrowTypes.sol";
-import "../types/ValidCalls.sol";
+import "src/contracts/types/UserOperation.sol";
+import "src/contracts/types/ConfigTypes.sol";
+import "src/contracts/types/DAppOperation.sol";
+import "src/contracts/types/SolverOperation.sol";
+import "src/contracts/types/EscrowTypes.sol";
+import "src/contracts/types/ValidCalls.sol";
 
 interface IAtlasVerification {
     // AtlasVerification.sol

--- a/src/contracts/interfaces/IDAppControl.sol
+++ b/src/contracts/interfaces/IDAppControl.sol
@@ -1,9 +1,9 @@
 //SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.25;
 
-import "../types/UserOperation.sol";
-import "../types/SolverOperation.sol";
-import "../types/ConfigTypes.sol";
+import "src/contracts/types/UserOperation.sol";
+import "src/contracts/types/SolverOperation.sol";
+import "src/contracts/types/ConfigTypes.sol";
 
 interface IDAppControl {
     function preOpsCall(UserOperation calldata userOp) external payable returns (bytes memory);

--- a/src/contracts/interfaces/IExecutionEnvironment.sol
+++ b/src/contracts/interfaces/IExecutionEnvironment.sol
@@ -1,10 +1,10 @@
 //SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.25;
 
-import "../types/SolverOperation.sol";
-import "../types/UserOperation.sol";
-import "../types/ConfigTypes.sol";
-import "../types/EscrowTypes.sol";
+import "src/contracts/types/SolverOperation.sol";
+import "src/contracts/types/UserOperation.sol";
+import "src/contracts/types/ConfigTypes.sol";
+import "src/contracts/types/EscrowTypes.sol";
 
 interface IExecutionEnvironment {
     function preOpsWrapper(UserOperation calldata userOp) external returns (bytes memory preOpsData);

--- a/src/contracts/interfaces/ISimulator.sol
+++ b/src/contracts/interfaces/ISimulator.sol
@@ -1,9 +1,9 @@
 //SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.25;
 
-import "../types/SolverOperation.sol";
-import "../types/UserOperation.sol";
-import "../types/ConfigTypes.sol";
+import "src/contracts/types/SolverOperation.sol";
+import "src/contracts/types/UserOperation.sol";
+import "src/contracts/types/ConfigTypes.sol";
 import "src/contracts/types/DAppOperation.sol";
 
 enum Result {

--- a/src/contracts/libraries/CallBits.sol
+++ b/src/contracts/libraries/CallBits.sol
@@ -1,9 +1,9 @@
 //SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.25;
 
-import { IDAppControl } from "../interfaces/IDAppControl.sol";
+import { IDAppControl } from "src/contracts/interfaces/IDAppControl.sol";
 
-import "../types/ConfigTypes.sol";
+import "src/contracts/types/ConfigTypes.sol";
 
 library CallBits {
     uint32 internal constant _ONE = uint32(1);

--- a/src/contracts/solver/src/TestSolver.sol
+++ b/src/contracts/solver/src/TestSolver.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import { SolverBase } from "../SolverBase.sol";
+import { SolverBase } from "src/contracts/solver/SolverBase.sol";
 
 // Flashbots opensource repo
 import { BlindBackrun } from "./BlindBackrun/BlindBackrun.sol";

--- a/src/contracts/solver/src/TestSolverExPost.sol
+++ b/src/contracts/solver/src/TestSolverExPost.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.25;
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
-import { SolverBase } from "../SolverBase.sol";
+import { SolverBase } from "src/contracts/solver/SolverBase.sol";
 
 // Flashbots opensource repo
 import { BlindBackrun } from "./BlindBackrun/BlindBackrun.sol";

--- a/test/helpers/DummyDAppControlBuilder.sol
+++ b/test/helpers/DummyDAppControlBuilder.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import { DummyDAppControl } from "../base/DummyDAppControl.sol";
+import { DummyDAppControl } from "test/base/DummyDAppControl.sol";
 import { CallConfig } from "src/contracts/types/ConfigTypes.sol";
 import { AtlasVerification } from "src/contracts/atlas/AtlasVerification.sol";
 

--- a/test/libraries/CallBits.t.sol
+++ b/test/libraries/CallBits.t.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 
 import { CallBits } from "src/contracts/libraries/CallBits.sol";
 import "src/contracts/types/UserOperation.sol";
-import "../base/TestUtils.sol";
+import "test/base/TestUtils.sol";
 
 contract CallBitsTest is Test {
     using CallBits for uint32;

--- a/test/libraries/CallVerification.t.sol
+++ b/test/libraries/CallVerification.t.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 
 import { CallVerification } from "src/contracts/libraries/CallVerification.sol";
 import "src/contracts/types/UserOperation.sol";
-import "../base/TestUtils.sol";
+import "test/base/TestUtils.sol";
 
 contract CallVerificationTest is Test {
     using CallVerification for UserOperation;

--- a/test/libraries/SafetyBits.t.sol
+++ b/test/libraries/SafetyBits.t.sol
@@ -5,7 +5,7 @@ import "forge-std/Test.sol";
 
 import { SafetyBits } from "src/contracts/libraries/SafetyBits.sol";
 import "src/contracts/types/LockTypes.sol";
-import "../base/TestUtils.sol";
+import "test/base/TestUtils.sol";
 
 import { CallBits } from "src/contracts/libraries/CallBits.sol";
 


### PR DESCRIPTION
This fix is needed to allow Atlas to be imported as a git module. I ran into compiler errors with Atlas structs when the import path is relative, and changing to absolute seems to fix that. 