### PR TITLE
Arbitrum/atlas v1.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,6 @@
 [submodule "lib/solady"]
 	path = lib/solady
 	url = https://github.com/vectorized/solady
+[submodule "lib/nitro-contracts"]
+	path = lib/nitro-contracts
+	url = https://github.com/offchainlabs/nitro-contracts

--- a/remappings.txt
+++ b/remappings.txt
@@ -4,4 +4,4 @@ forge-std/=lib/forge-std/src/
 hardhat/=node_modules/hardhat/
 openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/
 openzeppelin-contracts/=lib/openzeppelin-contracts/
-solady/=lib/solady/src/
+nitro-contracts/=lib/nitro-contracts/

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -9,6 +9,7 @@ import { NonceManager } from "src/contracts/atlas/NonceManager.sol";
 
 import { CallBits } from "src/contracts/libraries/CallBits.sol";
 import { CallVerification } from "src/contracts/libraries/CallVerification.sol";
+import { SafeBlockNumber } from "src/contracts/libraries/SafeBlockNumber.sol";
 import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 import { AtlasConstants } from "src/contracts/types/AtlasConstants.sol";
 import "src/contracts/types/SolverOperation.sol";
@@ -109,12 +110,12 @@ contract AtlasVerification is EIP712, NonceManager, DAppIntegration {
             }
 
             // Check if past user's deadline
