### PR TITLE
refactor: split most of Factory out to FactoryLib

### DIFF
--- a/script/deploy-atlas.s.sol
+++ b/script/deploy-atlas.s.sol
@@ -6,6 +6,7 @@ import "forge-std/Test.sol";
 
 import { DeployBaseScript } from "./base/deploy-base.s.sol";
 
+import { FactoryLib } from "../src/contracts/atlas/FactoryLib.sol";
 import { Atlas } from "../src/contracts/atlas/Atlas.sol";
 import { AtlasVerification } from "../src/contracts/atlas/AtlasVerification.sol";
 import { TxBuilder } from "../src/contracts/helpers/TxBuilder.sol";
@@ -27,9 +28,9 @@ contract DeployAtlasScript is DeployBaseScript {
         address deployer = vm.addr(deployerPrivateKey);
 
         // Computes the addresses at which AtlasVerification will be deployed
-        address expectedAtlasAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 1);
-        address expectedAtlasVerificationAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 2);
-        address expectedSimulatorAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 3);
+        address expectedAtlasAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 2);
+        address expectedAtlasVerificationAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 3);
+        address expectedSimulatorAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 4);
 
         address prevSimAddr = _getAddressFromDeploymentsJson("SIMULATOR");
         uint256 prevSimBalance = (prevSimAddr == address(0)) ? 0 : prevSimAddr.balance;
