### PR TITLE
fix: no solvers = no surcharge logic

### DIFF
--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -435,8 +435,7 @@ abstract contract GasAccounting is SafetyLocks {
         // If zero solvers, no surcharges applied -> opp for early return or revert
         if (ctx.solverCount == 0) {
             // If withdrawals > deposits, and no solvers to pay shortfall, revert
-            if (_amountSolverPays > 0) revert InsufficientTotalBalance(_amountSolverPays);
-            // TODO maybe change ^ to unique error
+            if (_amountSolverPays > 0) revert SettleDeficitZeroSolvers(_amountSolverPays);
 
             // If deposits > withdrawals, and no solvers to receive surplus, credit bundler's bonded AtlETH balance
             if (_amountSolverReceives > 0) _credit(ctx.bundler, _amountSolverReceives, _adjustedClaims);

--- a/src/contracts/types/AtlasErrors.sol
+++ b/src/contracts/types/AtlasErrors.sol
@@ -106,6 +106,7 @@ contract AtlasErrors {
     error InsufficientSolverBalance(uint256 actual, uint256 msgValue, uint256 holds, uint256 needed);
     error InsufficientAtlETHBalance(uint256 actual, uint256 needed);
     error InsufficientTotalBalance(uint256 shortfall);
+    error SettleDeficitZeroSolvers(uint256 shortfall);
     error UnbalancedAccounting();
 
     // SafetyLocks


### PR DESCRIPTION
In progress...

Some refactors and additional accounting logic changes to the initial "no solvers = no surcharge" PR #423 