-            if (userOp.deadline != 0 && block.number > userOp.deadline) {
+            if (userOp.deadline != 0 && SafeBlockNumber.get() > userOp.deadline) {
                 return ValidCallsResult.UserDeadlineReached;
             }
 
             // Check if past dapp's deadline
-            if (dAppOp.deadline != 0 && block.number > dAppOp.deadline) {
+            if (dAppOp.deadline != 0 && SafeBlockNumber.get() > dAppOp.deadline) {
                 return ValidCallsResult.DAppDeadlineReached;
             }
 

--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -12,6 +12,7 @@ import { SafeCall } from "src/contracts/libraries/SafeCall/SafeCall.sol";
 import { EscrowBits } from "src/contracts/libraries/EscrowBits.sol";
 import { CallBits } from "src/contracts/libraries/CallBits.sol";
 import { SafetyBits } from "src/contracts/libraries/SafetyBits.sol";
+import { SafeBlockNumber } from "src/contracts/libraries/SafeBlockNumber.sol";
 import { AccountingMath } from "src/contracts/libraries/AccountingMath.sol";
 import { DAppConfig } from "src/contracts/types/ConfigTypes.sol";
 import "src/contracts/types/SolverOperation.sol";
@@ -343,7 +344,7 @@ abstract contract Escrow is AtlETH {
         view
         returns (uint256 result)
     {
-        if (solverOp.deadline != 0 && block.number > solverOp.deadline) {
+        if (solverOp.deadline != 0 && SafeBlockNumber.get() > solverOp.deadline) {
             result |= (
                 1
                     << uint256(
@@ -357,7 +358,7 @@ abstract contract Escrow is AtlETH {
 
         uint256 lastAccessedBlock = S_accessData[solverOp.from].lastAccessedBlock;
 
-        if (lastAccessedBlock >= block.number) {
+        if (lastAccessedBlock >= SafeBlockNumber.get()) {
             result |= 1 << uint256(SolverOutcome.PerBlockLimit);
         }
     }

--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.25;
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 import { SafeCast } from "openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
 import { SafetyLocks } from "src/contracts/atlas/SafetyLocks.sol";
+import { SafeBlockNumber } from "src/contracts/libraries/SafeBlockNumber.sol";
 import { EscrowBits } from "src/contracts/libraries/EscrowBits.sol";
 import { AccountingMath } from "src/contracts/libraries/AccountingMath.sol";
 import { SolverOperation } from "src/contracts/types/SolverOperation.sol";
@@ -224,7 +225,7 @@ abstract contract GasAccounting is SafetyLocks {
 
         // Update analytics (auctionWins, auctionFails, totalGasValueUsed) and lastAccessedBlock
         _updateAnalytics(_aData, solverWon && deficit == 0, gasValueUsed);
-        _aData.lastAccessedBlock = uint32(block.number);
+        _aData.lastAccessedBlock = uint32(SafeBlockNumber.get());
 
         // Persist changes in the _aData memory struct back to storage
         S_accessData[owner] = _aData;
@@ -242,7 +243,7 @@ abstract contract GasAccounting is SafetyLocks {
 
         EscrowAccountAccessData memory _aData = S_accessData[owner];
 
-        _aData.lastAccessedBlock = uint32(block.number);
+        _aData.lastAccessedBlock = uint32(SafeBlockNumber.get());
         _aData.bonded += _amt;
 
         S_bondedTotalSupply += amount;

--- a/src/contracts/examples/ex-post-mev-example/V2ExPost.sol
+++ b/src/contracts/examples/ex-post-mev-example/V2ExPost.sol
@@ -25,6 +25,8 @@ import { IUniswapV2Factory } from "./interfaces/IUniswapV2Factory.sol";
 // Misc
 import { SwapMath } from "./SwapMath.sol";
 
+import { ChainAddresses } from "test/helpers/ChainAddresses.sol";
+
 // import "forge-std/Test.sol";
 
 interface IWETH {
@@ -33,7 +35,7 @@ interface IWETH {
 }
 
 contract V2ExPost is DAppControl {
-    address public constant WETH = address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+    address public constant WETH = address(ChainAddresses.WETH_ADDRESS);
 
     event GiftedGovernanceToken(address indexed user, address indexed token, uint256 amount);
 

--- a/src/contracts/examples/ex-post-mev-example/V2ExPost.sol
+++ b/src/contracts/examples/ex-post-mev-example/V2ExPost.sol
@@ -25,8 +25,6 @@ import { IUniswapV2Factory } from "./interfaces/IUniswapV2Factory.sol";
 // Misc
 import { SwapMath } from "./SwapMath.sol";
 
-import { ChainAddresses } from "test/helpers/ChainAddresses.sol";
-
 // import "forge-std/Test.sol";
 
 interface IWETH {
@@ -35,7 +33,7 @@ interface IWETH {
 }
 
 contract V2ExPost is DAppControl {
-    address public constant WETH = address(ChainAddresses.WETH_ADDRESS);
+    address public constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
 
     event GiftedGovernanceToken(address indexed user, address indexed token, uint256 amount);
 

--- a/src/contracts/examples/fastlane-online/SolverGateway.sol
+++ b/src/contracts/examples/fastlane-online/SolverGateway.sol
@@ -9,6 +9,7 @@ import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol"
 import { DAppControl } from "src/contracts/dapp/DAppControl.sol";
 import { DAppOperation } from "src/contracts/types/DAppOperation.sol";
 import { CallConfig } from "src/contracts/types/ConfigTypes.sol";
+import { SafeBlockNumber } from "src/contracts/libraries/SafeBlockNumber.sol";
 import "src/contracts/types/UserOperation.sol";
 import "src/contracts/types/SolverOperation.sol";
 import "src/contracts/types/LockTypes.sol";
@@ -101,7 +102,7 @@ contract SolverGateway is OuterHelpers {
         // NOTE: Anyone can call this on behalf of the solver
         // NOTE: the solverOp deadline cannot be before the userOp deadline, therefore if the
         // solverOp deadline is passed then we know the userOp deadline is passed.
-        if (solverOp.deadline >= block.number) {
+        if (solverOp.deadline >= SafeBlockNumber.get()) {
             revert SolverGateway_RefundCongestionBuyIns_DeadlineNotPassed();
         }
 

--- a/src/contracts/examples/v4-example/UniV4Hook.sol
+++ b/src/contracts/examples/v4-example/UniV4Hook.sol
@@ -10,6 +10,7 @@ import { V4DAppControl } from "./V4DAppControl.sol";
 
 import { IAtlas } from "src/contracts/interfaces/IAtlas.sol";
 import { SafetyBits } from "src/contracts/libraries/SafetyBits.sol";
+import { SafeBlockNumber } from "src/contracts/libraries/SafeBlockNumber.sol";
 
 import "src/contracts/types/SolverOperation.sol";
 import "src/contracts/types/UserOperation.sol";
@@ -103,7 +104,7 @@ contract UniV4Hook is V4DAppControl {
                 abi.encodePacked(
                     IPoolManager.Currency.unwrap(key.currency0),
                     IPoolManager.Currency.unwrap(key.currency1),
-                    block.number
+                    SafeBlockNumber.get()
                 )
             );
 

--- a/src/contracts/examples/v4-example/V4DAppControl.sol
+++ b/src/contracts/examples/v4-example/V4DAppControl.sol
@@ -8,6 +8,7 @@ import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol"
 // Atlas Base Imports
 import { IAtlas } from "src/contracts/interfaces/IAtlas.sol";
 import { SafetyBits } from "src/contracts/libraries/SafetyBits.sol";
+import { SafeBlockNumber } from "src/contracts/libraries/SafeBlockNumber.sol";
 
 import { CallConfig } from "src/contracts/types/ConfigTypes.sol";
 import "src/contracts/types/SolverOperation.sol";
@@ -39,7 +40,7 @@ contract V4DAppControl is DAppControl {
 
     // Map to track when "Non Adversarial" flow is allowed.
     // NOTE: This hook is meant to be used for multiple pairs
-    // key: keccak(token0, token1, block.number)
+    // key: keccak(token0, token1, SafeBlockNumber.get())
     mapping(bytes32 => bool) public sequenceLock;
 
     uint256 transient_slot_initialized = uint256(keccak256("V4DAppControl.initialized"));
@@ -176,7 +177,7 @@ contract V4DAppControl is DAppControl {
         // Flag the pool to be open for trading for the remainder of the block
         bytes32 sequenceKey = keccak256(
             abi.encodePacked(
-                IPoolManager.Currency.unwrap(key.currency0), IPoolManager.Currency.unwrap(key.currency1), block.number
+                IPoolManager.Currency.unwrap(key.currency0), IPoolManager.Currency.unwrap(key.currency1), SafeBlockNumber.get()
             )
         );
 

--- a/src/contracts/helpers/ChainAddresses.sol
+++ b/src/contracts/helpers/ChainAddresses.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+library ChainAddresses {
+    // Arbitrum One addresses
+    address constant WETH_ADDRESS = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1; // Arbitrum One WETH
+    address constant DAI_ADDRESS = 0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1; // Arbitrum One DAI
+    address constant USDC_ADDRESS = 0xaf88d065e77c8cC2239327C5EDb3A432268e5831; // Arbitrum One USDC
+    address constant UNISWAP_V2_ROUTER = 0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506; // SushiSwap router on Arbitrum
+
+    address constant GOVERNANCE_TOKEN = 0xFa7F8980b0f1E64A2062791cc3b0871572f1F7f0; // Arbitrum One UNI
+    address constant WETH_X_GOVERNANCE_POOL = 0xf4a6c89E06318717657D352D16cFC7739D9a8B85;
+
+    address constant UNISWAP_POOL_ONE = 0x8dca5a5DBA32cA529594d43F86ED4210EaD2Ed83; // Uniswap V2 WETH/DAI
+    address constant UNISWAP_POOL_TWO = 0x692a0B300366D1042679397e40f3d2cb4b8F7D30; // SushiSwap V2 WETH/DAI
+
+    function getWETHAddress() internal pure returns (address) {
+        return WETH_ADDRESS;
+    }
+
+    function getDAIAddress() internal pure returns (address) {
+        return DAI_ADDRESS;
+    }
+
+    function getUSDCAddress() internal pure returns (address) {
+        return USDC_ADDRESS;
+    }
+
+    function getUniswapV2RouterAddress() internal pure returns (address) {
+        return UNISWAP_V2_ROUTER;
+    }
+}

--- a/src/contracts/helpers/Sorter.sol
+++ b/src/contracts/helpers/Sorter.sol
@@ -5,6 +5,7 @@ import { IAtlas } from "src/contracts/interfaces/IAtlas.sol";
 import { IDAppControl } from "src/contracts/interfaces/IDAppControl.sol";
 import { IAtlasVerification } from "src/contracts/interfaces/IAtlasVerification.sol";
 
+import { SafeBlockNumber } from "src/contracts/libraries/SafeBlockNumber.sol";
 import { CallBits } from "src/contracts/libraries/CallBits.sol";
 import { AccountingMath } from "src/contracts/libraries/AccountingMath.sol";
 import { CallVerification } from "src/contracts/libraries/CallVerification.sol";
@@ -94,7 +95,7 @@ contract Sorter is AtlasConstants {
 
         // Solvers can only do one tx per block - this prevents double counting bonded balances
         uint256 solverLastActiveBlock = IAtlas(address(ATLAS)).accountLastActiveBlock(solverOp.from);
-        if (solverLastActiveBlock >= block.number) {
+        if (solverLastActiveBlock >= SafeBlockNumber.get()) {
             return false;
         }
 
@@ -114,7 +115,7 @@ contract Sorter is AtlasConstants {
         }
 
         // solverOp.deadline must be in the future
-        if (solverOp.deadline != 0 && block.number > solverOp.deadline) {
+        if (solverOp.deadline != 0 && SafeBlockNumber.get() > solverOp.deadline) {
             return false;
         }
 

--- a/src/contracts/libraries/SafeBlockNumber.sol
+++ b/src/contracts/libraries/SafeBlockNumber.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import { ArbSys } from "nitro-contracts/src/precompiles/ArbSys.sol";
+import { console } from "forge-std/console.sol";
+
+library SafeBlockNumber {
+    ArbSys internal constant arbsys = ArbSys(address(0x0000000000000000000000000000000000000064));
+
+    uint256 internal constant ARBITRUM_ONE_CHAIN_ID = 42_161;
+    uint256 internal constant ARBITRUM_NOVA_CHAIN_ID = 42_170;
+
+    function get() internal view returns (uint256) {
+        if (block.chainid == ARBITRUM_ONE_CHAIN_ID || block.chainid == ARBITRUM_NOVA_CHAIN_ID) {
+            // Arbitrum One or Nova chain
+            return arbsys.arbBlockNumber();
+        } else {
+            return block.number;
+        }
+    }
+}

--- a/test/Accounting.t.sol
+++ b/test/Accounting.t.sol
@@ -13,6 +13,7 @@ import { DAppConfig } from "src/contracts/types/ConfigTypes.sol";
 import "src/contracts/types/DAppOperation.sol";
 
 import { SafetyBits } from "src/contracts/libraries/SafetyBits.sol";
+import { SafeBlockNumber } from "src/contracts/libraries/SafeBlockNumber.sol";
 import "src/contracts/types/LockTypes.sol";
 
 import { TestUtils } from "./base/TestUtils.sol";
@@ -138,7 +139,7 @@ contract AccountingTest is BaseTest {
             to: address(swapIntentControl),
             maxFeePerGas: tx.gasprice + 1,
             value: 0,
-            deadline: block.number + 2,
+            deadline: SafeBlockNumber.get() + 2,
             data: userCallData
         });
         userOp.sessionKey = governanceEOA;
@@ -149,8 +150,7 @@ contract AccountingTest is BaseTest {
         // userOp.signature = abi.encodePacked(sig.r, sig.s, sig.v);
 
         // Build solver calldata (function selector on solver contract and its params)
-        bytes memory solverOpData =
-            abi.encodeCall(HonestRFQSolver.fulfillRFQ, (swapIntent, executionEnvironment));
+        bytes memory solverOpData = abi.encodeCall(HonestRFQSolver.fulfillRFQ, (swapIntent, executionEnvironment));
 
         vm.prank(solverOneEOA);
         atlas.bond(1 ether);

--- a/test/AtlETH.t.sol
+++ b/test/AtlETH.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.25;
 import "forge-std/Test.sol";
 
 import { BaseTest } from "./base/BaseTest.t.sol";
+import { SafeBlockNumber } from "src/contracts/libraries/SafeBlockNumber.sol";
 import {AtlasEvents} from "src/contracts/types/AtlasEvents.sol";
 import {AtlasErrors} from "src/contracts/types/AtlasErrors.sol";
 
@@ -74,7 +75,7 @@ contract AtlETHTest is BaseTest {
         vm.stopPrank();
 
         assertEq(atlas.balanceOfUnbonding(solverTwoEOA), 1e18, "unbonding atleth should be 1 ETH");
-        vm.roll(block.number + atlas.ESCROW_DURATION() + 1);
+        vm.roll(SafeBlockNumber.get() + atlas.ESCROW_DURATION() + 1);
         assertEq(atlas.balanceOfUnbonding(solverTwoEOA), 1e18, "unbonding atleth should still be 1 ETH");
         solverEthBalanceBefore = address(solverTwoEOA).balance;
 
@@ -149,14 +150,14 @@ contract AtlETHTest is BaseTest {
         atlas.unbond(2e18);
 
         vm.expectEmit(true, true, false, true);
-        emit AtlasEvents.Unbond(solverOneEOA, 1e18, block.number + atlas.ESCROW_DURATION() + 1);
+        emit AtlasEvents.Unbond(solverOneEOA, 1e18, SafeBlockNumber.get() + atlas.ESCROW_DURATION() + 1);
         atlas.unbond(1e18);
 
         // NOTE: On unbonding, individual account bonded balances decrease, but total bonded supply remains the same
         assertEq(atlas.balanceOf(solverOneEOA), 0, "solverOne's atlETH balance should be 0");
         assertEq(atlas.balanceOfBonded(solverOneEOA), 0, "solverOne's bonded atlETH should be 1 ETH");
         assertEq(atlas.balanceOfUnbonding(solverOneEOA), 1e18, "solverOne's unbonding atlETH should be 1 ETH");
-        assertEq(atlas.accountLastActiveBlock(solverOneEOA), block.number, "solverOne's last active block should be the current block");
+        assertEq(atlas.accountLastActiveBlock(solverOneEOA), SafeBlockNumber.get(), "solverOne's last active block should be the current block");
         assertEq(atlas.bondedTotalSupply(), 1e18, "total bonded atlETH supply should be 1e18");
     }
 
@@ -180,7 +181,7 @@ contract AtlETHTest is BaseTest {
         vm.expectRevert(AtlasErrors.EscrowLockActive.selector);
         atlas.redeem(1e18);
 
-        vm.roll(block.number + atlas.ESCROW_DURATION() + 1);
+        vm.roll(SafeBlockNumber.get() + atlas.ESCROW_DURATION() + 1);
 
         vm.expectEmit(true, true, false, true);
         emit AtlasEvents.Redeem(solverOneEOA, 1e18);
@@ -236,7 +237,7 @@ contract AtlETHTest is BaseTest {
         atlas.unbond(1e18);
         vm.stopPrank();
 
-        assertEq(atlas.accountLastActiveBlock(solverOneEOA), block.number, "solverOne's last active block should be the current block");
+        assertEq(atlas.accountLastActiveBlock(solverOneEOA), SafeBlockNumber.get(), "solverOne's last active block should be the current block");
     }
 
     function test_atleth_unbondingCompleteBlock() public {
@@ -247,6 +248,6 @@ contract AtlETHTest is BaseTest {
         atlas.unbond(1e18);
         vm.stopPrank();
 
-        assertEq(atlas.unbondingCompleteBlock(solverOneEOA), block.number + atlas.ESCROW_DURATION(), "solverOne's unbonding complete block should be the current block + 64");
+        assertEq(atlas.unbondingCompleteBlock(solverOneEOA), SafeBlockNumber.get() + atlas.ESCROW_DURATION(), "solverOne's unbonding complete block should be the current block + 64");
     }
 }

--- a/test/AtlasVerification.t.sol
+++ b/test/AtlasVerification.t.sol
@@ -15,6 +15,7 @@ import { BaseTest } from "./base/BaseTest.t.sol";
 import { CallVerification } from "src/contracts/libraries/CallVerification.sol";
 import { CallBits } from "src/contracts/libraries/CallBits.sol";
 import { SolverOutcome } from "src/contracts/types/EscrowTypes.sol";
+import { SafeBlockNumber } from "src/contracts/libraries/SafeBlockNumber.sol";
 import { DummyDAppControlBuilder } from "./helpers/DummyDAppControlBuilder.sol";
 import { CallConfigBuilder } from "./helpers/CallConfigBuilder.sol";
 import { UserOperationBuilder } from "./base/builders/UserOperationBuilder.sol";
@@ -82,7 +83,7 @@ contract AtlasVerificationBase is BaseTest {
             .withGas(1_000_000)
             .withMaxFeePerGas(tx.gasprice + 1)
             .withNonce(address(atlasVerification), userEOA)
-            .withDeadline(block.number + 2)
+            .withDeadline(SafeBlockNumber.get() + 2)
             .withControl(address(dAppControl))
             .withCallConfig(dAppControl.CALL_CONFIG())
             .withSessionKey(address(0))

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -11,6 +11,7 @@ import { AtlasEvents } from "src/contracts/types/AtlasEvents.sol";
 import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 import { CallBits } from "src/contracts/libraries/CallBits.sol";
 import { EscrowBits } from "src/contracts/libraries/EscrowBits.sol";
+import { SafeBlockNumber } from "src/contracts/libraries/SafeBlockNumber.sol";
 
 import { DummyDAppControl } from "./base/DummyDAppControl.sol";
 import { BaseTest } from "./base/BaseTest.t.sol";
@@ -65,7 +66,7 @@ contract EscrowTest is BaseTest {
             .withGas(1_000_000)
             .withMaxFeePerGas(tx.gasprice + 1)
             .withNonce(address(atlasVerification), userEOA)
-            .withDeadline(block.number + 2)
+            .withDeadline(SafeBlockNumber.get() + 2)
             .withDapp(_control)
             .withControl(_control)
             .withCallConfig(IDAppControl(_control).CALL_CONFIG())

--- a/test/FlashLoan.t.sol
+++ b/test/FlashLoan.t.sol
@@ -11,6 +11,7 @@ import { ArbitrageTest } from "./base/ArbitrageTest.t.sol";
 import { SolverBase } from "src/contracts/solver/SolverBase.sol";
 import { DAppControl } from "src/contracts/dapp/DAppControl.sol";
 import { CallConfig } from "src/contracts/types/ConfigTypes.sol";
+import { SafeBlockNumber } from "src/contracts/libraries/SafeBlockNumber.sol";
 import { SolverOutcome } from "src/contracts/types/EscrowTypes.sol";
 import { UserOperation } from "src/contracts/types/UserOperation.sol";
 import { SolverOperation } from "src/contracts/types/SolverOperation.sol";
@@ -65,7 +66,7 @@ contract FlashLoanTest is BaseTest {
             .withDapp(address(control))
             .withControl(address(control))
             .withCallConfig(control.CALL_CONFIG())
-            .withDeadline(block.number + 2)
+            .withDeadline(SafeBlockNumber.get() + 2)
             .withData(new bytes(0))
             .build();
 

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -11,6 +11,7 @@ import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 import { AtlasConstants } from "src/contracts/types/AtlasConstants.sol";
 
 import { EscrowBits } from "src/contracts/libraries/EscrowBits.sol";
+import { SafeBlockNumber } from "src/contracts/libraries/SafeBlockNumber.sol";
 import { IL2GasCalculator } from "src/contracts/interfaces/IL2GasCalculator.sol";
 
 import "src/contracts/libraries/AccountingMath.sol";
@@ -795,7 +796,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         assertEq(deficit, 0, "Deficit should be 0");
 
         (, uint32 lastAccessedBlock,,,) = mockGasAccounting.accessData(solverOp.from);
-        assertEq(lastAccessedBlock, uint32(block.number));
+        assertEq(lastAccessedBlock, uint32(SafeBlockNumber.get()));
 
         uint256 bondedTotalSupplyAfter = mockGasAccounting.bondedTotalSupply();
         uint256 depositsAfter = mockGasAccounting.getDeposits();
@@ -822,7 +823,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
 
         // Retrieve and check the updated access data
         (, uint32 lastAccessedBlock,,,) = mockGasAccounting.accessData(solverOp.from);
-        assertEq(lastAccessedBlock, uint32(block.number), "Last accessed block should be current block");
+        assertEq(lastAccessedBlock, uint32(SafeBlockNumber.get()), "Last accessed block should be current block");
 
         // Check the updated bonded total supply and deposits
         assertEq(
@@ -852,7 +853,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         uint256 deficit = mockGasAccounting.assign(solverOp.from, assignedAmount, assignedAmount, true);
         assertEq(deficit, assignedAmount - (unbondingAmount + bondedAmount));
         (, uint32 lastAccessedBlock,,,) = mockGasAccounting.accessData(solverOp.from);
-        assertEq(lastAccessedBlock, uint32(block.number));
+        assertEq(lastAccessedBlock, uint32(SafeBlockNumber.get()));
         assertEq(mockGasAccounting.bondedTotalSupply(), bondedTotalSupplyBefore - (unbondingAmount + bondedAmount));
         assertEq(mockGasAccounting.getDeposits(), depositsBefore + (unbondingAmount + bondedAmount));
         (uint112 bonded, uint112 unbonding) = mockGasAccounting._balanceOf(solverOp.from);
@@ -944,7 +945,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         (, lastAccessedBlock,,,) = mockGasAccounting.accessData(solverOp.from);
         (uint112 bondedAfter,,,,) = mockGasAccounting.accessData(solverOp.from);
 
-        assertEq(lastAccessedBlock, uint32(block.number));
+        assertEq(lastAccessedBlock, uint32(SafeBlockNumber.get()));
         assertEq(mockGasAccounting.bondedTotalSupply(), bondedTotalSupplyBefore + creditedAmount);
         assertEq(bondedAfter, bondedBefore + uint112(creditedAmount));
         assertEq(mockGasAccounting.getWithdrawals(), withdrawalsBefore + creditedAmount);

--- a/test/Simulator.t.sol
+++ b/test/Simulator.t.sol
@@ -13,6 +13,7 @@ import { AtlasErrors } from "src/contracts/types/AtlasErrors.sol";
 import { ValidCallsResult } from "src/contracts/types/ValidCalls.sol";
 import { SolverOutcome } from "src/contracts/types/EscrowTypes.sol";
 import { CallVerification } from "src/contracts/libraries/CallVerification.sol";
+import { SafeBlockNumber } from "src/contracts/libraries/SafeBlockNumber.sol";
 
 import { BaseTest } from "./base/BaseTest.t.sol";
 import { UserOperationBuilder } from "./base/builders/UserOperationBuilder.sol";
@@ -279,7 +280,7 @@ contract SimulatorTest is BaseTest {
             .withGas(1_000_000)
             .withMaxFeePerGas(tx.gasprice + 1)
             .withNonce(address(atlasVerification), userEOA)
-            .withDeadline(block.number + 2)
+            .withDeadline(SafeBlockNumber.get() + 2)
             .withControl(address(dAppControl))
             .withSessionKey(address(0))
             .withData("")

--- a/test/Sorter.t.sol
+++ b/test/Sorter.t.sol
@@ -8,6 +8,7 @@ import { DummyDAppControlBuilder } from "./helpers/DummyDAppControlBuilder.sol";
 import { CallConfigBuilder } from "./helpers/CallConfigBuilder.sol";
 import { UserOperationBuilder } from "./base/builders/UserOperationBuilder.sol";
 import { SolverOperationBuilder } from "./base/builders/SolverOperationBuilder.sol";
+import { SafeBlockNumber } from "src/contracts/libraries/SafeBlockNumber.sol";
 
 import "src/contracts/types/UserOperation.sol";
 import "src/contracts/types/SolverOperation.sol";
@@ -53,7 +54,7 @@ contract SorterTest is BaseTest {
             .withGas(1_000_000)
             .withMaxFeePerGas(tx.gasprice + 1)
             .withNonce(address(atlasVerification), userEOA)
-            .withDeadline(block.number + 2)
+            .withDeadline(SafeBlockNumber.get() + 2)
             .withDapp(address(dAppControl))
             .withControl(address(dAppControl))
             .withSessionKey(address(0))

--- a/test/Storage.t.sol
+++ b/test/Storage.t.sol
@@ -7,6 +7,7 @@ import { Storage } from "src/contracts/atlas/Storage.sol";
 import "src/contracts/types/LockTypes.sol";
 
 import { BaseTest } from "test/base/BaseTest.t.sol";
+import { SafeBlockNumber } from "src/contracts/libraries/SafeBlockNumber.sol";
 
 contract StorageTest is BaseTest {
     using stdStorage for StdStorage;
@@ -89,7 +90,7 @@ contract StorageTest is BaseTest {
         (bonded, lastAccessedBlock, auctionWins, auctionFails, totalGasValueUsed) = atlas.accessData(userEOA);
 
         assertEq(bonded, 0, "user bonded should be 0 again");
-        assertEq(lastAccessedBlock, block.number, "user lastAccessedBlock should be equal to block.number");
+        assertEq(lastAccessedBlock, SafeBlockNumber.get(), "user lastAccessedBlock should be equal to SafeBlockNumber.get()");
         assertEq(auctionWins, 0, "user auctionWins should still be 0");
         assertEq(auctionFails, 0, "user auctionFails should still be 0");
         assertEq(totalGasValueUsed, 0, "user totalGasValueUsed should still be 0");

--- a/test/V2Helper.sol
+++ b/test/V2Helper.sol
@@ -13,6 +13,7 @@ import "src/contracts/types/ConfigTypes.sol";
 import "src/contracts/types/EscrowTypes.sol";
 import "src/contracts/types/LockTypes.sol";
 import "src/contracts/types/ConfigTypes.sol";
+import {SafeBlockNumber} from "src/contracts/libraries/SafeBlockNumber.sol";
 
 import "forge-std/Test.sol";
 
@@ -66,7 +67,7 @@ contract V2Helper is Test, TxBuilder {
         console.log("-");
 
         return TxBuilder.buildUserOperation(
-            from, firstPool, maxFeePerGas, 0, block.number + 2, buildV2SwapCalldata(token0Balance, token1Balance, from)
+            from, firstPool, maxFeePerGas, 0, SafeBlockNumber.get() + 2, buildV2SwapCalldata(token0Balance, token1Balance, from)
         );
     }
 

--- a/test/V2RewardDAppControl.t.sol
+++ b/test/V2RewardDAppControl.t.sol
@@ -13,6 +13,7 @@ import { UserOperationBuilder } from "test/base/builders/UserOperationBuilder.so
 import { SolverOperation } from "src/contracts/types/SolverOperation.sol";
 import { UserOperation } from "src/contracts/types/UserOperation.sol";
 import { DAppConfig } from "src/contracts/types/ConfigTypes.sol";
+import { SafeBlockNumber } from "src/contracts/libraries/SafeBlockNumber.sol";
 import "src/contracts/types/DAppOperation.sol";
 
 import { V2RewardDAppControl } from "src/contracts/examples/v2-example-router/V2RewardDAppControl.sol";
@@ -77,7 +78,7 @@ contract V2RewardDAppControlTest is BaseTest {
             to: address(v2RewardControl),
             maxFeePerGas: tx.gasprice + 1,
             value: 0,
-            deadline: block.number + 555, // block deadline
+            deadline: SafeBlockNumber.get() + 555, // block deadline
             data: userOpData
         });
 

--- a/test/arbitrum/ArbSysMock.sol
+++ b/test/arbitrum/ArbSysMock.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import { ArbitrumTest } from "test/arbitrum/ArbitrumTest.t.sol";
+
+/// @title ArbSysMock
+/// @notice a mocked version of the Arbitrum system contract, add additional methods as needed
+contract ArbSysMock {
+    uint256 private constant ARBITRUM_BLOCK_NUMBER = 260_145_837;
+
+    /// @notice Get Arbitrum block number (distinct from L1 block number; Arbitrum genesis block has block number 0)
+    /// @return block number as uint256
+    function arbBlockNumber() external view returns (uint256) {
+        return ARBITRUM_BLOCK_NUMBER;
+    }
+}

--- a/test/arbitrum/ArbitrumTest.t.sol
+++ b/test/arbitrum/ArbitrumTest.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import { SafeBlockNumber } from "src/contracts/libraries/SafeBlockNumber.sol";
+
+import { BaseTest } from "../base/BaseTest.t.sol";
+import { ArbSysMock } from "./ArbSysMock.sol";
+
+abstract contract ArbitrumTest is BaseTest {
+    ArbSysMock public arbsys;
+    uint256 public constant ARBITRUM_BLOCK_NUMBER = 260_145_837;
+
+    function setUp() public virtual override {
+        // Deploy the ArbSysMock contract
+        arbsys = new ArbSysMock();
+
+        super.setUpChain("ARBITRUM_RPC_URL", ARBITRUM_BLOCK_NUMBER);
+        vm.etch(address(0x0000000000000000000000000000000000000064), address(arbsys).code);
+    }
+}

--- a/test/arbitrum/BlockNumber.t.sol
+++ b/test/arbitrum/BlockNumber.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Test, console } from "forge-std/Test.sol";
+import { BaseTest } from "../base/BaseTest.t.sol";
+import { ArbitrumTest } from "./ArbitrumTest.t.sol";
+
+import { SafeBlockNumber } from "src/contracts/libraries/SafeBlockNumber.sol";
+
+contract BlockNumberTest is ArbitrumTest {
+    function setUp() public override {
+        super.setUp();
+    }
+
+    function testBlockNumber() public {
+        uint256 currentBlockNumber = block.number;
+        uint256 arbBlockNumber = SafeBlockNumber.get();
+        console.log("Current block number:", currentBlockNumber);
+        console.log("Arbitrum block number:", arbBlockNumber);
+
+        // You can add assertions here if needed
+        // For example:
+        // assertGt(currentBlockNumber, 0, "Block number should be greater than 0");
+    }
+}

--- a/test/base/BaseTest.t.sol
+++ b/test/base/BaseTest.t.sol
@@ -60,6 +60,9 @@ contract BaseTest is Test {
     function setUpChain(string memory rpcEnvVar, uint256 forkBlock) public virtual {
         if (forkBlock == 0) forkBlock = MAINNET_FORK_BLOCK;
         if (bytes(rpcEnvVar).length == 0) rpcEnvVar = "MAINNET_RPC_URL";
+        console.log("RPC URL:", vm.envString(rpcEnvVar));
+        console.log("Fork block:", forkBlock);
+
         vm.createSelectFork(vm.envString(rpcEnvVar), forkBlock);
         __createAndLabelAccounts();
         __deployAtlasContracts();

--- a/test/base/BaseTest.t.sol
+++ b/test/base/BaseTest.t.sol
@@ -45,16 +45,22 @@ contract BaseTest is Test {
     Sorter sorter;
     GovernanceBurner govBurner;
 
-    address WETH_ADDRESS = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1;
-    address DAI_ADDRESS = 0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1;
+    address WETH_ADDRESS = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address DAI_ADDRESS = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
     IERC20 WETH = IERC20(WETH_ADDRESS);
     IERC20 DAI = IERC20(DAI_ADDRESS);
 
     uint256 DEFAULT_ESCROW_DURATION = 64;
-    uint256 ARBITUM_FORK_BLOCK = 259_824_410;
+    uint256 MAINNET_FORK_BLOCK = 17_441_786;
 
     function setUp() public virtual {
-        vm.createSelectFork(vm.envString("ARBITUM_RPC_URL"), ARBITUM_FORK_BLOCK);
+        setUpChain("MAINNET_RPC_URL", MAINNET_FORK_BLOCK);
+    }
+
+    function setUpChain(string memory rpcEnvVar, uint256 forkBlock) public virtual {
+        if (forkBlock == 0) forkBlock = MAINNET_FORK_BLOCK;
+        if (bytes(rpcEnvVar).length == 0) rpcEnvVar = "MAINNET_RPC_URL";
+        vm.createSelectFork(vm.envString(rpcEnvVar), forkBlock);
         __createAndLabelAccounts();
         __deployAtlasContracts();
         __fundSolversAndDepositAtlETH();

--- a/test/base/BaseTest.t.sol
+++ b/test/base/BaseTest.t.sol
@@ -45,16 +45,16 @@ contract BaseTest is Test {
     Sorter sorter;
     GovernanceBurner govBurner;
 
-    address WETH_ADDRESS = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
-    address DAI_ADDRESS = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+    address WETH_ADDRESS = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1;
+    address DAI_ADDRESS = 0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1;
     IERC20 WETH = IERC20(WETH_ADDRESS);
     IERC20 DAI = IERC20(DAI_ADDRESS);
 
     uint256 DEFAULT_ESCROW_DURATION = 64;
-    uint256 MAINNET_FORK_BLOCK = 17_441_786;
+    uint256 ARBITUM_FORK_BLOCK = 259_824_410;
 
     function setUp() public virtual {
-        vm.createSelectFork(vm.envString("MAINNET_RPC_URL"), MAINNET_FORK_BLOCK);
+        vm.createSelectFork(vm.envString("ARBITUM_RPC_URL"), ARBITUM_FORK_BLOCK);
         __createAndLabelAccounts();
         __deployAtlasContracts();
         __fundSolversAndDepositAtlETH();

--- a/test/libraries/SafeBlockNumber.t.sol
+++ b/test/libraries/SafeBlockNumber.t.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import { ArbitrumTest } from "../arbitrum/ArbitrumTest.t.sol";
+import "forge-std/Test.sol";
+import { SafeBlockNumber } from "src/contracts/libraries/SafeBlockNumber.sol";
+
+contract SafeBlockNumberArbitrumTest is ArbitrumTest {
+    function setUp() public override {
+        super.setUp();
+    }
+
+    function testSafeBlockNumber() public {
+        assertEq(SafeBlockNumber.get(), ArbitrumTest.ARBITRUM_BLOCK_NUMBER);
+    }
+}
+
+contract SafeBlockNumberTest is Test {
+    function testSafeBlockNumber() public {
+        assertEq(SafeBlockNumber.get(), block.number);
+    }
+}


### PR DESCRIPTION
This change introduces a new library `SafeBlockNumber`

- it will detect the chainId for Arbitrum chains and use the ArbSys precompile to return the Arbitrum Block 