### PR TITLE
Improve `Escrow.t.sol` hook input and revert tests

### DIFF
--- a/test/base/DummyDAppControl.sol
+++ b/test/base/DummyDAppControl.sol
@@ -21,7 +21,6 @@ contract DummyDAppControl is DAppControl {
     bool public allocateValueShouldRevert;
     bool public postOpsShouldRevert;
 
-    // TODO add storage vars to store input data for each hook, then test hooks were passed the correct data
     bytes public preOpsInputData;
     bytes public userOpInputData;
     bytes public preSolverInputData;


### PR DESCRIPTION
Changes:

- Decouple `userOp.data` encoded input, with the logic in the DummyDAppControl that determines if a hook reverts or not.
- DummyDAppControl hooks can be individually preset to revert.
- DummyDAppControl hooks each store their input data in a persistent storage var to be checked in tests after metacall is performed