### PR TITLE
feat: cap bundler surcharge if all solvers fail

### DIFF
--- a/src/contracts/libraries/AccountingMath.sol
+++ b/src/contracts/libraries/AccountingMath.sol
@@ -5,6 +5,7 @@ library AccountingMath {
     // Gas Accounting public constants
     uint256 internal constant _ATLAS_SURCHARGE_RATE = 1_000_000; // out of 10_000_000 = 10%
     uint256 internal constant _BUNDLER_SURCHARGE_RATE = 1_000_000; // out of 10_000_000 = 10%
+    uint256 internal constant _MAX_BUNDLER_REFUND_RATE = 8_000_000; // out of 10_000_000 = 80%
     uint256 internal constant _SOLVER_GAS_LIMIT_BUFFER_PERCENTAGE = 500_000; // out of 10_000_000 = 5%
     uint256 internal constant _SCALE = 10_000_000; // 10_000_000 / 10_000_000 = 100%
     uint256 internal constant _FIXED_GAS_OFFSET = 85_000;
@@ -28,6 +29,12 @@ library AccountingMath {
 
     function getAtlasPortionFromTotalSurcharge(uint256 totalSurcharge) internal pure returns (uint256 atlasSurcharge) {
         atlasSurcharge = totalSurcharge * _ATLAS_SURCHARGE_RATE / (_ATLAS_SURCHARGE_RATE + _BUNDLER_SURCHARGE_RATE);
+    }
+
+    // NOTE: This max should only be applied when there are no winning solvers.
+    // Set to 80% of the metacall gas cost, because the remaining 20% can be collected through storage refunds.
+    function maxBundlerRefund(uint256 metacallGasCost) internal pure returns (uint256 maxRefund) {
+        maxRefund = metacallGasCost * _MAX_BUNDLER_REFUND_RATE / _SCALE;
     }
 
     function solverGasLimitScaledDown(


### PR DESCRIPTION
### Summary

Bundling should not be profitable when all solvers fail. If they fail due to fault of the solver, the current accounting charges Atlas and Bundler surcharges on the gas costs of the execution of those SolverOperations. This was then distributed to Atlas and Bundler at the end of the metacall.

However, the Bundler may also collect storage refunds after bundling a metacall, which in combination with the Bundler surcharges, could result in a profitable tx (ETH spent on gas cost vs refunds and surcharges received). As such, we now cap the Bundler surcharge, only in the case of all solvers failing, to a max of 80% of the metacall gas cost. The remaining 20% may be made up through storage refunds.

If the max is exceeded, the excess is instead taken as Atlas gas surcharge.