### PR TITLE
refactor: set surcharge rates in constructor

### DIFF
--- a/script/deploy-atlas.s.sol
+++ b/script/deploy-atlas.s.sol
@@ -14,6 +14,10 @@ import { Sorter } from "src/contracts/helpers/Sorter.sol";
 import { ExecutionEnvironment } from "src/contracts/common/ExecutionEnvironment.sol";
 
 contract DeployAtlasScript is DeployBaseScript {
+    uint256 ESCROW_DURATION = 64;
+    uint256 ATLAS_SURCHARGE_RATE = 1_000_000; // 10%
+    uint256 BUNDLER_SURCHARGE_RATE = 1_000_000; // 10%
+
     function run() external {
         console.log("\n=== DEPLOYING Atlas ===\n");
 
@@ -37,7 +41,9 @@ contract DeployAtlasScript is DeployBaseScript {
 
         ExecutionEnvironment execEnvTemplate = new ExecutionEnvironment(expectedAtlasAddr);
         atlas = new Atlas({
-            escrowDuration: 64,
+            escrowDuration: ESCROW_DURATION,
+            atlasSurchargeRate: ATLAS_SURCHARGE_RATE,
+            bundlerSurchargeRate: BUNDLER_SURCHARGE_RATE,
             verification: expectedAtlasVerificationAddr,
             simulator: expectedSimulatorAddr,
             executionTemplate: address(execEnvTemplate),

--- a/src/contracts/atlas/AtlETH.sol
+++ b/src/contracts/atlas/AtlETH.sol
@@ -11,12 +11,22 @@ import "src/contracts/types/EscrowTypes.sol";
 abstract contract AtlETH is Permit69 {
     constructor(
         uint256 escrowDuration,
+        uint256 atlasSurchargeRate,
+        uint256 bundlerSurchargeRate,
         address verification,
         address simulator,
         address initialSurchargeRecipient,
         address l2GasCalculator
     )
-        Permit69(escrowDuration, verification, simulator, initialSurchargeRecipient, l2GasCalculator)
+        Permit69(
+            escrowDuration,
+            atlasSurchargeRate,
+            bundlerSurchargeRate,
+            verification,
+            simulator,
+            initialSurchargeRecipient,
+            l2GasCalculator
+        )
     { }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -28,13 +28,23 @@ contract Atlas is Escrow, Factory {
 
     constructor(
         uint256 escrowDuration,
+        uint256 atlasSurchargeRate,
+        uint256 bundlerSurchargeRate,
         address verification,
         address simulator,
         address initialSurchargeRecipient,
         address l2GasCalculator,
         address executionTemplate
     )
-        Escrow(escrowDuration, verification, simulator, initialSurchargeRecipient, l2GasCalculator)
+        Escrow(
+            escrowDuration,
+            atlasSurchargeRate,
+            bundlerSurchargeRate,
+            verification,
+            simulator,
+            initialSurchargeRecipient,
+            l2GasCalculator
+        )
         Factory(executionTemplate)
     { }
 

--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -31,12 +31,22 @@ abstract contract Escrow is AtlETH {
 
     constructor(
         uint256 escrowDuration,
+        uint256 atlasSurchargeRate,
+        uint256 bundlerSurchargeRate,
         address verification,
         address simulator,
         address initialSurchargeRecipient,
         address l2GasCalculator
     )
-        AtlETH(escrowDuration, verification, simulator, initialSurchargeRecipient, l2GasCalculator)
+        AtlETH(
+            escrowDuration,
+            atlasSurchargeRate,
+            bundlerSurchargeRate,
+            verification,
+            simulator,
+            initialSurchargeRecipient,
+            l2GasCalculator
+        )
     {
         if (escrowDuration == 0) revert InvalidEscrowDuration();
     }

--- a/src/contracts/atlas/Permit69.sol
+++ b/src/contracts/atlas/Permit69.sol
@@ -26,12 +26,22 @@ import "src/contracts/types/EscrowTypes.sol";
 abstract contract Permit69 is GasAccounting {
     constructor(
         uint256 escrowDuration,
+        uint256 atlasSurchargeRate,
+        uint256 bundlerSurchargeRate,
         address verification,
         address simulator,
         address initialSurchargeRecipient,
         address l2GasCalculator
     )
-        GasAccounting(escrowDuration, verification, simulator, initialSurchargeRecipient, l2GasCalculator)
+        GasAccounting(
+            escrowDuration,
+            atlasSurchargeRate,
+            bundlerSurchargeRate,
+            verification,
+            simulator,
+            initialSurchargeRecipient,
+            l2GasCalculator
+        )
     { }
 
     /// @notice Verifies that the caller is an authorized Execution Environment contract.

--- a/src/contracts/atlas/SafetyLocks.sol
+++ b/src/contracts/atlas/SafetyLocks.sol
@@ -18,12 +18,22 @@ abstract contract SafetyLocks is Storage {
 
     constructor(
         uint256 escrowDuration,
+        uint256 atlasSurchargeRate,
+        uint256 bundlerSurchargeRate,
         address verification,
         address simulator,
         address initialSurchargeRecipient,
         address l2GasCalculator
     )
-        Storage(escrowDuration, verification, simulator, initialSurchargeRecipient, l2GasCalculator)
+        Storage(
+            escrowDuration,
+            atlasSurchargeRate,
+            bundlerSurchargeRate,
+            verification,
+            simulator,
+            initialSurchargeRecipient,
+            l2GasCalculator
+        )
     { }
 
     /// @notice Sets the Atlas lock to the specified execution environment.

--- a/src/contracts/atlas/Storage.sol
+++ b/src/contracts/atlas/Storage.sol
@@ -18,6 +18,8 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
     address public immutable SIMULATOR;
     address public immutable L2_GAS_CALCULATOR;
     uint256 public immutable ESCROW_DURATION;
+    uint256 public immutable ATLAS_SURCHARGE_RATE;
+    uint256 public immutable BUNDLER_SURCHARGE_RATE;
 
     // AtlETH public constants
     // These constants double as interface functions for the ERC20 standard, hence the lowercase naming convention.
@@ -26,8 +28,6 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
     uint8 public constant decimals = 18;
 
     // Gas Accounting public constants
-    uint256 public constant ATLAS_SURCHARGE_RATE = AccountingMath._ATLAS_SURCHARGE_RATE;
-    uint256 public constant BUNDLER_SURCHARGE_RATE = AccountingMath._BUNDLER_SURCHARGE_RATE;
     uint256 public constant SCALE = AccountingMath._SCALE;
     uint256 public constant FIXED_GAS_OFFSET = AccountingMath._FIXED_GAS_OFFSET;
 
@@ -56,6 +56,8 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
 
     constructor(
         uint256 escrowDuration,
+        uint256 atlasSurchargeRate,
+        uint256 bundlerSurchargeRate,
         address verification,
         address simulator,
         address initialSurchargeRecipient,
@@ -67,6 +69,8 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
         SIMULATOR = simulator;
         L2_GAS_CALCULATOR = l2GasCalculator;
         ESCROW_DURATION = escrowDuration;
+        ATLAS_SURCHARGE_RATE = atlasSurchargeRate;
+        BUNDLER_SURCHARGE_RATE = bundlerSurchargeRate;
 
         // Gas Accounting
         // Initialized with msg.value to seed flash loan liquidity

--- a/src/contracts/libraries/AccountingMath.sol
+++ b/src/contracts/libraries/AccountingMath.sol
@@ -3,27 +3,40 @@ pragma solidity 0.8.25;
 
 library AccountingMath {
     // Gas Accounting public constants
-    uint256 internal constant _ATLAS_SURCHARGE_RATE = 1_000_000; // out of 10_000_000 = 10%
-    uint256 internal constant _BUNDLER_SURCHARGE_RATE = 1_000_000; // out of 10_000_000 = 10%
     uint256 internal constant _SOLVER_GAS_LIMIT_BUFFER_PERCENTAGE = 500_000; // out of 10_000_000 = 5%
     uint256 internal constant _SCALE = 10_000_000; // 10_000_000 / 10_000_000 = 100%
     uint256 internal constant _FIXED_GAS_OFFSET = 85_000;
 
-    function withBundlerSurcharge(uint256 amount) internal pure returns (uint256 adjustedAmount) {
-        adjustedAmount = amount * (_SCALE + _BUNDLER_SURCHARGE_RATE) / _SCALE;
+    function withSurcharge(uint256 amount, uint256 surchargeRate) internal pure returns (uint256 adjustedAmount) {
+        adjustedAmount = amount * (_SCALE + surchargeRate) / _SCALE;
     }
 
-    function withoutBundlerSurcharge(uint256 amount) internal pure returns (uint256 unadjustedAmount) {
-        unadjustedAmount = amount * _SCALE / (_SCALE + _BUNDLER_SURCHARGE_RATE);
+    function withoutSurcharge(uint256 amount, uint256 surchargeRate) internal pure returns (uint256 unadjustedAmount) {
+        unadjustedAmount = amount * _SCALE / (_SCALE + surchargeRate);
     }
 
-    function withAtlasAndBundlerSurcharges(uint256 amount) internal pure returns (uint256 adjustedAmount) {
-        adjustedAmount = amount * (_SCALE + _ATLAS_SURCHARGE_RATE + _BUNDLER_SURCHARGE_RATE) / _SCALE;
+    function withSurcharges(
+        uint256 amount,
+        uint256 atlasSurchargeRate,
+        uint256 bundlerSurchargeRate
+    )
+        internal
+        pure
+        returns (uint256 adjustedAmount)
+    {
+        adjustedAmount = amount * (_SCALE + atlasSurchargeRate + bundlerSurchargeRate) / _SCALE;
     }
 
     // gets the Atlas surcharge from an unadjusted amount
-    function getAtlasSurcharge(uint256 amount) internal pure returns (uint256 surcharge) {
-        surcharge = amount * _ATLAS_SURCHARGE_RATE / _SCALE;
+    function getSurcharge(
+        uint256 unadjustedAmount,
+        uint256 surchargeRate
+    )
+        internal
+        pure
+        returns (uint256 surchargeAmount)
+    {
+        surchargeAmount = unadjustedAmount * surchargeRate / _SCALE;
     }
 
     function solverGasLimitScaledDown(

--- a/test/AccountingMath.t.sol
+++ b/test/AccountingMath.t.sol
@@ -5,68 +5,83 @@ import "forge-std/Test.sol";
 import "src/contracts/libraries/AccountingMath.sol";
 
 contract AccountingMathTest is Test {
+    uint256 DEFAULT_ATLAS_SURCHARGE_RATE = 1_000_000; // 10%
+    uint256 DEFAULT_BUNDLER_SURCHARGE_RATE = 1_000_000; // 10%
+
     function testWithBundlerSurcharge() public {
-        assertEq(AccountingMath.withBundlerSurcharge(0), uint256(0));
-        assertEq(AccountingMath.withBundlerSurcharge(1), uint256(1));
-        assertEq(AccountingMath.withBundlerSurcharge(11), uint256(12));
-        assertEq(AccountingMath.withBundlerSurcharge(100), uint256(110));
-        assertEq(AccountingMath.withBundlerSurcharge(1e18), uint256(11e17));
+        assertEq(AccountingMath.withSurcharge(0, DEFAULT_BUNDLER_SURCHARGE_RATE), uint256(0));
+        assertEq(AccountingMath.withSurcharge(1, DEFAULT_BUNDLER_SURCHARGE_RATE), uint256(1));
+        assertEq(AccountingMath.withSurcharge(11, DEFAULT_BUNDLER_SURCHARGE_RATE), uint256(12));
+        assertEq(AccountingMath.withSurcharge(100, DEFAULT_BUNDLER_SURCHARGE_RATE), uint256(110));
+        assertEq(AccountingMath.withSurcharge(1e18, DEFAULT_BUNDLER_SURCHARGE_RATE), uint256(11e17));
         vm.expectRevert();
-        AccountingMath.withBundlerSurcharge(type(uint256).max);
+        AccountingMath.withSurcharge(type(uint256).max, DEFAULT_BUNDLER_SURCHARGE_RATE);
     }
 
     function testWithoutBundlerSurcharge() public {
-        assertEq(AccountingMath.withoutBundlerSurcharge(0), uint256(0));
-        assertEq(AccountingMath.withoutBundlerSurcharge(1), uint256(0));
-        assertEq(AccountingMath.withoutBundlerSurcharge(12), uint256(10));
-        assertEq(AccountingMath.withoutBundlerSurcharge(110), uint256(100));
-        assertEq(AccountingMath.withoutBundlerSurcharge(11e17), uint256(1e18));
+        assertEq(AccountingMath.withoutSurcharge(0, DEFAULT_BUNDLER_SURCHARGE_RATE), uint256(0));
+        assertEq(AccountingMath.withoutSurcharge(1, DEFAULT_BUNDLER_SURCHARGE_RATE), uint256(0));
+        assertEq(AccountingMath.withoutSurcharge(12, DEFAULT_BUNDLER_SURCHARGE_RATE), uint256(10));
+        assertEq(AccountingMath.withoutSurcharge(110, DEFAULT_BUNDLER_SURCHARGE_RATE), uint256(100));
+        assertEq(AccountingMath.withoutSurcharge(11e17, DEFAULT_BUNDLER_SURCHARGE_RATE), uint256(1e18));
         vm.expectRevert();
-        AccountingMath.withoutBundlerSurcharge(type(uint256).max);
+        AccountingMath.withoutSurcharge(type(uint256).max, DEFAULT_BUNDLER_SURCHARGE_RATE);
     }
 
     function testWithAtlasAndBundlerSurcharges() public {
-        assertEq(AccountingMath.withAtlasAndBundlerSurcharges(0), uint256(0));
-        assertEq(AccountingMath.withAtlasAndBundlerSurcharges(1), uint256(1));
-        assertEq(AccountingMath.withAtlasAndBundlerSurcharges(10), uint256(12));
-        assertEq(AccountingMath.withAtlasAndBundlerSurcharges(100), uint256(120));
-        assertEq(AccountingMath.withAtlasAndBundlerSurcharges(1e18), uint256(12e17));
+        assertEq(
+            AccountingMath.withSurcharges(0, DEFAULT_ATLAS_SURCHARGE_RATE, DEFAULT_BUNDLER_SURCHARGE_RATE), uint256(0)
+        );
+        assertEq(
+            AccountingMath.withSurcharges(1, DEFAULT_ATLAS_SURCHARGE_RATE, DEFAULT_BUNDLER_SURCHARGE_RATE), uint256(1)
+        );
+        assertEq(
+            AccountingMath.withSurcharges(10, DEFAULT_ATLAS_SURCHARGE_RATE, DEFAULT_BUNDLER_SURCHARGE_RATE), uint256(12)
+        );
+        assertEq(
+            AccountingMath.withSurcharges(100, DEFAULT_ATLAS_SURCHARGE_RATE, DEFAULT_BUNDLER_SURCHARGE_RATE),
+            uint256(120)
+        );
+        assertEq(
+            AccountingMath.withSurcharges(1e18, DEFAULT_ATLAS_SURCHARGE_RATE, DEFAULT_BUNDLER_SURCHARGE_RATE),
+            uint256(12e17)
+        );
         vm.expectRevert();
-        AccountingMath.withAtlasAndBundlerSurcharges(type(uint256).max);
+        AccountingMath.withSurcharges(type(uint256).max, DEFAULT_ATLAS_SURCHARGE_RATE, DEFAULT_BUNDLER_SURCHARGE_RATE);
     }
 
     function testGetAtlasSurcharge() public {
-        assertEq(AccountingMath.getAtlasSurcharge(0), uint256(0));
-        assertEq(AccountingMath.getAtlasSurcharge(10), uint256(1));
-        assertEq(AccountingMath.getAtlasSurcharge(20), uint256(2));
-        assertEq(AccountingMath.getAtlasSurcharge(30), uint256(3));
-        assertEq(AccountingMath.getAtlasSurcharge(100), uint256(10));
-        assertEq(AccountingMath.getAtlasSurcharge(1_000_000), uint256(100_000));
-        assertEq(AccountingMath.getAtlasSurcharge(1e18), uint256(1e17));
+        assertEq(AccountingMath.getSurcharge(0, DEFAULT_ATLAS_SURCHARGE_RATE), uint256(0));
+        assertEq(AccountingMath.getSurcharge(10, DEFAULT_ATLAS_SURCHARGE_RATE), uint256(1));
+        assertEq(AccountingMath.getSurcharge(20, DEFAULT_ATLAS_SURCHARGE_RATE), uint256(2));
+        assertEq(AccountingMath.getSurcharge(30, DEFAULT_ATLAS_SURCHARGE_RATE), uint256(3));
+        assertEq(AccountingMath.getSurcharge(100, DEFAULT_ATLAS_SURCHARGE_RATE), uint256(10));
+        assertEq(AccountingMath.getSurcharge(1_000_000, DEFAULT_ATLAS_SURCHARGE_RATE), uint256(100_000));
+        assertEq(AccountingMath.getSurcharge(1e18, DEFAULT_ATLAS_SURCHARGE_RATE), uint256(1e17));
         vm.expectRevert();
-        AccountingMath.getAtlasSurcharge(type(uint256).max);
+        AccountingMath.getSurcharge(type(uint256).max, DEFAULT_ATLAS_SURCHARGE_RATE);
     }
 
     function testSolverGasLimitScaledDown() public {
         assertEq(AccountingMath.solverGasLimitScaledDown(0, 100), uint256(0));
         assertEq(AccountingMath.solverGasLimitScaledDown(50, 100), uint256(47)); // 50 * 10_000_000 / 10_500_000
         assertEq(AccountingMath.solverGasLimitScaledDown(100, 200), uint256(95));
-        
+
         assertEq(AccountingMath.solverGasLimitScaledDown(200, 100), uint256(95));
         assertEq(AccountingMath.solverGasLimitScaledDown(300, 200), uint256(190));
-        
+
         assertEq(AccountingMath.solverGasLimitScaledDown(100, 100), uint256(95));
         assertEq(AccountingMath.solverGasLimitScaledDown(200, 200), uint256(190));
-        
-        assertEq(AccountingMath.solverGasLimitScaledDown(1_000_000, 500_000), uint256(476_190)); // 500_000 * 10_000_000 / 10_500_000
-        assertEq(AccountingMath.solverGasLimitScaledDown(1e18, 1e18), uint256(952380952380952380));
-        
+
+        assertEq(AccountingMath.solverGasLimitScaledDown(1_000_000, 500_000), uint256(476_190)); // 500_000 * 10_000_000
+            // / 10_500_000
+        assertEq(AccountingMath.solverGasLimitScaledDown(1e18, 1e18), uint256(952_380_952_380_952_380));
+
         vm.expectRevert();
         assertEq(AccountingMath.solverGasLimitScaledDown(type(uint256).max, type(uint256).max), type(uint256).max);
-        
+
         assertEq(AccountingMath.solverGasLimitScaledDown(1, 2), uint256(0)); // 1 * 10_000_000 / 10_500_000
         assertEq(AccountingMath.solverGasLimitScaledDown(3, 3), uint256(2)); // 3 * 10_000_000 / 10_500_000
         assertEq(AccountingMath.solverGasLimitScaledDown(5, 10), uint256(4)); // 5 * 10_000_000 / 10_500_000
-
     }
 }

--- a/test/BidFinding.t.sol
+++ b/test/BidFinding.t.sol
@@ -20,38 +20,11 @@ import "src/contracts/types/LockTypes.sol";
 
 import { LibSort } from "solady/utils/LibSort.sol";
 
-// These tests focus on the functions found in the Atlas.sol file
-contract AtlasTest is BaseTest {
-
-    function setUp_bidFindingIteration() public {
-        // super.setUp();
-
-        // vm.startPrank(payee);
-        // simulator = new Simulator();
-
-        // // Computes the addresses at which AtlasVerification will be deployed
-        // address expectedAtlasAddr = vm.computeCreateAddress(payee, vm.getNonce(payee) + 1);
-        // address expectedAtlasVerificationAddr = vm.computeCreateAddress(payee, vm.getNonce(payee) + 2);
-        // bytes32 salt = keccak256(abi.encodePacked(block.chainid, expectedAtlasAddr, "AtlasFactory 1.0"));
-        // ExecutionEnvironment execEnvTemplate = new ExecutionEnvironment{ salt: salt }(expectedAtlasAddr);
-
-        // atlas = new MockAtlas({
-        //     escrowDuration: 64,
-        //     verification: expectedAtlasVerificationAddr,
-        //     simulator: address(simulator),
-        //     executionTemplate: address(execEnvTemplate),
-        //     surchargeRecipient: payee
-        // });
-        // atlasVerification = new AtlasVerification(address(atlas));
-        // simulator.setAtlas(address(atlas));
-        // sorter = new Sorter(address(atlas));
-        // vm.stopPrank();
-    }
-
+contract BidFindingTest is BaseTest {
     function test_bidFindingIteration_sortingOrder() public pure {
         // Test order of bidsAndIndices after insertionSort
 
-        // 3 items. [200, 0, 100] --> [0, 100, 200] 
+        // 3 items. [200, 0, 100] --> [0, 100, 200]
         uint256[] memory bidsAndIndices = new uint256[](3);
         bidsAndIndices[0] = 100;
         bidsAndIndices[1] = 0;
@@ -80,7 +53,7 @@ contract AtlasTest is BaseTest {
     }
 
     function test_bidFindingIteration_packBidAndIndex() public pure {
-        uint256 bid = 12345;
+        uint256 bid = 12_345;
         uint256 index = 2;
 
         uint256 packed = _packBidAndIndex(bid, index);
@@ -113,7 +86,6 @@ contract AtlasTest is BaseTest {
         assertEq(unpackedIndex, index);
     }
 
-
     // Packs bid and index into a single uint256, replicates logic used in `_bidFindingIteration()`
     function _packBidAndIndex(uint256 bid, uint256 index) internal pure returns (uint256) {
         return uint256(bid << 16 | uint16(index));
@@ -126,30 +98,5 @@ contract AtlasTest is BaseTest {
 
         // uint256 solverOpsIndex = bidsAndIndices[i] & FIRST_16_BITS_MASK;
         index = packed & uint256(0xFFFF);
-    }
-}
-
-// MockAtlas exposes Atlas' internal functions for testing
-contract MockAtlas is Atlas {
-    constructor(
-        uint256 _escrowDuration,
-        address _verification,
-        address _simulator,
-        address _surchargeRecipient,
-        address _l2GasCalculator,
-        address _executionTemplate
-    ) 
-        Atlas(_escrowDuration, _verification, _simulator, _surchargeRecipient, _l2GasCalculator, _executionTemplate) 
-    { }
-
-    function bidFindingIteration(
-        DAppConfig calldata dConfig,
-        UserOperation calldata userOp,
-        SolverOperation[] calldata solverOps,
-        bytes memory returnData,
-        Context memory ctx
-    ) public returns (Context memory) {
-        _bidFindingIteration(ctx, dConfig, userOp, solverOps, returnData);
-        return ctx;
     }
 }

--- a/test/DAppIntegration.t.sol
+++ b/test/DAppIntegration.t.sol
@@ -16,6 +16,9 @@ contract MockDAppIntegration is DAppIntegration {
 }
 
 contract DAppIntegrationTest is Test {
+    uint256 DEFAULT_ATLAS_SURCHARGE_RATE = 1_000_000; // 10%
+    uint256 DEFAULT_BUNDLER_SURCHARGE_RATE = 1_000_000; // 10%
+
     Atlas public atlas;
     MockDAppIntegration public dAppIntegration;
     DummyDAppControl public dAppControl;
@@ -40,6 +43,8 @@ contract DAppIntegrationTest is Test {
         // Deploy the Atlas contract with correct parameters
         atlas = new Atlas({
             escrowDuration: 64,
+            atlasSurchargeRate: DEFAULT_ATLAS_SURCHARGE_RATE,
+            bundlerSurchargeRate: DEFAULT_BUNDLER_SURCHARGE_RATE,
             verification: address(atlasVerification),
             simulator: address(0),
             executionTemplate: address(execEnvTemplate),

--- a/test/Factory.t.sol
+++ b/test/Factory.t.sol
@@ -47,6 +47,9 @@ contract MockFactory is Factory, Test {
 }
 
 contract FactoryTest is Test {
+    uint256 DEFAULT_ATLAS_SURCHARGE_RATE = 1_000_000; // 10%
+    uint256 DEFAULT_BUNDLER_SURCHARGE_RATE = 1_000_000; // 10%
+
     Atlas public atlas;
     AtlasVerification public atlasVerification;
     MockFactory public mockFactory;
@@ -66,6 +69,8 @@ contract FactoryTest is Test {
         vm.startPrank(deployer);
         atlas = new Atlas({
             escrowDuration: 64,
+            atlasSurchargeRate: DEFAULT_ATLAS_SURCHARGE_RATE,
+            bundlerSurchargeRate: DEFAULT_BUNDLER_SURCHARGE_RATE,
             verification: expectedAtlasVerificationAddr,
             simulator: address(0),
             executionTemplate: address(execEnvTemplate),

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -30,13 +30,15 @@ contract MockGasAccounting is TestAtlas, BaseTest {
 
     constructor(
         uint256 _escrowDuration,
+        uint256 _atlasSurchargeRate,
+        uint256 _bundlerSurchargeRate,
         address _verification,
         address _simulator,
         address _surchargeRecipient,
         address _l2GasCalculator,
         address _executionTemplate
     )
-        TestAtlas(_escrowDuration, _verification, _simulator, _surchargeRecipient, _l2GasCalculator, _executionTemplate)
+        TestAtlas(_escrowDuration, _atlasSurchargeRate, _bundlerSurchargeRate, _verification, _simulator, _surchargeRecipient, _l2GasCalculator, _executionTemplate)
     { }
 
     /////////////////////////////////////////////////////////
@@ -172,14 +174,6 @@ contract MockGasAccounting is TestAtlas, BaseTest {
     function getFixedGasOffset() external pure returns (uint256) {
         return AccountingMath._FIXED_GAS_OFFSET;
     }
-
-    function getAtlasSurchargeRate() external pure returns (uint256) {
-        return AccountingMath._ATLAS_SURCHARGE_RATE;
-    }
-
-    function getBundlerSurchargeRate() external pure returns (uint256) {
-        return AccountingMath._BUNDLER_SURCHARGE_RATE;
-    }
 }
 
 contract MockGasCalculator is IL2GasCalculator, Test {
@@ -212,6 +206,8 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         // Initialize MockGasAccounting
         mockGasAccounting = new MockGasAccounting(
             DEFAULT_ESCROW_DURATION,
+            DEFAULT_ATLAS_SURCHARGE_RATE,
+            DEFAULT_BUNDLER_SURCHARGE_RATE,
             address(atlasVerification),
             address(simulator),
             deployer,
@@ -973,7 +969,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
             (gasWaterMark + mockGasAccounting.getSolverBaseGasUsed() - gasleft()) * tx.gasprice + gasUsedOffset;
         mockGasAccounting.handleSolverAccounting(solverOp, gasWaterMark, result, false);
 
-        uint256 expectedWriteoffs = initialWriteoffs + AccountingMath.withAtlasAndBundlerSurcharges(gasUsed);
+        uint256 expectedWriteoffs = initialWriteoffs + AccountingMath.withSurcharges(gasUsed, DEFAULT_ATLAS_SURCHARGE_RATE, DEFAULT_BUNDLER_SURCHARGE_RATE);
         // Verify writeoffs have increased
         assertApproxEqRel(
             mockGasAccounting.getWriteoffs(),
@@ -1110,6 +1106,8 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         IL2GasCalculator gasCalculator = new MockGasCalculator();
         MockGasAccounting mockL2GasAccounting = new MockGasAccounting(
             DEFAULT_ESCROW_DURATION,
+            DEFAULT_ATLAS_SURCHARGE_RATE,
+            DEFAULT_BUNDLER_SURCHARGE_RATE,
             address(atlasVerification),
             address(simulator),
             deployer,

--- a/test/Permit69.t.sol
+++ b/test/Permit69.t.sol
@@ -22,7 +22,6 @@ import "src/contracts/types/LockTypes.sol";
 import "src/contracts/types/DAppOperation.sol";
 
 contract Permit69Test is BaseTest {
-
     Context ctx;
     address mockUser;
 
@@ -42,10 +41,12 @@ contract Permit69Test is BaseTest {
         address expectedFactoryAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 2);
         bytes32 salt = keccak256(abi.encodePacked(block.chainid, expectedFactoryAddr));
         ExecutionEnvironment execEnvTemplate = new ExecutionEnvironment{ salt: salt }(expectedFactoryAddr);
-        
+
         vm.startPrank(deployer);
         mockAtlas = new MockAtlasForPermit69Tests({
             _escrowDuration: 64,
+            _atlasSurchargeRate: DEFAULT_ATLAS_SURCHARGE_RATE,
+            _bundlerSurchargeRate: DEFAULT_BUNDLER_SURCHARGE_RATE,
             _verification: expectedAtlasVerificationAddr,
             _simulator: address(0),
             _executionTemplate: address(execEnvTemplate),
@@ -97,9 +98,7 @@ contract Permit69Test is BaseTest {
 
         vm.prank(solverOneEOA);
         vm.expectRevert(AtlasErrors.InvalidEnvironment.selector);
-        mockAtlas.transferUserERC20(
-            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl
-        );
+        mockAtlas.transferUserERC20(WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl);
     }
 
     function testTransferUserERC20RevertsIfLockStateNotValid() public {
@@ -115,27 +114,21 @@ contract Permit69Test is BaseTest {
 
         // Uninitialized
         vm.expectRevert(AtlasErrors.InvalidLockState.selector);
-        mockAtlas.transferUserERC20(
-            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl
-        );
+        mockAtlas.transferUserERC20(WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl);
 
         // AllocateValue
         phase = ExecutionPhase.AllocateValue;
         mockAtlas.setContext(ctx);
         mockAtlas.setPhase(phase);
         vm.expectRevert(AtlasErrors.InvalidLockState.selector);
-        mockAtlas.transferUserERC20(
-            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl
-        );
+        mockAtlas.transferUserERC20(WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl);
 
         // Releasing
         phase = ExecutionPhase.Uninitialized;
         mockAtlas.setContext(ctx);
         mockAtlas.setPhase(phase);
         vm.expectRevert(AtlasErrors.InvalidLockState.selector);
-        mockAtlas.transferUserERC20(
-            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl
-        );
+        mockAtlas.transferUserERC20(WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl);
 
         vm.stopPrank();
     }
@@ -157,9 +150,7 @@ contract Permit69Test is BaseTest {
         WETH.approve(address(mockAtlas), wethTransferred);
 
         vm.prank(mockExecutionEnvAddress);
-        mockAtlas.transferUserERC20(
-            WETH_ADDRESS, solverOneEOA, wethTransferred, mockUser, mockDAppControl
-        );
+        mockAtlas.transferUserERC20(WETH_ADDRESS, solverOneEOA, wethTransferred, mockUser, mockDAppControl);
 
         assertEq(WETH.balanceOf(mockUser), userWethBefore - wethTransferred, "User did not lose WETH");
         assertEq(WETH.balanceOf(solverOneEOA), solverWethBefore + wethTransferred, "Solver did not gain WETH");
@@ -173,9 +164,7 @@ contract Permit69Test is BaseTest {
 
         vm.prank(solverOneEOA);
         vm.expectRevert(AtlasErrors.InvalidEnvironment.selector);
-        mockAtlas.transferDAppERC20(
-            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl
-        );
+        mockAtlas.transferDAppERC20(WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl);
     }
 
     function testTransferDAppERC20RevertsIfLockStateNotValid() public {
@@ -189,33 +178,25 @@ contract Permit69Test is BaseTest {
         ExecutionPhase phase = ExecutionPhase.Uninitialized;
         mockAtlas.setPhase(phase);
         vm.expectRevert(AtlasErrors.InvalidLockState.selector);
-        mockAtlas.transferDAppERC20(
-            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl
-        );
+        mockAtlas.transferDAppERC20(WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl);
 
         // UserOperation
         phase = ExecutionPhase.UserOperation;
         mockAtlas.setPhase(phase);
         vm.expectRevert(AtlasErrors.InvalidLockState.selector);
-        mockAtlas.transferDAppERC20(
-            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl
-        );
+        mockAtlas.transferDAppERC20(WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl);
 
         // SolverOperations
         phase = ExecutionPhase.SolverOperation;
         mockAtlas.setPhase(phase);
         vm.expectRevert(AtlasErrors.InvalidLockState.selector);
-        mockAtlas.transferDAppERC20(
-            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl
-        );
+        mockAtlas.transferDAppERC20(WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl);
 
         // Releasing
         phase = ExecutionPhase.Uninitialized;
         mockAtlas.setPhase(phase);
         vm.expectRevert(AtlasErrors.InvalidLockState.selector);
-        mockAtlas.transferDAppERC20(
-            WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl
-        );
+        mockAtlas.transferDAppERC20(WETH_ADDRESS, solverOneEOA, 10e18, mockUser, mockDAppControl);
 
         vm.stopPrank();
     }
@@ -236,9 +217,7 @@ contract Permit69Test is BaseTest {
         WETH.approve(address(mockAtlas), wethTransferred);
 
         vm.prank(mockExecutionEnvAddress);
-        mockAtlas.transferDAppERC20(
-            WETH_ADDRESS, solverOneEOA, wethTransferred, mockUser, mockDAppControl
-        );
+        mockAtlas.transferDAppERC20(WETH_ADDRESS, solverOneEOA, wethTransferred, mockUser, mockDAppControl);
 
         assertEq(WETH.balanceOf(mockDAppControl), dAppWethBefore - wethTransferred, "DApp did not lose WETH");
         assertEq(WETH.balanceOf(solverOneEOA), solverWethBefore + wethTransferred, "Solver did not gain WETH");
@@ -279,7 +258,7 @@ contract Permit69Test is BaseTest {
     function testConstantValueOfSafeDAppTransfer() public {
         // FIXME: fix before merging spearbit-reaudit branch
         vm.skip(true);
-        
+
         string memory expectedBitMapString = "0000111010100000";
         // Safe phases for dApp transfers are PreOps, AllocateValue, and DAppOperation
         // preOpsPhaseSafe = 0000 0000 0010 0000
@@ -293,8 +272,8 @@ contract Permit69Test is BaseTest {
         // verificationPhaseSafe = 0000 0100 0000 0000
         uint8 verificationPhaseSafe = uint8(ExecutionPhase.PostOps);
 
-        uint16 expectedSafeDAppTransferBitMap =
-            preOpsPhaseSafe | preSolverOpsPhaseSafe | postSolverOpsPhaseSafe | allocateValuePhaseSafe | verificationPhaseSafe;
+        uint16 expectedSafeDAppTransferBitMap = preOpsPhaseSafe | preSolverOpsPhaseSafe | postSolverOpsPhaseSafe
+            | allocateValuePhaseSafe | verificationPhaseSafe;
 
         assertEq(
             mockAtlas.getSafeDAppTransfer(),
@@ -323,13 +302,24 @@ contract Permit69Test is BaseTest {
 contract MockAtlasForPermit69Tests is Atlas {
     constructor(
         uint256 _escrowDuration,
+        uint256 _atlasSurchargeRate,
+        uint256 _bundlerSurchargeRate,
         address _verification,
         address _simulator,
         address _surchargeRecipient,
         address _l2GasCalculator,
         address _executionTemplate
     )
-        Atlas(_escrowDuration, _verification, _simulator, _surchargeRecipient, _l2GasCalculator, _executionTemplate)
+        Atlas(
+            _escrowDuration,
+            _atlasSurchargeRate,
+            _bundlerSurchargeRate,
+            _verification,
+            _simulator,
+            _surchargeRecipient,
+            _l2GasCalculator,
+            _executionTemplate
+        )
     { }
 
     // Declared in SafetyLocks.sol in the canonical Atlas system
@@ -354,10 +344,7 @@ contract MockAtlasForPermit69Tests is Atlas {
         _environment = _activeEnvironment;
     }
 
-    function setLock(
-        address _activeEnvironment,
-        uint32 callConfig
-    ) public {
+    function setLock(address _activeEnvironment, uint32 callConfig) public {
         _setLock({
             activeEnvironment: _activeEnvironment,
             callConfig: callConfig,
@@ -376,12 +363,20 @@ contract MockAtlasForPermit69Tests is Atlas {
         uint32 callConfig
     )
         public
-        returns (address executionEnvironment) 
+        returns (address executionEnvironment)
     {
         return _getOrCreateExecutionEnvironment(user, control, callConfig);
     }
 
-    function verifyUserControlExecutionEnv(address sender, address user, address control, uint32 callConfig) internal view  returns (bool)
+    function verifyUserControlExecutionEnv(
+        address sender,
+        address user,
+        address control,
+        uint32 callConfig
+    )
+        internal
+        view
+        returns (bool)
     {
         return _verifyUserControlExecutionEnv(sender, user, control, callConfig);
     }

--- a/test/SafetyLocks.t.sol
+++ b/test/SafetyLocks.t.sol
@@ -11,7 +11,7 @@ import "src/contracts/types/ConfigTypes.sol";
 import "src/contracts/types/LockTypes.sol";
 
 contract MockSafetyLocks is SafetyLocks {
-    constructor() SafetyLocks(0, address(0), address(0), address(0), address(0)) { }
+    constructor() SafetyLocks(0, 1000000, 1000000, address(0), address(0), address(0), address(0)) { }
 
     function initializeLock(
         address executionEnvironment,

--- a/test/Storage.t.sol
+++ b/test/Storage.t.sol
@@ -11,8 +11,6 @@ import { BaseTest } from "test/base/BaseTest.t.sol";
 contract StorageTest is BaseTest {
     using stdStorage for StdStorage;
 
-    uint256 constant DEFAULT_ATLAS_SURCHARGE_RATE = 1_000_000; // out of 10_000_000 = 10%
-    uint256 constant DEFAULT_BUNDLER_SURCHARGE_RATE = 1_000_000; // out of 10_000_000 = 10%
     uint256 constant DEFAULT_SCALE = 10_000_000; // out of 10_000_000 = 100%
     uint256 constant DEFAULT_FIXED_GAS_OFFSET = 85_000;
 
@@ -32,7 +30,9 @@ contract StorageTest is BaseTest {
         assertEq(atlas.decimals(), 18, "decimals set incorrectly");
 
         assertEq(atlas.ATLAS_SURCHARGE_RATE(), DEFAULT_ATLAS_SURCHARGE_RATE, "ATLAS_SURCHARGE_RATE set incorrectly");
-        assertEq(atlas.BUNDLER_SURCHARGE_RATE(), DEFAULT_BUNDLER_SURCHARGE_RATE, "BUNDLER_SURCHARGE_RATE set incorrectly");
+        assertEq(
+            atlas.BUNDLER_SURCHARGE_RATE(), DEFAULT_BUNDLER_SURCHARGE_RATE, "BUNDLER_SURCHARGE_RATE set incorrectly"
+        );
         assertEq(atlas.SCALE(), DEFAULT_SCALE, "SCALE set incorrectly");
         assertEq(atlas.FIXED_GAS_OFFSET(), DEFAULT_FIXED_GAS_OFFSET, "FIXED_GAS_OFFSET set incorrectly");
     }
@@ -45,7 +45,7 @@ contract StorageTest is BaseTest {
 
         vm.deal(userEOA, depositAmount);
         vm.prank(userEOA);
-        atlas.deposit{value: depositAmount}();
+        atlas.deposit{ value: depositAmount }();
 
         assertEq(atlas.totalSupply(), startTotalSupply + depositAmount, "totalSupply did not increase correctly");
     }
@@ -56,14 +56,20 @@ contract StorageTest is BaseTest {
 
         vm.deal(userEOA, depositAmount);
         vm.prank(userEOA);
-        atlas.depositAndBond{value: depositAmount}(depositAmount);
+        atlas.depositAndBond{ value: depositAmount }(depositAmount);
 
         assertEq(atlas.bondedTotalSupply(), depositAmount, "bondedTotalSupply did not increase correctly");
     }
 
     function test_storage_view_accessData() public {
         uint256 depositAmount = 1e18;
-        (uint256 bonded, uint256 lastAccessedBlock, uint256 auctionWins, uint256 auctionFails, uint256 totalGasValueUsed) = atlas.accessData(userEOA);
+        (
+            uint256 bonded,
+            uint256 lastAccessedBlock,
+            uint256 auctionWins,
+            uint256 auctionFails,
+            uint256 totalGasValueUsed
+        ) = atlas.accessData(userEOA);
 
         assertEq(bonded, 0, "user bonded should start as 0");
         assertEq(lastAccessedBlock, 0, "user lastAccessedBlock should start as 0");
@@ -73,7 +79,7 @@ contract StorageTest is BaseTest {
 
         vm.deal(userEOA, depositAmount);
         vm.prank(userEOA);
-        atlas.depositAndBond{value: depositAmount}(depositAmount);
+        atlas.depositAndBond{ value: depositAmount }(depositAmount);
 
         (bonded, lastAccessedBlock, auctionWins, auctionFails, totalGasValueUsed) = atlas.accessData(userEOA);
 
@@ -96,7 +102,15 @@ contract StorageTest is BaseTest {
     }
 
     function test_storage_view_solverOpHashes() public {
-        MockStorage mockStorage = new MockStorage(DEFAULT_ESCROW_DURATION, address(0), address(0), address(0), address(0));
+        MockStorage mockStorage = new MockStorage(
+            DEFAULT_ESCROW_DURATION,
+            DEFAULT_ATLAS_SURCHARGE_RATE,
+            DEFAULT_BUNDLER_SURCHARGE_RATE,
+            address(0),
+            address(0),
+            address(0),
+            address(0)
+        );
         bytes32 testHash = keccak256(abi.encodePacked("test"));
         assertEq(mockStorage.solverOpHashes(testHash), false, "solverOpHashes[testHash] not false");
         mockStorage.setSolverOpHash(testHash);
@@ -104,7 +118,15 @@ contract StorageTest is BaseTest {
     }
 
     function test_storage_view_cumulativeSurcharge() public {
-        MockStorage mockStorage = new MockStorage(DEFAULT_ESCROW_DURATION, address(0), address(0), address(0), address(0));
+        MockStorage mockStorage = new MockStorage(
+            DEFAULT_ESCROW_DURATION,
+            DEFAULT_ATLAS_SURCHARGE_RATE,
+            DEFAULT_BUNDLER_SURCHARGE_RATE,
+            address(0),
+            address(0),
+            address(0),
+            address(0)
+        );
         assertEq(mockStorage.cumulativeSurcharge(), 0, "cumulativeSurcharge not 0");
         mockStorage.setCumulativeSurcharge(100);
         assertEq(mockStorage.cumulativeSurcharge(), 100, "cumulativeSurcharge not 100");
@@ -157,7 +179,15 @@ contract StorageTest is BaseTest {
 
     function test_storage_transient_solverLockData() public {
         // MockStorage just used here to access AtlasConstants
-        MockStorage mockStorage = new MockStorage(DEFAULT_ESCROW_DURATION, address(0), address(0), address(0), address(0));
+        MockStorage mockStorage = new MockStorage(
+            DEFAULT_ESCROW_DURATION,
+            DEFAULT_ATLAS_SURCHARGE_RATE,
+            DEFAULT_BUNDLER_SURCHARGE_RATE,
+            address(0),
+            address(0),
+            address(0),
+            address(0)
+        );
         (address currentSolver, bool calledBack, bool fulfilled) = atlas.solverLockData();
 
         assertEq(currentSolver, address(0), "currentSolver should start at 0");
@@ -180,7 +210,8 @@ contract StorageTest is BaseTest {
         assertEq(calledBack, true, "calledBack should still be true");
         assertEq(fulfilled, true, "fulfilled should be true");
 
-        testSolverLock = mockStorage.SOLVER_CALLED_BACK_MASK() | mockStorage.SOLVER_FULFILLED_MASK() | uint256(uint160(userEOA));
+        testSolverLock =
+            mockStorage.SOLVER_CALLED_BACK_MASK() | mockStorage.SOLVER_FULFILLED_MASK() | uint256(uint160(userEOA));
         atlas.setSolverLock(testSolverLock);
         (currentSolver, calledBack, fulfilled) = atlas.solverLockData();
 
@@ -247,7 +278,15 @@ contract StorageTest is BaseTest {
     }
 
     function test_storage_transient_solverTo() public {
-        MockStorage mockStorage = new MockStorage(DEFAULT_ESCROW_DURATION, address(0), address(0), address(0), address(0));
+        MockStorage mockStorage = new MockStorage(
+            DEFAULT_ESCROW_DURATION,
+            DEFAULT_ATLAS_SURCHARGE_RATE,
+            DEFAULT_BUNDLER_SURCHARGE_RATE,
+            address(0),
+            address(0),
+            address(0),
+            address(0)
+        );
         assertEq(mockStorage.solverTo(), address(0), "solverTo should start at 0");
 
         mockStorage.setSolverTo(userEOA);
@@ -258,7 +297,15 @@ contract StorageTest is BaseTest {
     }
 
     function test_storage_transient_activeEnvironment() public {
-        MockStorage mockStorage = new MockStorage(DEFAULT_ESCROW_DURATION, address(0), address(0), address(0), address(0));
+        MockStorage mockStorage = new MockStorage(
+            DEFAULT_ESCROW_DURATION,
+            DEFAULT_ATLAS_SURCHARGE_RATE,
+            DEFAULT_BUNDLER_SURCHARGE_RATE,
+            address(0),
+            address(0),
+            address(0),
+            address(0)
+        );
         assertEq(mockStorage.activeEnvironment(), address(0), "activeEnvironment should start at 0");
 
         mockStorage.setLock(address(1), 0, 0);
@@ -269,7 +316,15 @@ contract StorageTest is BaseTest {
     }
 
     function test_storage_transient_activeCallConfig() public {
-        MockStorage mockStorage = new MockStorage(DEFAULT_ESCROW_DURATION, address(0), address(0), address(0), address(0));
+        MockStorage mockStorage = new MockStorage(
+            DEFAULT_ESCROW_DURATION,
+            DEFAULT_ATLAS_SURCHARGE_RATE,
+            DEFAULT_BUNDLER_SURCHARGE_RATE,
+            address(0),
+            address(0),
+            address(0),
+            address(0)
+        );
         assertEq(mockStorage.activeCallConfig(), 0, "activeCallConfig should start at 0");
 
         mockStorage.setLock(address(0), 1, 0);
@@ -280,7 +335,15 @@ contract StorageTest is BaseTest {
     }
 
     function test_storage_transient_phase() public {
-        MockStorage mockStorage = new MockStorage(DEFAULT_ESCROW_DURATION, address(0), address(0), address(0), address(0));
+        MockStorage mockStorage = new MockStorage(
+            DEFAULT_ESCROW_DURATION,
+            DEFAULT_ATLAS_SURCHARGE_RATE,
+            DEFAULT_BUNDLER_SURCHARGE_RATE,
+            address(0),
+            address(0),
+            address(0),
+            address(0)
+        );
         assertEq(mockStorage.phase(), 0, "phase should start at 0");
 
         mockStorage.setLock(address(0), 0, 1);
@@ -293,19 +356,28 @@ contract StorageTest is BaseTest {
 
 // To test solverOpHashes() and cumulativeSurcharge() view function
 contract MockStorage is Storage {
-
     // For solverLockData test
     uint256 public constant SOLVER_CALLED_BACK_MASK = _SOLVER_CALLED_BACK_MASK;
     uint256 public constant SOLVER_FULFILLED_MASK = _SOLVER_FULFILLED_MASK;
 
     constructor(
         uint256 escrowDuration,
+        uint256 atlasSurchargeRate,
+        uint256 bundlerSurchargeRate,
         address verification,
         address simulator,
         address initialSurchargeRecipient,
         address l2GasCalculator
     )
-        Storage(escrowDuration, verification, simulator, initialSurchargeRecipient, l2GasCalculator)
+        Storage(
+            escrowDuration,
+            atlasSurchargeRate,
+            bundlerSurchargeRate,
+            verification,
+            simulator,
+            initialSurchargeRecipient,
+            l2GasCalculator
+        )
     { }
 
     function setSolverOpHash(bytes32 opHash) public {

--- a/test/base/BaseTest.t.sol
+++ b/test/base/BaseTest.t.sol
@@ -51,6 +51,8 @@ contract BaseTest is Test {
     IERC20 DAI = IERC20(DAI_ADDRESS);
 
     uint256 DEFAULT_ESCROW_DURATION = 64;
+    uint256 DEFAULT_ATLAS_SURCHARGE_RATE = 1_000_000; // 10%
+    uint256 DEFAULT_BUNDLER_SURCHARGE_RATE = 1_000_000; // 10%
     uint256 MAINNET_FORK_BLOCK = 17_441_786;
 
     function setUp() public virtual {
@@ -80,6 +82,8 @@ contract BaseTest is Test {
 
         atlas = new TestAtlas({
             escrowDuration: DEFAULT_ESCROW_DURATION,
+            atlasSurchargeRate: DEFAULT_ATLAS_SURCHARGE_RATE,
+            bundlerSurchargeRate: DEFAULT_BUNDLER_SURCHARGE_RATE,
             verification: expectedAtlasVerificationAddr,
             simulator: address(simulator),
             executionTemplate: address(execEnvTemplate),

--- a/test/base/TestAtlas.sol
+++ b/test/base/TestAtlas.sol
@@ -9,13 +9,24 @@ import "src/contracts/atlas/Atlas.sol";
 contract TestAtlas is Atlas {
     constructor(
         uint256 escrowDuration,
+        uint256 atlasSurchargeRate,
+        uint256 bundlerSurchargeRate,
         address verification,
         address simulator,
         address initialSurchargeRecipient,
         address l2GasCalculator,
         address executionTemplate
     )
-        Atlas(escrowDuration, verification, simulator, initialSurchargeRecipient, l2GasCalculator, executionTemplate)
+        Atlas(
+            escrowDuration,
+            atlasSurchargeRate,
+            bundlerSurchargeRate,
+            verification,
+            simulator,
+            initialSurchargeRecipient,
+            l2GasCalculator,
+            executionTemplate
+        )
     { }
 
     // Public functions to expose internal transient helpers for testing


### PR DESCRIPTION
We may want different Atlas gas surcharge and bundler surcharge rates on different chains, as they are proportionate to the gas cost of the metacall tx. On lower gas cost chains, we'd increase these surcharges above the default {10%, 10%} settings assumed for Ethereum mainnet.

This PR allows for setting both surcharges in the constructor.

Changes to AccountingMath functions:

- `withAtlasSurcharge(uint x)` and `withBundlerSurcharge(uint x)` are now both `withSurcharge(uint x, CHOSEN_SURCHARGE_RATE)`
- `withoutAtlasSurcharge(uint x)` and `withoutBundlerSurcharge(uint x)` are now both `withoutSurcharge(uint x, CHOSEN_SURCHARGE_RATE)`
- `withAtlasAndBundlerSurcharges(uint x)` is now `withSurcharges(uint x, ATLAS_SURCHARGE_RATE, BUNDLER_SURCHARGE_RATE)`
- These changes are necessary because the rates are no longer hardcoded in the lib, and must be passed in as an arg using the immutable rate vars from Storage.sol.