@@ -40,13 +41,14 @@ contract DeployAtlasScript is DeployBaseScript {
         vm.startBroadcast(deployerPrivateKey);
 
         ExecutionEnvironment execEnvTemplate = new ExecutionEnvironment(expectedAtlasAddr);
+        FactoryLib factoryLib = new FactoryLib(address(execEnvTemplate));
         atlas = new Atlas({
             escrowDuration: ESCROW_DURATION,
             atlasSurchargeRate: ATLAS_SURCHARGE_RATE,
             bundlerSurchargeRate: BUNDLER_SURCHARGE_RATE,
             verification: expectedAtlasVerificationAddr,
             simulator: expectedSimulatorAddr,
-            executionTemplate: address(execEnvTemplate),
+            factoryLib: address(factoryLib),
             initialSurchargeRecipient: deployer,
             l2GasCalculator: address(0)
         });
@@ -108,6 +110,16 @@ contract DeployAtlasScript is DeployBaseScript {
         // Check Sorter address set correctly everywhere
         if (address(sorter) == address(0)) {
             console.log("ERROR: Sorter deployment address is 0x0");
+            error = true;
+        }
+        // Check FactoryLib address set correctly in Atlas
+        if (address(factoryLib) != atlas.FACTORY_LIB()) {
+            console.log("ERROR: FactoryLib address not set correctly in Atlas");
+            error = true;
+        }
+        // Check ExecutionEnvironment address set correctly in FactoryLib
+        if (address(execEnvTemplate) != factoryLib.EXECUTION_ENV_TEMPLATE()) {
+            console.log("ERROR: ExecutionEnvironment address not set correctly in FactoryLib");
             error = true;
         }
         // Check ESCROW_DURATION was not set to 0

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -34,7 +34,7 @@ contract Atlas is Escrow, Factory {
         address simulator,
         address initialSurchargeRecipient,
         address l2GasCalculator,
-        address executionTemplate
+        address factoryLib
     )
         Escrow(
             escrowDuration,
@@ -45,7 +45,7 @@ contract Atlas is Escrow, Factory {
             initialSurchargeRecipient,
             l2GasCalculator
         )
-        Factory(executionTemplate)
+        Factory(factoryLib)
     { }
 
     /// @notice metacall is the entrypoint function for the Atlas transactions.
@@ -371,7 +371,6 @@ contract Atlas is Escrow, Factory {
         uint32 callConfig
     )
         internal
-        view
         override
         returns (bool)
     {

--- a/src/contracts/atlas/Factory.sol
+++ b/src/contracts/atlas/Factory.sol
@@ -1,29 +1,19 @@
 //SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.25;
 
+import { FactoryLib } from "./FactoryLib.sol";
+
 import { IDAppControl } from "../interfaces/IDAppControl.sol";
-import { Mimic } from "../common/Mimic.sol";
 import { DAppConfig } from "../types/ConfigTypes.sol";
 import { UserOperation } from "../types/UserOperation.sol";
-import { AtlasEvents } from "../types/AtlasEvents.sol";
 import { AtlasErrors } from "../types/AtlasErrors.sol";
 
-/// @title Factory
-/// @author FastLane Labs
-/// @notice Provides functionality for creating and managing execution environments for DApps within the Atlas Protocol.
-/// @dev This contract uses deterministic deployment to generate and manage Execution Environment instances based on
-/// predefined templates.
 abstract contract Factory {
-    address public immutable EXECUTION_ENV_TEMPLATE;
+    address public immutable FACTORY_LIB;
     bytes32 internal immutable _FACTORY_BASE_SALT;
 
-    /// @notice Initializes a new Factory contract instance by setting the immutable salt for deterministic deployment
-    /// of Execution Environments and storing the execution template address.
-    /// @dev The Execution Environment Template must be separately deployed using the same calculated salt.
-    /// @param executionTemplate Address of the pre-deployed execution template contract for creating Execution
-    /// Environment instances.
-    constructor(address executionTemplate) {
-        EXECUTION_ENV_TEMPLATE = executionTemplate;
+    constructor(address factoryLib) {
+        FACTORY_LIB = factoryLib;
         _FACTORY_BASE_SALT = keccak256(abi.encodePacked(block.chainid, address(this)));
     }
 
@@ -57,7 +47,6 @@ abstract contract Factory {
         address control
     )
         external
-        view
         returns (address executionEnvironment, uint32 callConfig, bool exists)
     {
         callConfig = IDAppControl(control).CALL_CONFIG();
@@ -100,25 +89,13 @@ abstract contract Factory {
         internal
         returns (address executionEnvironment)
     {
-        bytes memory _creationCode = _getMimicCreationCode({ user: user, control: control, callConfig: callConfig });
         bytes32 _salt = _computeSalt(user, control, callConfig);
 
-        executionEnvironment = address(
-            uint160(
-                uint256(
-                    keccak256(
-                        abi.encodePacked(bytes1(0xff), address(this), _salt, keccak256(abi.encodePacked(_creationCode)))
-                    )
-                )
-            )
+        bytes memory returnData = _delegatecallFactoryLib(
+            abi.encodeCall(FactoryLib.getOrCreateExecutionEnvironment, (user, control, callConfig, _salt))
         );
 
-        if (executionEnvironment.code.length == 0) {
-            assembly {
-                executionEnvironment := create2(0, add(_creationCode, 32), mload(_creationCode), _salt)
-            }
-            emit AtlasEvents.ExecutionEnvironmentCreated(user, executionEnvironment);
-        }
+        return abi.decode(returnData, (address));
     }
 
     /// @notice Generates the address of a user's execution environment affected by deprecated callConfig changes in the
@@ -135,79 +112,28 @@ abstract contract Factory {
         uint32 callConfig
     )
         internal
-        view
         returns (address executionEnvironment)
     {
-        bytes memory _creationCode = _getMimicCreationCode({ user: user, control: control, callConfig: callConfig });
         bytes32 _salt = _computeSalt(user, control, callConfig);
 
-        executionEnvironment = address(
-            uint160(
-                uint256(
-                    keccak256(
-                        abi.encodePacked(bytes1(0xff), address(this), _salt, keccak256(abi.encodePacked(_creationCode)))
-                    )
-                )
-            )
+        bytes memory returnData = _delegatecallFactoryLib(
+            abi.encodeCall(FactoryLib.getExecutionEnvironmentCustom, (user, control, callConfig, _salt))
         );
+
+        return abi.decode(returnData, (address));
     }
 
     function _computeSalt(address user, address control, uint32 callConfig) internal view returns (bytes32) {
         return keccak256(abi.encodePacked(_FACTORY_BASE_SALT, user, control, callConfig));
     }
 
-    /// @notice Generates the creation code for the execution environment contract.
-    /// @param control The address of the DAppControl contract associated with the execution environment.
-    /// @param callConfig The configuration flags defining the behavior of the execution environment.
-    /// @param user The address of the user for whom the execution environment is being created, contributing to the
-    /// uniqueness of the creation code.
-    /// @return creationCode The bytecode representing the creation code of the execution environment contract.
-    function _getMimicCreationCode(
-        address user,
-        address control,
-        uint32 callConfig
-    )
-        internal
-        view
-        returns (bytes memory creationCode)
-    {
-        address _executionLib = EXECUTION_ENV_TEMPLATE;
-        // NOTE: Changing compiler settings or solidity versions can break this.
-        creationCode = type(Mimic).creationCode;
-
-        assembly {
-            // Insert the ExecutionEnvironment "Lib" address, into the AAAA placeholder in the creation code.
-            mstore(
-                add(creationCode, 79),
-                or(
-                    and(mload(add(creationCode, 79)), not(shl(96, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))),
-                    shl(96, _executionLib)
-                )
-            )
-
-            // Insert the user address into the BBBB placeholder in the creation code.
-            mstore(
-                add(creationCode, 111),
-                or(
-                    and(mload(add(creationCode, 111)), not(shl(96, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))),
-                    shl(96, user)
-                )
-            )
-
-            // Insert the control address into the CCCC placeholder in the creation code.
-            mstore(
-                add(creationCode, 132),
-                or(
-                    and(mload(add(creationCode, 132)), not(shl(96, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))),
-                    shl(96, control)
-                )
-            )
-
-            // Insert the callConfig into the 2222 placeholder in the creation code.
-            mstore(
-                add(creationCode, 153),
-                or(and(mload(add(creationCode, 153)), not(shl(224, 0xFFFFFFFF))), shl(224, callConfig))
-            )
+    function _delegatecallFactoryLib(bytes memory data) internal returns (bytes memory) {
+        (bool _success, bytes memory _result) = FACTORY_LIB.delegatecall(data);
+        if (!_success) {
+            assembly {
+                revert(add(_result, 32), mload(_result))
+            }
         }
+        return _result;
     }
 }

--- a/src/contracts/atlas/FactoryLib.sol
+++ b/src/contracts/atlas/FactoryLib.sol
@@ -35,6 +35,7 @@ contract FactoryLib {
         bytes32 salt
     )
         public
+        payable
         returns (address executionEnvironment)
     {
         bytes memory _creationCode = _getMimicCreationCode({ user: user, control: control, callConfig: callConfig });

--- a/src/contracts/atlas/FactoryLib.sol
+++ b/src/contracts/atlas/FactoryLib.sol
@@ -1,0 +1,145 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.25;
+
+import { Mimic } from "../common/Mimic.sol";
+import { AtlasEvents } from "../types/AtlasEvents.sol";
+
+// NOTE: Do not call these functions directly. This contract should only ever be delegatecalled by the Atlas contract.
+
+contract FactoryLib {
+    address public immutable EXECUTION_ENV_TEMPLATE;
+
+    /// @notice Initializes a new Factory contract instance by setting the immutable salt for deterministic deployment
+    /// of Execution Environments and storing the execution template address.
+    /// @dev The Execution Environment Template must be separately deployed using the same calculated salt.
+    /// @param executionTemplate Address of the pre-deployed execution template contract for creating Execution
+    /// Environment instances.
+    constructor(address executionTemplate) {
+        EXECUTION_ENV_TEMPLATE = executionTemplate;
+    }
+
+    /// @notice Deploys a new execution environment or retrieves the address of an existing one based on the DApp
+    /// control, user, and configuration.
+    /// @dev Uses the `create2` opcode for deterministic deployment, allowing the calculation of the execution
+    /// environment's address before deployment. The deployment uses a combination of the DAppControl address, user
+    /// address, call configuration, and a unique salt to ensure the uniqueness and predictability of the environment's
+    /// address.
+    /// @param user The address of the user for whom the execution environment is being set.
+    /// @param control The address of the DAppControl contract providing the operational context.
+    /// @param callConfig CallConfig settings of the DAppControl contract.
+    /// @return executionEnvironment The address of the newly created or already existing execution environment.
+    function getOrCreateExecutionEnvironment(
+        address user,
+        address control,
+        uint32 callConfig,
+        bytes32 salt
+    )
+        public
+        returns (address executionEnvironment)
+    {
+        bytes memory _creationCode = _getMimicCreationCode({ user: user, control: control, callConfig: callConfig });
+
+        executionEnvironment = address(
+            uint160(
+                uint256(
+                    keccak256(
+                        abi.encodePacked(bytes1(0xff), address(this), salt, keccak256(abi.encodePacked(_creationCode)))
+                    )
+                )
+            )
+        );
+
+        if (executionEnvironment.code.length == 0) {
+            assembly {
+                executionEnvironment := create2(0, add(_creationCode, 32), mload(_creationCode), salt)
+            }
+            emit AtlasEvents.ExecutionEnvironmentCreated(user, executionEnvironment);
+        }
+    }
+
+    /// @notice Generates the address of a user's execution environment affected by deprecated callConfig changes in the
+    /// DAppControl.
+    /// @dev Calculates the deterministic address of the execution environment based on the user, control,
+    /// callConfig, and controlCodeHash, ensuring consistency across changes in callConfig.
+    /// @param user The address of the user for whom the execution environment's address is being generated.
+    /// @param control The address of the DAppControl contract associated with the execution environment.
+    /// @param callConfig The configuration flags defining the behavior of the execution environment.
+    /// @return executionEnvironment The address of the user's execution environment.
+    function getExecutionEnvironmentCustom(
+        address user,
+        address control,
+        uint32 callConfig,
+        bytes32 salt
+    )
+        public
+        view
+        returns (address executionEnvironment)
+    {
+        bytes memory _creationCode = _getMimicCreationCode({ user: user, control: control, callConfig: callConfig });
+
+        executionEnvironment = address(
+            uint160(
+                uint256(
+                    keccak256(
+                        abi.encodePacked(bytes1(0xff), address(this), salt, keccak256(abi.encodePacked(_creationCode)))
+                    )
+                )
+            )
+        );
+    }
+
+    /// @notice Generates the creation code for the execution environment contract.
+    /// @param control The address of the DAppControl contract associated with the execution environment.
+    /// @param callConfig The configuration flags defining the behavior of the execution environment.
+    /// @param user The address of the user for whom the execution environment is being created, contributing to the
+    /// uniqueness of the creation code.
+    /// @return creationCode The bytecode representing the creation code of the execution environment contract.
+    function _getMimicCreationCode(
+        address user,
+        address control,
+        uint32 callConfig
+    )
+        internal
+        view
+        returns (bytes memory creationCode)
+    {
+        address _executionLib = EXECUTION_ENV_TEMPLATE;
+        // NOTE: Changing compiler settings or solidity versions can break this.
+        creationCode = type(Mimic).creationCode;
+
+        assembly {
+            // Insert the ExecutionEnvironment "Lib" address, into the AAAA placeholder in the creation code.
+            mstore(
+                add(creationCode, 79),
+                or(
+                    and(mload(add(creationCode, 79)), not(shl(96, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))),
+                    shl(96, _executionLib)
+                )
+            )
+
+            // Insert the user address into the BBBB placeholder in the creation code.
+            mstore(
+                add(creationCode, 111),
+                or(
+                    and(mload(add(creationCode, 111)), not(shl(96, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))),
+                    shl(96, user)
+                )
+            )
+
+            // Insert the control address into the CCCC placeholder in the creation code.
+            mstore(
+                add(creationCode, 132),
+                or(
+                    and(mload(add(creationCode, 132)), not(shl(96, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))),
+                    shl(96, control)
+                )
+            )
+
+            // Insert the callConfig into the 2222 placeholder in the creation code.
+            mstore(
+                add(creationCode, 153),
+                or(and(mload(add(creationCode, 153)), not(shl(224, 0xFFFFFFFF))), shl(224, callConfig))
+            )
+        }
+    }
+}

--- a/test/DAppIntegration.t.sol
+++ b/test/DAppIntegration.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.25;
 
 import "forge-std/Test.sol";
 
+import { FactoryLib } from "../src/contracts/atlas/FactoryLib.sol";
 import { Atlas } from "../src/contracts/atlas/Atlas.sol";
 import { ExecutionEnvironment } from "../src/contracts/common/ExecutionEnvironment.sol";
 import { DAppIntegration } from "../src/contracts/atlas/DAppIntegration.sol";
@@ -23,6 +24,7 @@ contract DAppIntegrationTest is Test {
     MockDAppIntegration public dAppIntegration;
     DummyDAppControl public dAppControl;
     AtlasVerification atlasVerification;
+    FactoryLib factoryLib;
 
     address atlasDeployer = makeAddr("atlas deployer");
     address governance = makeAddr("governance");
@@ -33,12 +35,13 @@ contract DAppIntegrationTest is Test {
         vm.startPrank(atlasDeployer);
         
         // Compute expected addresses for Atlas
-        address expectedAtlasAddr = vm.computeCreateAddress(atlasDeployer, vm.getNonce(atlasDeployer) + 2);
+        address expectedAtlasAddr = vm.computeCreateAddress(atlasDeployer, vm.getNonce(atlasDeployer) + 3);
 
         ExecutionEnvironment execEnvTemplate = new ExecutionEnvironment(expectedAtlasAddr);
 
         // Deploy the AtlasVerification contract
         atlasVerification = new AtlasVerification(expectedAtlasAddr);
+        factoryLib = new FactoryLib(address(execEnvTemplate));
 
         // Deploy the Atlas contract with correct parameters
         atlas = new Atlas({
@@ -47,7 +50,7 @@ contract DAppIntegrationTest is Test {
             bundlerSurchargeRate: DEFAULT_BUNDLER_SURCHARGE_RATE,
             verification: address(atlasVerification),
             simulator: address(0),
-            executionTemplate: address(execEnvTemplate),
+            factoryLib: address(factoryLib),
             initialSurchargeRecipient: atlasDeployer,
             l2GasCalculator: address(0)
         });

--- a/test/Factory.t.sol
+++ b/test/Factory.t.sol
@@ -6,6 +6,7 @@ import "forge-std/Test.sol";
 import { Atlas } from "../src/contracts/atlas/Atlas.sol";
 import { AtlasVerification } from "../src/contracts/atlas/AtlasVerification.sol";
 import { Factory } from "../src/contracts/atlas/Factory.sol";
+import { FactoryLib } from "../src/contracts/atlas/FactoryLib.sol";
 import { ExecutionEnvironment } from "../src/contracts/common/ExecutionEnvironment.sol";
 import { DummyDAppControl, CallConfigBuilder } from "./base/DummyDAppControl.sol";
 import { AtlasEvents } from "../src/contracts/types/AtlasEvents.sol";
@@ -15,8 +16,8 @@ import "../src/contracts/types/UserOperation.sol";
 
 import "./base/TestUtils.sol";
 
-contract MockFactory is Factory, Test {
-    constructor(address _executionTemplate) Factory(_executionTemplate) { }
+contract MockFactory is Factory {
+    constructor(address factoryLib) Factory(factoryLib) { }
 
     function getOrCreateExecutionEnvironment(UserOperation calldata userOp)
         external
@@ -32,6 +33,10 @@ contract MockFactory is Factory, Test {
     function baseSalt() external view returns (bytes32) {
         return _FACTORY_BASE_SALT;
     }
+}
+
+contract MockFactoryLib is FactoryLib {
+    constructor(address executionTemplate) FactoryLib(executionTemplate) { }
 
     function getMimicCreationCode(
         address user,
@@ -40,10 +45,10 @@ contract MockFactory is Factory, Test {
     )
         external
         view
-        returns (bytes memory creationCode) {
-            require(EXECUTION_ENV_TEMPLATE != address(0), "TEST: Execution environment template not set");
-            return _getMimicCreationCode(user, control, callConfig);
-        }
+        returns (bytes memory)
+    {
+        return _getMimicCreationCode(user, control, callConfig);
+    }
 }
 
 contract FactoryTest is Test {
@@ -53,6 +58,7 @@ contract FactoryTest is Test {
     Atlas public atlas;
     AtlasVerification public atlasVerification;
     MockFactory public mockFactory;
+    MockFactoryLib public factoryLib;
     DummyDAppControl public dAppControl;
 
     address public user;
@@ -60,42 +66,51 @@ contract FactoryTest is Test {
     function setUp() public {
         user = address(999);
         address deployer = address(333);
-        address expectedAtlasAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 0);
-        address expectedAtlasVerificationAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 1);
-        address expectedFactoryAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 2);
-        bytes32 salt = keccak256(abi.encodePacked(block.chainid, expectedFactoryAddr));
-        ExecutionEnvironment execEnvTemplate = new ExecutionEnvironment{ salt: salt }(expectedFactoryAddr);
-        
+
+        address expectedFactoryLibAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer));
+        address expectedAtlasAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 1);
+        address expectedAtlasVerificationAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 2);
+        address expectedFactoryAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 3);
+
         vm.startPrank(deployer);
+        ExecutionEnvironment execEnvTemplate = new ExecutionEnvironment(expectedFactoryAddr);
+
+        factoryLib = new MockFactoryLib(address(execEnvTemplate));
+        assertEq(address(factoryLib), expectedFactoryLibAddr, "FactoryLib address mismatch");
+
         atlas = new Atlas({
             escrowDuration: 64,
             atlasSurchargeRate: DEFAULT_ATLAS_SURCHARGE_RATE,
             bundlerSurchargeRate: DEFAULT_BUNDLER_SURCHARGE_RATE,
             verification: expectedAtlasVerificationAddr,
             simulator: address(0),
-            executionTemplate: address(execEnvTemplate),
+            factoryLib: address(factoryLib),
             initialSurchargeRecipient: deployer,
             l2GasCalculator: address(0)
         });
         assertEq(address(atlas), expectedAtlasAddr, "Atlas address mismatch");
+
         atlasVerification = new AtlasVerification(address(atlas));
         assertEq(address(atlasVerification), expectedAtlasVerificationAddr, "AtlasVerification address mismatch");
-        mockFactory = new MockFactory({ _executionTemplate: address(execEnvTemplate) });
+
+        mockFactory = new MockFactory({ factoryLib: address(factoryLib) });
         assertEq(address(mockFactory), expectedFactoryAddr, "Factory address mismatch");
+
         dAppControl = new DummyDAppControl(expectedAtlasAddr, deployer, CallConfigBuilder.allFalseCallConfig());
         vm.stopPrank();
     }
 
     function test_createExecutionEnvironment() public {
         uint32 callConfig = dAppControl.CALL_CONFIG();
-        bytes memory creationCode = mockFactory.getMimicCreationCode(user, address(dAppControl), callConfig);
+        // NOTE: getMimicCreationCode is now in FactoryLib
+        bytes memory creationCode = factoryLib.getMimicCreationCode(user, address(dAppControl), callConfig);
         address expectedExecutionEnvironment = address(
             uint160(
                 uint256(
                     keccak256(
                         abi.encodePacked(
                             bytes1(0xff),
-                            address(mockFactory),
+                            address(factoryLib),
                             mockFactory.computeSalt(user, address(dAppControl), callConfig),
                             keccak256(abi.encodePacked(creationCode))
                         )
@@ -152,7 +167,7 @@ contract FactoryTest is Test {
         assertEq(predictedEE, actualEE, "Predicted and actual EE addrs should match 2");
 
         (predictedEE,, exists) = mockFactory.getExecutionEnvironment(user, address(dAppControl));
-        
+
         assertTrue(exists, "Execution environment should exist - exist should return true");
         assertFalse(predictedEE.code.length == 0, "Execution environment should exist - code at addr");
         assertEq(predictedEE, actualEE, "Predicted and actual EE addrs should match 2");
@@ -167,6 +182,10 @@ contract FactoryTest is Test {
         uint32 _callConfig = 789;
 
         bytes32 expectedComputeSalt = keccak256(abi.encodePacked(baseSalt, _user, _control, _callConfig));
-        assertEq(expectedComputeSalt, mockFactory.computeSalt(_user, _control, _callConfig), "user salt not computed correctly - depends on base salt");
+        assertEq(
+            expectedComputeSalt,
+            mockFactory.computeSalt(_user, _control, _callConfig),
+            "user salt not computed correctly - depends on base salt"
+        );
     }
 }

--- a/test/Factory.t.sol
+++ b/test/Factory.t.sol
@@ -67,10 +67,10 @@ contract FactoryTest is Test {
         user = address(999);
         address deployer = address(333);
 
-        address expectedFactoryLibAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer));
-        address expectedAtlasAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 1);
-        address expectedAtlasVerificationAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 2);
-        address expectedFactoryAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 3);
+        address expectedFactoryLibAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 1);
+        address expectedAtlasAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 2);
+        address expectedAtlasVerificationAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 3);
+        address expectedFactoryAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 4);
 
         vm.startPrank(deployer);
         ExecutionEnvironment execEnvTemplate = new ExecutionEnvironment(expectedFactoryAddr);
@@ -110,7 +110,7 @@ contract FactoryTest is Test {
                     keccak256(
                         abi.encodePacked(
                             bytes1(0xff),
-                            address(factoryLib),
+                            address(mockFactory),
                             mockFactory.computeSalt(user, address(dAppControl), callConfig),
                             keccak256(abi.encodePacked(creationCode))
                         )

--- a/test/base/BaseTest.t.sol
+++ b/test/base/BaseTest.t.sol
@@ -5,6 +5,7 @@ import "forge-std/Test.sol";
 
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
+import { FactoryLib } from "../../src/contracts/atlas/FactoryLib.sol";
 import { TestAtlas } from "./TestAtlas.sol";
 import { AtlasVerification } from "../../src/contracts/atlas/AtlasVerification.sol";
 import { ExecutionEnvironment } from "../../src/contracts/common/ExecutionEnvironment.sol";
@@ -76,9 +77,10 @@ contract BaseTest is Test {
         simulator = new Simulator();
 
         // Computes the addresses at which AtlasVerification will be deployed
-        address expectedAtlasAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 1);
-        address expectedAtlasVerificationAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 2);
+        address expectedAtlasAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 2);
+        address expectedAtlasVerificationAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 3);
         ExecutionEnvironment execEnvTemplate = new ExecutionEnvironment(expectedAtlasAddr);
+        FactoryLib factoryLib = new FactoryLib(address(execEnvTemplate));
 
         atlas = new TestAtlas({
             escrowDuration: DEFAULT_ESCROW_DURATION,
@@ -86,7 +88,7 @@ contract BaseTest is Test {
             bundlerSurchargeRate: DEFAULT_BUNDLER_SURCHARGE_RATE,
             verification: expectedAtlasVerificationAddr,
             simulator: address(simulator),
-            executionTemplate: address(execEnvTemplate),
+            factoryLib: address(factoryLib),
             initialSurchargeRecipient: deployer,
             l2GasCalculator: address(0)
         });

--- a/test/base/TestAtlas.sol
+++ b/test/base/TestAtlas.sol
@@ -15,7 +15,7 @@ contract TestAtlas is Atlas {
         address simulator,
         address initialSurchargeRecipient,
         address l2GasCalculator,
-        address executionTemplate
+        address factoryLib
     )
         Atlas(
             escrowDuration,
@@ -25,7 +25,7 @@ contract TestAtlas is Atlas {
             simulator,
             initialSurchargeRecipient,
             l2GasCalculator,
-            executionTemplate
+            factoryLib
         )
     { }
 


### PR DESCRIPTION
Changes:

- In order to cut down Atlas contract size, we've started the contract splitting with Factory.
- Atlas is used as the endpoint contract for a lot of the external Factory functions in tests and testnet deployments, so these have been left in Factory, as well as the internal functions called inside Atlas. The salt calculation function has also be left in Atlas.
- The rest of the factory logic as been moved to FactoryLib, a new contract which is delegatecalled by Factory. FactoryLib must be explicitly deployed separately and configured as a constructor param in Atlas.
- This results in a `524 bytes` decrease in contract size.