### PR TITLE
refactor: contract size cuts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           echo "✅ Passed" >> $GITHUB_STEP_SUMMARY
 
   tests:
-    needs: ["lint", "build"]
+    needs: ["build"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,7 +5,7 @@
   block_gas_limit = 300000000
   gas_limit = 3000000000
   gas_price = 1500000000
-  solc_version = "0.8.25"
+  solc_version = "0.8.28"
   evm_version = "cancun"
   isolate = false
   gas_reports = ["Atlas", "AtlasVerification", "Simulator", "Sorter", "ExecutionEnvironment"]

--- a/script/base/deploy-base.s.sol
+++ b/script/base/deploy-base.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Script.sol";
 import "forge-std/Test.sol";

--- a/script/create-oev-demo-positions.s.sol
+++ b/script/create-oev-demo-positions.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Script.sol";
 import "forge-std/Test.sol";

--- a/script/deploy-atlas.s.sol
+++ b/script/deploy-atlas.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Script.sol";
 import "forge-std/Test.sol";

--- a/script/deploy-atlas.s.sol
+++ b/script/deploy-atlas.s.sol
@@ -6,6 +6,7 @@ import "forge-std/Test.sol";
 
 import { DeployBaseScript } from "./base/deploy-base.s.sol";
 
+import { FactoryLib } from "../src/contracts/atlas/FactoryLib.sol";
 import { Atlas } from "../src/contracts/atlas/Atlas.sol";
 import { AtlasVerification } from "../src/contracts/atlas/AtlasVerification.sol";
 import { TxBuilder } from "../src/contracts/helpers/TxBuilder.sol";
@@ -27,9 +28,9 @@ contract DeployAtlasScript is DeployBaseScript {
         address deployer = vm.addr(deployerPrivateKey);
 
         // Computes the addresses at which AtlasVerification will be deployed
-        address expectedAtlasAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 1);
-        address expectedAtlasVerificationAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 2);
-        address expectedSimulatorAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 3);
+        address expectedAtlasAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 2);
+        address expectedAtlasVerificationAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 3);
+        address expectedSimulatorAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 4);
 
         address prevSimAddr = _getAddressFromDeploymentsJson("SIMULATOR");
         uint256 prevSimBalance = (prevSimAddr == address(0)) ? 0 : prevSimAddr.balance;
@@ -40,13 +41,14 @@ contract DeployAtlasScript is DeployBaseScript {
         vm.startBroadcast(deployerPrivateKey);
 
         ExecutionEnvironment execEnvTemplate = new ExecutionEnvironment(expectedAtlasAddr);
+        FactoryLib factoryLib = new FactoryLib(address(execEnvTemplate));
         atlas = new Atlas({
             escrowDuration: ESCROW_DURATION,
             atlasSurchargeRate: ATLAS_SURCHARGE_RATE,
             bundlerSurchargeRate: BUNDLER_SURCHARGE_RATE,
             verification: expectedAtlasVerificationAddr,
             simulator: expectedSimulatorAddr,
-            executionTemplate: address(execEnvTemplate),
+            factoryLib: address(factoryLib),
             initialSurchargeRecipient: deployer,
             l2GasCalculator: address(0)
         });
@@ -108,6 +110,16 @@ contract DeployAtlasScript is DeployBaseScript {
         // Check Sorter address set correctly everywhere
         if (address(sorter) == address(0)) {
             console.log("ERROR: Sorter deployment address is 0x0");
+            error = true;
+        }
+        // Check FactoryLib address set correctly in Atlas
+        if (address(factoryLib) != atlas.FACTORY_LIB()) {
+            console.log("ERROR: FactoryLib address not set correctly in Atlas");
+            error = true;
+        }
+        // Check ExecutionEnvironment address set correctly in FactoryLib
+        if (address(execEnvTemplate) != factoryLib.EXECUTION_ENV_TEMPLATE()) {
+            console.log("ERROR: ExecutionEnvironment address not set correctly in FactoryLib");
             error = true;
         }
         // Check ESCROW_DURATION was not set to 0

--- a/script/deploy-demo-tokens.s.sol
+++ b/script/deploy-demo-tokens.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Script.sol";
 import "forge-std/Test.sol";

--- a/script/deploy-exec-env.s.sol
+++ b/script/deploy-exec-env.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Script.sol";
 import "forge-std/Test.sol";

--- a/script/deploy-fl-online-control.s.sol
+++ b/script/deploy-fl-online-control.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Script.sol";
 import "forge-std/Test.sol";

--- a/script/deploy-gas-calculator.s.sol
+++ b/script/deploy-gas-calculator.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/script/deploy-oev-demo.s.sol
+++ b/script/deploy-oev-demo.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Script.sol";
 import "forge-std/Test.sol";

--- a/script/deploy-solver.s.sol
+++ b/script/deploy-solver.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Script.sol";
 import "forge-std/Test.sol";

--- a/script/deploy-sorter.s.sol
+++ b/script/deploy-sorter.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Script.sol";
 import "forge-std/Test.sol";

--- a/script/deploy-swap-intent-control.s.sol
+++ b/script/deploy-swap-intent-control.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Script.sol";
 import "forge-std/Test.sol";

--- a/script/deploy-tx-builder.s.sol
+++ b/script/deploy-tx-builder.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Script.sol";
 import "forge-std/Test.sol";

--- a/script/deploy-v2-reward-control.s.sol
+++ b/script/deploy-v2-reward-control.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Script.sol";
 import "forge-std/Test.sol";

--- a/script/log-balances.s.sol
+++ b/script/log-balances.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Script.sol";
 import "forge-std/Test.sol";

--- a/script/mint-demo-tokens.s.sol
+++ b/script/mint-demo-tokens.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Script.sol";
 import "forge-std/Test.sol";

--- a/script/set-oev-demo-signers.s.sol
+++ b/script/set-oev-demo-signers.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Script.sol";
 import "forge-std/Test.sol";

--- a/script/solver-deposit.s.sol
+++ b/script/solver-deposit.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Script.sol";
 import "forge-std/Test.sol";

--- a/src/contracts/atlas/AtlETH.sol
+++ b/src/contracts/atlas/AtlETH.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 import { SafeCast } from "openzeppelin-contracts/contracts/utils/math/SafeCast.sol";

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -34,7 +34,7 @@ contract Atlas is Escrow, Factory {
         address simulator,
         address initialSurchargeRecipient,
         address l2GasCalculator,
-        address executionTemplate
+        address factoryLib
     )
         Escrow(
             escrowDuration,
@@ -45,7 +45,7 @@ contract Atlas is Escrow, Factory {
             initialSurchargeRecipient,
             l2GasCalculator
         )
-        Factory(executionTemplate)
+        Factory(factoryLib)
     { }
 
     /// @notice metacall is the entrypoint function for the Atlas transactions.
@@ -371,7 +371,6 @@ contract Atlas is Escrow, Factory {
         uint32 callConfig
     )
         internal
-        view
         override
         returns (bool)
     {

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 import { LibSort } from "solady/utils/LibSort.sol";

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { EIP712 } from "openzeppelin-contracts/contracts/utils/cryptography/EIP712.sol";
 import { ECDSA } from "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";

--- a/src/contracts/atlas/DAppIntegration.sol
+++ b/src/contracts/atlas/DAppIntegration.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { IDAppControl } from "../interfaces/IDAppControl.sol";
 import { IAtlas } from "../interfaces/IAtlas.sol";

--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { AtlETH } from "./AtlETH.sol";
 import { IExecutionEnvironment } from "../interfaces/IExecutionEnvironment.sol";
@@ -573,8 +573,8 @@ abstract contract Escrow is AtlETH {
         bool _success;
 
         // Set the solver lock and solver address at the beginning to ensure reliability
-        _setSolverLock(uint256(uint160(solverOp.from)));
-        _setSolverTo(solverOp.solver);
+        t_solverLock = uint256(uint160(solverOp.from));
+        t_solverTo = solverOp.solver;
 
         // ------------------------------------- //
         //             Pre-Solver Call           //

--- a/src/contracts/atlas/Factory.sol
+++ b/src/contracts/atlas/Factory.sol
@@ -1,29 +1,19 @@
 //SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.25;
 
+import { FactoryLib } from "./FactoryLib.sol";
+
 import { IDAppControl } from "../interfaces/IDAppControl.sol";
-import { Mimic } from "../common/Mimic.sol";
 import { DAppConfig } from "../types/ConfigTypes.sol";
 import { UserOperation } from "../types/UserOperation.sol";
-import { AtlasEvents } from "../types/AtlasEvents.sol";
 import { AtlasErrors } from "../types/AtlasErrors.sol";
 
-/// @title Factory
-/// @author FastLane Labs
-/// @notice Provides functionality for creating and managing execution environments for DApps within the Atlas Protocol.
-/// @dev This contract uses deterministic deployment to generate and manage Execution Environment instances based on
-/// predefined templates.
 abstract contract Factory {
-    address public immutable EXECUTION_ENV_TEMPLATE;
+    address public immutable FACTORY_LIB;
     bytes32 internal immutable _FACTORY_BASE_SALT;
 
-    /// @notice Initializes a new Factory contract instance by setting the immutable salt for deterministic deployment
-    /// of Execution Environments and storing the execution template address.
-    /// @dev The Execution Environment Template must be separately deployed using the same calculated salt.
-    /// @param executionTemplate Address of the pre-deployed execution template contract for creating Execution
-    /// Environment instances.
-    constructor(address executionTemplate) {
-        EXECUTION_ENV_TEMPLATE = executionTemplate;
+    constructor(address factoryLib) {
+        FACTORY_LIB = factoryLib;
         _FACTORY_BASE_SALT = keccak256(abi.encodePacked(block.chainid, address(this)));
     }
 
@@ -57,7 +47,6 @@ abstract contract Factory {
         address control
     )
         external
-        view
         returns (address executionEnvironment, uint32 callConfig, bool exists)
     {
         callConfig = IDAppControl(control).CALL_CONFIG();
@@ -100,25 +89,13 @@ abstract contract Factory {
         internal
         returns (address executionEnvironment)
     {
-        bytes memory _creationCode = _getMimicCreationCode({ user: user, control: control, callConfig: callConfig });
         bytes32 _salt = _computeSalt(user, control, callConfig);
 
-        executionEnvironment = address(
-            uint160(
-                uint256(
-                    keccak256(
-                        abi.encodePacked(bytes1(0xff), address(this), _salt, keccak256(abi.encodePacked(_creationCode)))
-                    )
-                )
-            )
+        bytes memory returnData = _delegatecallFactoryLib(
+            abi.encodeCall(FactoryLib.getOrCreateExecutionEnvironment, (user, control, callConfig, _salt))
         );
 
-        if (executionEnvironment.code.length == 0) {
-            assembly {
-                executionEnvironment := create2(0, add(_creationCode, 32), mload(_creationCode), _salt)
-            }
-            emit AtlasEvents.ExecutionEnvironmentCreated(user, executionEnvironment);
-        }
+        return abi.decode(returnData, (address));
     }
 
     /// @notice Generates the address of a user's execution environment affected by deprecated callConfig changes in the
@@ -135,79 +112,28 @@ abstract contract Factory {
         uint32 callConfig
     )
         internal
-        view
         returns (address executionEnvironment)
     {
-        bytes memory _creationCode = _getMimicCreationCode({ user: user, control: control, callConfig: callConfig });
         bytes32 _salt = _computeSalt(user, control, callConfig);
 
-        executionEnvironment = address(
-            uint160(
-                uint256(
-                    keccak256(
-                        abi.encodePacked(bytes1(0xff), address(this), _salt, keccak256(abi.encodePacked(_creationCode)))
-                    )
-                )
-            )
+        bytes memory returnData = _delegatecallFactoryLib(
+            abi.encodeCall(FactoryLib.getExecutionEnvironmentCustom, (user, control, callConfig, _salt))
         );
+
+        return abi.decode(returnData, (address));
     }
 
     function _computeSalt(address user, address control, uint32 callConfig) internal view returns (bytes32) {
         return keccak256(abi.encodePacked(_FACTORY_BASE_SALT, user, control, callConfig));
     }
 
-    /// @notice Generates the creation code for the execution environment contract.
-    /// @param control The address of the DAppControl contract associated with the execution environment.
-    /// @param callConfig The configuration flags defining the behavior of the execution environment.
-    /// @param user The address of the user for whom the execution environment is being created, contributing to the
-    /// uniqueness of the creation code.
-    /// @return creationCode The bytecode representing the creation code of the execution environment contract.
-    function _getMimicCreationCode(
-        address user,
-        address control,
-        uint32 callConfig
-    )
-        internal
-        view
-        returns (bytes memory creationCode)
-    {
-        address _executionLib = EXECUTION_ENV_TEMPLATE;
-        // NOTE: Changing compiler settings or solidity versions can break this.
-        creationCode = type(Mimic).creationCode;
-
-        assembly {
-            // Insert the ExecutionEnvironment "Lib" address, into the AAAA placeholder in the creation code.
-            mstore(
-                add(creationCode, 79),
-                or(
-                    and(mload(add(creationCode, 79)), not(shl(96, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))),
-                    shl(96, _executionLib)
-                )
-            )
-
-            // Insert the user address into the BBBB placeholder in the creation code.
-            mstore(
-                add(creationCode, 111),
-                or(
-                    and(mload(add(creationCode, 111)), not(shl(96, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))),
-                    shl(96, user)
-                )
-            )
-
-            // Insert the control address into the CCCC placeholder in the creation code.
-            mstore(
-                add(creationCode, 132),
-                or(
-                    and(mload(add(creationCode, 132)), not(shl(96, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))),
-                    shl(96, control)
-                )
-            )
-
-            // Insert the callConfig into the 2222 placeholder in the creation code.
-            mstore(
-                add(creationCode, 153),
-                or(and(mload(add(creationCode, 153)), not(shl(224, 0xFFFFFFFF))), shl(224, callConfig))
-            )
+    function _delegatecallFactoryLib(bytes memory data) internal returns (bytes memory) {
+        (bool _success, bytes memory _result) = FACTORY_LIB.delegatecall(data);
+        if (!_success) {
+            assembly {
+                revert(add(_result, 32), mload(_result))
+            }
         }
+        return _result;
     }
 }

--- a/src/contracts/atlas/Factory.sol
+++ b/src/contracts/atlas/Factory.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { FactoryLib } from "./FactoryLib.sol";
 

--- a/src/contracts/atlas/FactoryLib.sol
+++ b/src/contracts/atlas/FactoryLib.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { Mimic } from "../common/Mimic.sol";
 import { AtlasEvents } from "../types/AtlasEvents.sol";

--- a/src/contracts/atlas/FactoryLib.sol
+++ b/src/contracts/atlas/FactoryLib.sol
@@ -1,0 +1,146 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.25;
+
+import { Mimic } from "../common/Mimic.sol";
+import { AtlasEvents } from "../types/AtlasEvents.sol";
+
+// NOTE: Do not call these functions directly. This contract should only ever be delegatecalled by the Atlas contract.
+
+contract FactoryLib {
+    address public immutable EXECUTION_ENV_TEMPLATE;
+
+    /// @notice Initializes a new Factory contract instance by setting the immutable salt for deterministic deployment
+    /// of Execution Environments and storing the execution template address.
+    /// @dev The Execution Environment Template must be separately deployed using the same calculated salt.
+    /// @param executionTemplate Address of the pre-deployed execution template contract for creating Execution
+    /// Environment instances.
+    constructor(address executionTemplate) {
+        EXECUTION_ENV_TEMPLATE = executionTemplate;
+    }
+
+    /// @notice Deploys a new execution environment or retrieves the address of an existing one based on the DApp
+    /// control, user, and configuration.
+    /// @dev Uses the `create2` opcode for deterministic deployment, allowing the calculation of the execution
+    /// environment's address before deployment. The deployment uses a combination of the DAppControl address, user
+    /// address, call configuration, and a unique salt to ensure the uniqueness and predictability of the environment's
+    /// address.
+    /// @param user The address of the user for whom the execution environment is being set.
+    /// @param control The address of the DAppControl contract providing the operational context.
+    /// @param callConfig CallConfig settings of the DAppControl contract.
+    /// @return executionEnvironment The address of the newly created or already existing execution environment.
+    function getOrCreateExecutionEnvironment(
+        address user,
+        address control,
+        uint32 callConfig,
+        bytes32 salt
+    )
+        public
+        payable
+        returns (address executionEnvironment)
+    {
+        bytes memory _creationCode = _getMimicCreationCode({ user: user, control: control, callConfig: callConfig });
+
+        executionEnvironment = address(
+            uint160(
+                uint256(
+                    keccak256(
+                        abi.encodePacked(bytes1(0xff), address(this), salt, keccak256(abi.encodePacked(_creationCode)))
+                    )
+                )
+            )
+        );
+
+        if (executionEnvironment.code.length == 0) {
+            assembly {
+                executionEnvironment := create2(0, add(_creationCode, 32), mload(_creationCode), salt)
+            }
+            emit AtlasEvents.ExecutionEnvironmentCreated(user, executionEnvironment);
+        }
+    }
+
+    /// @notice Generates the address of a user's execution environment affected by deprecated callConfig changes in the
+    /// DAppControl.
+    /// @dev Calculates the deterministic address of the execution environment based on the user, control,
+    /// callConfig, and controlCodeHash, ensuring consistency across changes in callConfig.
+    /// @param user The address of the user for whom the execution environment's address is being generated.
+    /// @param control The address of the DAppControl contract associated with the execution environment.
+    /// @param callConfig The configuration flags defining the behavior of the execution environment.
+    /// @return executionEnvironment The address of the user's execution environment.
+    function getExecutionEnvironmentCustom(
+        address user,
+        address control,
+        uint32 callConfig,
+        bytes32 salt
+    )
+        public
+        view
+        returns (address executionEnvironment)
+    {
+        bytes memory _creationCode = _getMimicCreationCode({ user: user, control: control, callConfig: callConfig });
+
+        executionEnvironment = address(
+            uint160(
+                uint256(
+                    keccak256(
+                        abi.encodePacked(bytes1(0xff), address(this), salt, keccak256(abi.encodePacked(_creationCode)))
+                    )
+                )
+            )
+        );
+    }
+
+    /// @notice Generates the creation code for the execution environment contract.
+    /// @param control The address of the DAppControl contract associated with the execution environment.
+    /// @param callConfig The configuration flags defining the behavior of the execution environment.
+    /// @param user The address of the user for whom the execution environment is being created, contributing to the
+    /// uniqueness of the creation code.
+    /// @return creationCode The bytecode representing the creation code of the execution environment contract.
+    function _getMimicCreationCode(
+        address user,
+        address control,
+        uint32 callConfig
+    )
+        internal
+        view
+        returns (bytes memory creationCode)
+    {
+        address _executionLib = EXECUTION_ENV_TEMPLATE;
+        // NOTE: Changing compiler settings or solidity versions can break this.
+        creationCode = type(Mimic).creationCode;
+
+        assembly {
+            // Insert the ExecutionEnvironment "Lib" address, into the AAAA placeholder in the creation code.
+            mstore(
+                add(creationCode, 79),
+                or(
+                    and(mload(add(creationCode, 79)), not(shl(96, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))),
+                    shl(96, _executionLib)
+                )
+            )
+
+            // Insert the user address into the BBBB placeholder in the creation code.
+            mstore(
+                add(creationCode, 111),
+                or(
+                    and(mload(add(creationCode, 111)), not(shl(96, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))),
+                    shl(96, user)
+                )
+            )
+
+            // Insert the control address into the CCCC placeholder in the creation code.
+            mstore(
+                add(creationCode, 132),
+                or(
+                    and(mload(add(creationCode, 132)), not(shl(96, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))),
+                    shl(96, control)
+                )
+            )
+
+            // Insert the callConfig into the 2222 placeholder in the creation code.
+            mstore(
+                add(creationCode, 153),
+                or(and(mload(add(creationCode, 153)), not(shl(224, 0xFFFFFFFF))), shl(224, callConfig))
+            )
+        }
+    }
+}

--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 import { SafeCast } from "openzeppelin-contracts/contracts/utils/math/SafeCast.sol";
@@ -46,20 +46,18 @@ abstract contract GasAccounting is SafetyLocks {
         uint256 _rawClaims = (FIXED_GAS_OFFSET + gasMarker) * tx.gasprice;
 
         // Set any withdraws or deposits
-        _setClaims(_rawClaims.withSurcharge(BUNDLER_SURCHARGE_RATE));
+        t_claims = _rawClaims.withSurcharge(BUNDLER_SURCHARGE_RATE);
 
         // Atlas surcharge is based on the raw claims value.
-        _setFees(_rawClaims.getSurcharge(ATLAS_SURCHARGE_RATE));
-        _setDeposits(msg.value);
-        _setSolverSurcharge(0);
+        t_fees = _rawClaims.getSurcharge(ATLAS_SURCHARGE_RATE);
+        t_deposits = msg.value;
 
-        // Explicitly set writeoffs and withdrawals to 0 in case multiple metacalls in single tx.
-        _setWriteoffs(0);
-        _setWithdrawals(0);
-
-        // Explicitly clear solverLock and solverTo in case multiple metacalls in single tx.
-        _setSolverLock(0);
-        _setSolverTo(address(0));
+        // Explicitly set other transient vars to 0 in case multiple metacalls in single tx.
+        t_writeoffs = 0;
+        t_withdrawals = 0;
+        t_solverSurcharge = 0;
+        t_solverLock = 0;
+        t_solverTo = address(0);
 
         // The Lock slot is cleared at the end of the metacall, so no need to zero again here.
     }
@@ -100,12 +98,12 @@ abstract contract GasAccounting is SafetyLocks {
     /// @return uint256 The current shortfall amount, or 0 if there is no shortfall.
     function shortfall() external view returns (uint256) {
         uint256 _currentDeficit = _deficit();
-        uint256 _deposits = deposits();
+        uint256 _deposits = t_deposits;
         return (_currentDeficit > _deposits) ? (_currentDeficit - _deposits) : 0;
     }
 
     function _deficit() internal view returns (uint256) {
-        return claims() + withdrawals() + fees() - writeoffs();
+        return t_claims + t_withdrawals + t_fees - t_writeoffs;
     }
 
     /// @notice Allows a solver to settle any outstanding ETH owed, either to repay gas used by their solverOp or to
@@ -128,7 +126,7 @@ abstract contract GasAccounting is SafetyLocks {
         // calls directly to the solver contract in this phase, the solver should be careful to not call malicious
         // contracts which may call reconcile() on their behalf, with an excessive maxApprovedGasSpend.
         if (_phase() != uint8(ExecutionPhase.SolverOperation)) revert WrongPhase();
-        if (msg.sender != _solverTo()) revert InvalidAccess();
+        if (msg.sender != t_solverTo) revert InvalidAccess();
 
         (address _currentSolver, bool _calledBack, bool _fulfilled) = _solverLockData();
         uint256 _bondedBalance = uint256(S_accessData[_currentSolver].bonded);
@@ -137,12 +135,12 @@ abstract contract GasAccounting is SafetyLocks {
         if (maxApprovedGasSpend > _bondedBalance) maxApprovedGasSpend = _bondedBalance;
 
         uint256 _deductions = _deficit();
-        uint256 _additions = deposits() + msg.value;
+        uint256 _additions = t_deposits + msg.value;
 
         // Add msg.value to solver's deposits
         // NOTE: Surplus deposits are credited back to the Solver during settlement.
         // NOTE: This function is called inside the solver try/catch and will be undone if solver fails.
-        if (msg.value > 0) _setDeposits(_additions);
+        if (msg.value > 0) t_deposits = _additions;
 
         // CASE: Callback verified but insufficient balance
         if (_deductions > _additions + maxApprovedGasSpend) {
@@ -151,21 +149,21 @@ abstract contract GasAccounting is SafetyLocks {
                 // but it does treat any msg.value as a deposit and allows for either the solver to call back with a
                 // higher maxApprovedGasSpend or to have their deficit covered by a contribute during the postSolverOp
                 // hook.
-                _setSolverLock(uint256(uint160(_currentSolver)) | _SOLVER_CALLED_BACK_MASK);
+                t_solverLock = (uint256(uint160(_currentSolver)) | _SOLVER_CALLED_BACK_MASK);
             }
             return _deductions - _additions;
         }
 
         // CASE: Callback verified and solver duty fulfilled
         if (!_fulfilled) {
-            _setSolverLock(uint256(uint160(_currentSolver)) | _SOLVER_CALLED_BACK_MASK | _SOLVER_FULFILLED_MASK);
+            t_solverLock = (uint256(uint160(_currentSolver)) | _SOLVER_CALLED_BACK_MASK | _SOLVER_FULFILLED_MASK);
         }
         return 0;
     }
 
     /// @notice Internal function to handle ETH contribution, increasing deposits if a non-zero value is sent.
     function _contribute() internal {
-        if (msg.value != 0) _setDeposits(deposits() + msg.value);
+        if (msg.value != 0) t_deposits += msg.value;
     }
 
     /// @notice Borrows ETH from the contract, transferring the specified amount to the caller if available.
@@ -178,7 +176,7 @@ abstract contract GasAccounting is SafetyLocks {
         if (amount == 0) return true;
         if (address(this).balance < amount) return false;
 
-        _setWithdrawals(withdrawals() + amount);
+        t_withdrawals += amount;
 
         return true;
     }
@@ -221,7 +219,7 @@ abstract contract GasAccounting is SafetyLocks {
                 s_balanceOf[owner].unbonding = 0;
                 _aData.bonded = 0;
 
-                _setWriteoffs(writeoffs() + deficit);
+                t_writeoffs += deficit;
                 amount -= deficit; // Set amount equal to total to accurately track the changing bondedTotalSupply
             } else {
                 // The unbonding balance is sufficient to cover the remaining amount owed. Draw everything from the
@@ -242,7 +240,7 @@ abstract contract GasAccounting is SafetyLocks {
         S_accessData[owner] = _aData;
 
         S_bondedTotalSupply -= amount;
-        _setDeposits(deposits() + amount);
+        t_deposits += amount;
     }
 
     /// @notice Increases the owner's bonded balance by the specified amount.
@@ -264,7 +262,7 @@ abstract contract GasAccounting is SafetyLocks {
 
         // Persist changes in the _aData memory struct back to storage
         S_accessData[owner] = _aData;
-        _setWithdrawals(withdrawals() + amount);
+        t_withdrawals += amount;
     }
 
     /// @notice Accounts for the gas cost of a failed SolverOperation, either by increasing writeoffs (if the bundler is
@@ -293,7 +291,7 @@ abstract contract GasAccounting is SafetyLocks {
         if (result.bundlersFault()) {
             // CASE: Solver is not responsible for the failure of their operation, so we blame the bundler
             // and reduce the total amount refunded to the bundler
-            _setWriteoffs(writeoffs() + _gasUsed.withSurcharges(ATLAS_SURCHARGE_RATE, BUNDLER_SURCHARGE_RATE));
+            t_writeoffs += _gasUsed.withSurcharges(ATLAS_SURCHARGE_RATE, BUNDLER_SURCHARGE_RATE);
         } else {
             // CASE: Solver failed, so we calculate what they owe.
             uint256 _gasUsedWithSurcharges = _gasUsed.withSurcharges(ATLAS_SURCHARGE_RATE, BUNDLER_SURCHARGE_RATE);
@@ -308,13 +306,13 @@ abstract contract GasAccounting is SafetyLocks {
             // so that in the event of no successful solvers, any `_assign()`ed surcharges can be attributed to an
             // increase in Atlas' cumulative surcharge.
             if (_surchargesOnly > _assignDeficit) {
-                _setSolverSurcharge(solverSurcharge() + (_surchargesOnly - _assignDeficit));
+                t_solverSurcharge += (_surchargesOnly - _assignDeficit);
             }
         }
     }
 
     function _writeOffBidFindGasCost(uint256 gasUsed) internal {
-        _setWriteoffs(writeoffs() + gasUsed.withSurcharges(ATLAS_SURCHARGE_RATE, BUNDLER_SURCHARGE_RATE));
+        t_writeoffs += gasUsed.withSurcharges(ATLAS_SURCHARGE_RATE, BUNDLER_SURCHARGE_RATE);
     }
 
     /// @param ctx Context struct containing relevant context information for the Atlas auction.
@@ -344,11 +342,11 @@ abstract contract GasAccounting is SafetyLocks {
     {
         uint256 _surcharge = S_cumulativeSurcharge;
 
-        adjustedWithdrawals = withdrawals();
-        adjustedDeposits = deposits();
-        adjustedClaims = claims();
-        adjustedWriteoffs = writeoffs();
-        uint256 _fees = fees();
+        adjustedWithdrawals = t_withdrawals;
+        adjustedDeposits = t_deposits;
+        adjustedClaims = t_claims;
+        adjustedWriteoffs = t_writeoffs;
+        uint256 _fees = t_fees;
 
         uint256 _gasLeft = gasleft(); // Hold this constant for the calculations
 
@@ -368,7 +366,7 @@ abstract contract GasAccounting is SafetyLocks {
             S_cumulativeSurcharge = _surcharge + netAtlasGasSurcharge;
         } else {
             // If no successful solvers, only collect partial surcharges from solver's fault failures (if any)
-            uint256 _solverSurcharge = solverSurcharge();
+            uint256 _solverSurcharge = t_solverSurcharge;
             if (_solverSurcharge > 0) {
                 netAtlasGasSurcharge = _solverSurcharge.getPortionFromTotalSurcharge({
                     targetSurchargeRate: ATLAS_SURCHARGE_RATE,
@@ -533,6 +531,6 @@ abstract contract GasAccounting is SafetyLocks {
     /// correct.
     /// @return True if the balance is reconciled, false otherwise.
     function _isBalanceReconciled() internal view returns (bool) {
-        return deposits() >= _deficit();
+        return t_deposits >= _deficit();
     }
 }

--- a/src/contracts/atlas/NonceManager.sol
+++ b/src/contracts/atlas/NonceManager.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { AtlasConstants } from "../types/AtlasConstants.sol";
 

--- a/src/contracts/atlas/Permit69.sol
+++ b/src/contracts/atlas/Permit69.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";

--- a/src/contracts/atlas/SafetyLocks.sol
+++ b/src/contracts/atlas/SafetyLocks.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { Storage } from "./Storage.sol";
 import { CallBits } from "../libraries/CallBits.sol";

--- a/src/contracts/common/ExecutionBase.sol
+++ b/src/contracts/common/ExecutionBase.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";

--- a/src/contracts/common/ExecutionEnvironment.sol
+++ b/src/contracts/common/ExecutionEnvironment.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";

--- a/src/contracts/common/Mimic.sol
+++ b/src/contracts/common/Mimic.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 contract Mimic {
     /*

--- a/src/contracts/dapp/ControlTemplate.sol
+++ b/src/contracts/dapp/ControlTemplate.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "../types/SolverOperation.sol";
 import "../types/UserOperation.sol";

--- a/src/contracts/dapp/DAppControl.sol
+++ b/src/contracts/dapp/DAppControl.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { DAppControlTemplate } from "./ControlTemplate.sol";
 import { ExecutionBase } from "../common/ExecutionBase.sol";

--- a/src/contracts/examples/ex-post-mev-example/V2ExPost.sol
+++ b/src/contracts/examples/ex-post-mev-example/V2ExPost.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 // Base Imports
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";

--- a/src/contracts/examples/fastlane-online/BaseStorage.sol
+++ b/src/contracts/examples/fastlane-online/BaseStorage.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "../../types/SolverOperation.sol";
 

--- a/src/contracts/examples/fastlane-online/FastLaneControl.sol
+++ b/src/contracts/examples/fastlane-online/FastLaneControl.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 // Base Imports
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";

--- a/src/contracts/examples/fastlane-online/FastLaneOnlineErrors.sol
+++ b/src/contracts/examples/fastlane-online/FastLaneOnlineErrors.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 contract FastLaneOnlineErrors {
     // FastLaneControl.sol

--- a/src/contracts/examples/fastlane-online/FastLaneOnlineInner.sol
+++ b/src/contracts/examples/fastlane-online/FastLaneOnlineInner.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 // Base Imports
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";

--- a/src/contracts/examples/fastlane-online/FastLaneOnlineOuter.sol
+++ b/src/contracts/examples/fastlane-online/FastLaneOnlineOuter.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 // Base Imports
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";

--- a/src/contracts/examples/fastlane-online/FastLaneTypes.sol
+++ b/src/contracts/examples/fastlane-online/FastLaneTypes.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 // External representation of the swap intent
 struct SwapIntent {

--- a/src/contracts/examples/fastlane-online/IFastLaneOnline.sol
+++ b/src/contracts/examples/fastlane-online/IFastLaneOnline.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "../../types/UserOperation.sol";
 import "../../types/SolverOperation.sol";

--- a/src/contracts/examples/fastlane-online/OuterHelpers.sol
+++ b/src/contracts/examples/fastlane-online/OuterHelpers.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 // Base Imports
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";

--- a/src/contracts/examples/fastlane-online/SolverGateway.sol
+++ b/src/contracts/examples/fastlane-online/SolverGateway.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 // Base Imports
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";

--- a/src/contracts/examples/gas-filler/Filler.sol
+++ b/src/contracts/examples/gas-filler/Filler.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 // Base Imports
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";

--- a/src/contracts/examples/generalized-backrun/GeneralizedBackrunUserBundler.sol
+++ b/src/contracts/examples/generalized-backrun/GeneralizedBackrunUserBundler.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 // Base Imports
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";

--- a/src/contracts/examples/intents-example/StateIntent.sol
+++ b/src/contracts/examples/intents-example/StateIntent.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 // Atlas Base Imports
 import { IExecutionEnvironment } from "../../interfaces/IExecutionEnvironment.sol";

--- a/src/contracts/examples/intents-example/SwapIntentDAppControl.sol
+++ b/src/contracts/examples/intents-example/SwapIntentDAppControl.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 // Base Imports
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";

--- a/src/contracts/examples/oev-example/ChainlinkAtlasWrapper.sol
+++ b/src/contracts/examples/oev-example/ChainlinkAtlasWrapper.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { Ownable } from "openzeppelin-contracts/contracts/access/Ownable.sol";
 import { SafeERC20, IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/src/contracts/examples/oev-example/ChainlinkAtlasWrapperAlt.sol
+++ b/src/contracts/examples/oev-example/ChainlinkAtlasWrapperAlt.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { Ownable } from "openzeppelin-contracts/contracts/access/Ownable.sol";
 import { SafeERC20, IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/src/contracts/examples/oev-example/ChainlinkDAppControl.sol
+++ b/src/contracts/examples/oev-example/ChainlinkDAppControl.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { ECDSA } from "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
 import { CallConfig } from "../../types/ConfigTypes.sol";

--- a/src/contracts/examples/oev-example/ChainlinkDAppControlAlt.sol
+++ b/src/contracts/examples/oev-example/ChainlinkDAppControlAlt.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { CallConfig } from "../../types/ConfigTypes.sol";
 import "../../types/UserOperation.sol";

--- a/src/contracts/examples/oev-example/IChainlinkAtlasWrapper.sol
+++ b/src/contracts/examples/oev-example/IChainlinkAtlasWrapper.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { IChainlinkDAppControl } from "./IChainlinkDAppControl.sol";
 

--- a/src/contracts/examples/oev-example/IChainlinkDAppControl.sol
+++ b/src/contracts/examples/oev-example/IChainlinkDAppControl.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 interface IChainlinkDAppControl {
     function verifyTransmitSigners(

--- a/src/contracts/examples/trebleswap/TrebleSwapDAppControl.sol
+++ b/src/contracts/examples/trebleswap/TrebleSwapDAppControl.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";

--- a/src/contracts/examples/v2-example-router/V2RewardDAppControl.sol
+++ b/src/contracts/examples/v2-example-router/V2RewardDAppControl.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 // Base Imports
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";

--- a/src/contracts/examples/v2-example/V2DAppControl.sol
+++ b/src/contracts/examples/v2-example/V2DAppControl.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 // Base Imports
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";

--- a/src/contracts/examples/v4-example/IHooks.sol
+++ b/src/contracts/examples/v4-example/IHooks.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { IPoolManager } from "./IPoolManager.sol";
 

--- a/src/contracts/examples/v4-example/IPoolManager.sol
+++ b/src/contracts/examples/v4-example/IPoolManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { IHooks } from "./IHooks.sol";
 

--- a/src/contracts/examples/v4-example/UniV4Hook.sol
+++ b/src/contracts/examples/v4-example/UniV4Hook.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 // V4 Imports
 import { IPoolManager } from "./IPoolManager.sol";

--- a/src/contracts/examples/v4-example/V4DAppControl.sol
+++ b/src/contracts/examples/v4-example/V4DAppControl.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 // Base Imports
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";

--- a/src/contracts/gasCalculator/BaseGasCalculator.sol
+++ b/src/contracts/gasCalculator/BaseGasCalculator.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { IL2GasCalculator } from "src/contracts/interfaces/IL2GasCalculator.sol";

--- a/src/contracts/helpers/DemoLendingProtocol.sol
+++ b/src/contracts/helpers/DemoLendingProtocol.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { SafeERC20, IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import { Ownable } from "openzeppelin-contracts/contracts/access/Ownable.sol";

--- a/src/contracts/helpers/DemoToken.sol
+++ b/src/contracts/helpers/DemoToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { ERC20 } from "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import { Ownable } from "openzeppelin-contracts/contracts/access/Ownable.sol";

--- a/src/contracts/helpers/DemoWETH.sol
+++ b/src/contracts/helpers/DemoWETH.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { WETH } from "solady/tokens/WETH.sol";
 import { Ownable } from "openzeppelin-contracts/contracts/access/Ownable.sol";

--- a/src/contracts/helpers/GovernanceBurner.sol
+++ b/src/contracts/helpers/GovernanceBurner.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { IDAppControl } from "../interfaces/IDAppControl.sol";
 

--- a/src/contracts/helpers/Simulator.sol
+++ b/src/contracts/helpers/Simulator.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 

--- a/src/contracts/helpers/Sorter.sol
+++ b/src/contracts/helpers/Sorter.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { IAtlas } from "../interfaces/IAtlas.sol";
 import { IDAppControl } from "../interfaces/IDAppControl.sol";

--- a/src/contracts/helpers/TxBuilder.sol
+++ b/src/contracts/helpers/TxBuilder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { IDAppControl } from "../interfaces/IDAppControl.sol";
 import { IAtlas } from "../interfaces/IAtlas.sol";

--- a/src/contracts/helpers/Utilities.sol
+++ b/src/contracts/helpers/Utilities.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Script.sol";
 import "forge-std/Test.sol";

--- a/src/contracts/interfaces/IAtlas.sol
+++ b/src/contracts/interfaces/IAtlas.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "../types/SolverOperation.sol";
 import "../types/UserOperation.sol";

--- a/src/contracts/interfaces/IAtlasVerification.sol
+++ b/src/contracts/interfaces/IAtlasVerification.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "../types/UserOperation.sol";
 import "../types/ConfigTypes.sol";

--- a/src/contracts/interfaces/IDAppControl.sol
+++ b/src/contracts/interfaces/IDAppControl.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "../types/UserOperation.sol";
 import "../types/SolverOperation.sol";

--- a/src/contracts/interfaces/IExecutionEnvironment.sol
+++ b/src/contracts/interfaces/IExecutionEnvironment.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "../types/SolverOperation.sol";
 import "../types/UserOperation.sol";

--- a/src/contracts/interfaces/IL2GasCalculator.sol
+++ b/src/contracts/interfaces/IL2GasCalculator.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 interface IL2GasCalculator {
     /// @notice Calculate the cost of calldata in ETH on a L2 with a different fee structure than mainnet

--- a/src/contracts/interfaces/ISimulator.sol
+++ b/src/contracts/interfaces/ISimulator.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "../types/SolverOperation.sol";
 import "../types/UserOperation.sol";

--- a/src/contracts/interfaces/ISolverContract.sol
+++ b/src/contracts/interfaces/ISolverContract.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "../types/SolverOperation.sol";
 

--- a/src/contracts/libraries/AccountingMath.sol
+++ b/src/contracts/libraries/AccountingMath.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 library AccountingMath {
     uint256 internal constant _MAX_BUNDLER_REFUND_RATE = 8_000_000; // out of 10_000_000 = 80%

--- a/src/contracts/libraries/CallBits.sol
+++ b/src/contracts/libraries/CallBits.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { IDAppControl } from "../interfaces/IDAppControl.sol";
 

--- a/src/contracts/libraries/CallVerification.sol
+++ b/src/contracts/libraries/CallVerification.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "../types/SolverOperation.sol";
 import "../types/UserOperation.sol";

--- a/src/contracts/libraries/EscrowBits.sol
+++ b/src/contracts/libraries/EscrowBits.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "../types/EscrowTypes.sol";
 

--- a/src/contracts/libraries/SafeCall/SafeCall.sol
+++ b/src/contracts/libraries/SafeCall/SafeCall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 /// @title SafeCall
 /// @author FastLane Labs

--- a/src/contracts/libraries/SafetyBits.sol
+++ b/src/contracts/libraries/SafetyBits.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "../types/LockTypes.sol";
 

--- a/src/contracts/solver/SolverBase.sol
+++ b/src/contracts/solver/SolverBase.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";

--- a/src/contracts/solver/SolverBaseInvertBid.sol
+++ b/src/contracts/solver/SolverBaseInvertBid.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";

--- a/src/contracts/solver/src/TestSolver.sol
+++ b/src/contracts/solver/src/TestSolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { SolverBase } from "../../solver/SolverBase.sol";
 

--- a/src/contracts/solver/src/TestSolverExPost.sol
+++ b/src/contracts/solver/src/TestSolverExPost.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";

--- a/src/contracts/types/AtlasConstants.sol
+++ b/src/contracts/types/AtlasConstants.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "./ValidCalls.sol";
 
@@ -18,6 +18,7 @@ contract AtlasConstants {
 
     // Atlas constants used in `_bidFindingIteration()`
     uint256 internal constant _BITS_FOR_INDEX = 16;
+    uint256 internal constant _FIRST_16_BITS_TRUE_MASK = uint256(0xFFFF);
 
     // Escrow constants
     uint256 internal constant _VALIDATION_GAS_LIMIT = 500_000;
@@ -37,7 +38,7 @@ contract AtlasConstants {
     uint256 internal constant _SOLVER_FULFILLED_MASK = 1 << 162;
 
     // Used to set Lock phase without changing the activeEnvironment or callConfig.
-    bytes32 internal constant _LOCK_PHASE_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00;
+    uint256 internal constant _LOCK_PHASE_MASK = uint256(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00);
 
     // ValidCalls error threshold before which the metacall reverts, and after which it returns gracefully to store
     // nonces as used.
@@ -47,16 +48,5 @@ contract AtlasConstants {
     //               ATLAS VERIFICATION CONSTANTS              //
     // ------------------------------------------------------- //
 
-    uint256 internal constant _FULL_BITMAP = _FIRST_240_BITS_TRUE_MASK;
-    uint256 internal constant _NONCES_PER_BITMAP = 240;
     uint8 internal constant _MAX_SOLVERS = type(uint8).max - 1;
-
-    // ------------------------------------------------------- //
-    //                     SHARED CONSTANTS                    //
-    // ------------------------------------------------------- //
-
-    uint256 internal constant _FIRST_240_BITS_TRUE_MASK =
-        uint256(0x0000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF);
-    uint256 internal constant _FIRST_16_BITS_TRUE_MASK = uint256(0xFFFF);
-    uint256 internal constant _FIRST_4_BITS_TRUE_MASK = uint256(0xF);
 }

--- a/src/contracts/types/AtlasErrors.sol
+++ b/src/contracts/types/AtlasErrors.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "./ValidCalls.sol";
 

--- a/src/contracts/types/AtlasEvents.sol
+++ b/src/contracts/types/AtlasEvents.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 contract AtlasEvents {
     // Metacall

--- a/src/contracts/types/ConfigTypes.sol
+++ b/src/contracts/types/ConfigTypes.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 struct DAppConfig {
     address to; // Address of the DAppControl contract

--- a/src/contracts/types/DAppOperation.sol
+++ b/src/contracts/types/DAppOperation.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 bytes32 constant DAPP_TYPEHASH = keccak256(
     "DAppOperation(address from,address to,uint256 nonce,uint256 deadline,address control,address bundler,bytes32 userOpHash,bytes32 callChainHash)"

--- a/src/contracts/types/EscrowTypes.sol
+++ b/src/contracts/types/EscrowTypes.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 // bonded = total - unbonding
 struct EscrowAccountBalance {

--- a/src/contracts/types/LockTypes.sol
+++ b/src/contracts/types/LockTypes.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 struct Context {
     bytes32 userOpHash; // not packed

--- a/src/contracts/types/SolverOperation.sol
+++ b/src/contracts/types/SolverOperation.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 bytes32 constant SOLVER_TYPEHASH = keccak256(
     "SolverOperation(address from,address to,uint256 value,uint256 gas,uint256 maxFeePerGas,uint256 deadline,address solver,address control,bytes32 userOpHash,address bidToken,uint256 bidAmount,bytes data)"

--- a/src/contracts/types/UserOperation.sol
+++ b/src/contracts/types/UserOperation.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 // Default UserOperation typehash
 bytes32 constant USER_TYPEHASH_DEFAULT = keccak256(

--- a/src/contracts/types/ValidCalls.sol
+++ b/src/contracts/types/ValidCalls.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 /// @title ValidCallsResult
 /// @notice Enum for ValidCallsResult

--- a/test/Accounting.t.sol
+++ b/test/Accounting.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/AccountingMath.t.sol
+++ b/test/AccountingMath.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 import "../src/contracts/libraries/AccountingMath.sol";

--- a/test/AtlETH.t.sol
+++ b/test/AtlETH.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/AtlasVerification.t.sol
+++ b/test/AtlasVerification.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/BidFinding.t.sol
+++ b/test/BidFinding.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 import { LibSort } from "solady/utils/LibSort.sol";

--- a/test/DAppIntegration.t.sol
+++ b/test/DAppIntegration.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/DAppIntegration.t.sol
+++ b/test/DAppIntegration.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.25;
 
 import "forge-std/Test.sol";
 
+import { FactoryLib } from "../src/contracts/atlas/FactoryLib.sol";
 import { Atlas } from "../src/contracts/atlas/Atlas.sol";
 import { ExecutionEnvironment } from "../src/contracts/common/ExecutionEnvironment.sol";
 import { DAppIntegration } from "../src/contracts/atlas/DAppIntegration.sol";
@@ -23,6 +24,7 @@ contract DAppIntegrationTest is Test {
     MockDAppIntegration public dAppIntegration;
     DummyDAppControl public dAppControl;
     AtlasVerification atlasVerification;
+    FactoryLib factoryLib;
 
     address atlasDeployer = makeAddr("atlas deployer");
     address governance = makeAddr("governance");
@@ -33,12 +35,13 @@ contract DAppIntegrationTest is Test {
         vm.startPrank(atlasDeployer);
         
         // Compute expected addresses for Atlas
-        address expectedAtlasAddr = vm.computeCreateAddress(atlasDeployer, vm.getNonce(atlasDeployer) + 2);
+        address expectedAtlasAddr = vm.computeCreateAddress(atlasDeployer, vm.getNonce(atlasDeployer) + 3);
 
         ExecutionEnvironment execEnvTemplate = new ExecutionEnvironment(expectedAtlasAddr);
 
         // Deploy the AtlasVerification contract
         atlasVerification = new AtlasVerification(expectedAtlasAddr);
+        factoryLib = new FactoryLib(address(execEnvTemplate));
 
         // Deploy the Atlas contract with correct parameters
         atlas = new Atlas({
@@ -47,7 +50,7 @@ contract DAppIntegrationTest is Test {
             bundlerSurchargeRate: DEFAULT_BUNDLER_SURCHARGE_RATE,
             verification: address(atlasVerification),
             simulator: address(0),
-            executionTemplate: address(execEnvTemplate),
+            factoryLib: address(factoryLib),
             initialSurchargeRecipient: atlasDeployer,
             l2GasCalculator: address(0)
         });

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/ExPost.t.sol
+++ b/test/ExPost.t.sol
@@ -139,11 +139,6 @@ contract ExPostTest is BaseTest {
         address executionEnvironment = atlas.createExecutionEnvironment(userEOA, userOp.control);
         vm.label(address(executionEnvironment), "EXECUTION ENV");
 
-        console.log("userEOA", userEOA);
-        console.log("atlas", address(atlas));
-        console.log("v2 ExPost Control", address(v2ExPost));
-        console.log("executionEnvironment", executionEnvironment);
-
         // User must approve Atlas
         IERC20(TOKEN_ZERO).approve(address(atlas), type(uint256).max);
         IERC20(TOKEN_ONE).approve(address(atlas), type(uint256).max);
@@ -362,8 +357,6 @@ contract ExPostTest is BaseTest {
         (bool success,) =
             address(atlas).call(abi.encodeWithSelector(atlas.metacall.selector, userOp, solverOps, dAppOp));
         console.log("Metacall Gas Cost:", gasLeftBefore - gasleft());
-        if (success) console.log("success!");
-        else console.log("failure");
         assertTrue(success);
         vm.stopPrank();
     }

--- a/test/ExPost.t.sol
+++ b/test/ExPost.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/ExecutionBase.t.sol
+++ b/test/ExecutionBase.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/ExecutionEnvironment.t.sol
+++ b/test/ExecutionEnvironment.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 import { BaseTest } from "./base/BaseTest.t.sol";

--- a/test/FLOnline.t.sol
+++ b/test/FLOnline.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";

--- a/test/Factory.t.sol
+++ b/test/Factory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/Factory.t.sol
+++ b/test/Factory.t.sol
@@ -6,6 +6,7 @@ import "forge-std/Test.sol";
 import { Atlas } from "../src/contracts/atlas/Atlas.sol";
 import { AtlasVerification } from "../src/contracts/atlas/AtlasVerification.sol";
 import { Factory } from "../src/contracts/atlas/Factory.sol";
+import { FactoryLib } from "../src/contracts/atlas/FactoryLib.sol";
 import { ExecutionEnvironment } from "../src/contracts/common/ExecutionEnvironment.sol";
 import { DummyDAppControl, CallConfigBuilder } from "./base/DummyDAppControl.sol";
 import { AtlasEvents } from "../src/contracts/types/AtlasEvents.sol";
@@ -15,8 +16,8 @@ import "../src/contracts/types/UserOperation.sol";
 
 import "./base/TestUtils.sol";
 
-contract MockFactory is Factory, Test {
-    constructor(address _executionTemplate) Factory(_executionTemplate) { }
+contract MockFactory is Factory {
+    constructor(address factoryLib) Factory(factoryLib) { }
 
     function getOrCreateExecutionEnvironment(UserOperation calldata userOp)
         external
@@ -32,6 +33,10 @@ contract MockFactory is Factory, Test {
     function baseSalt() external view returns (bytes32) {
         return _FACTORY_BASE_SALT;
     }
+}
+
+contract MockFactoryLib is FactoryLib {
+    constructor(address executionTemplate) FactoryLib(executionTemplate) { }
 
     function getMimicCreationCode(
         address user,
@@ -40,10 +45,10 @@ contract MockFactory is Factory, Test {
     )
         external
         view
-        returns (bytes memory creationCode) {
-            require(EXECUTION_ENV_TEMPLATE != address(0), "TEST: Execution environment template not set");
-            return _getMimicCreationCode(user, control, callConfig);
-        }
+        returns (bytes memory)
+    {
+        return _getMimicCreationCode(user, control, callConfig);
+    }
 }
 
 contract FactoryTest is Test {
@@ -53,6 +58,7 @@ contract FactoryTest is Test {
     Atlas public atlas;
     AtlasVerification public atlasVerification;
     MockFactory public mockFactory;
+    MockFactoryLib public factoryLib;
     DummyDAppControl public dAppControl;
 
     address public user;
@@ -60,35 +66,44 @@ contract FactoryTest is Test {
     function setUp() public {
         user = address(999);
         address deployer = address(333);
-        address expectedAtlasAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 0);
-        address expectedAtlasVerificationAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 1);
-        address expectedFactoryAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 2);
-        bytes32 salt = keccak256(abi.encodePacked(block.chainid, expectedFactoryAddr));
-        ExecutionEnvironment execEnvTemplate = new ExecutionEnvironment{ salt: salt }(expectedFactoryAddr);
-        
+
+        address expectedFactoryLibAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 1);
+        address expectedAtlasAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 2);
+        address expectedAtlasVerificationAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 3);
+        address expectedFactoryAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 4);
+
         vm.startPrank(deployer);
+        ExecutionEnvironment execEnvTemplate = new ExecutionEnvironment(expectedFactoryAddr);
+
+        factoryLib = new MockFactoryLib(address(execEnvTemplate));
+        assertEq(address(factoryLib), expectedFactoryLibAddr, "FactoryLib address mismatch");
+
         atlas = new Atlas({
             escrowDuration: 64,
             atlasSurchargeRate: DEFAULT_ATLAS_SURCHARGE_RATE,
             bundlerSurchargeRate: DEFAULT_BUNDLER_SURCHARGE_RATE,
             verification: expectedAtlasVerificationAddr,
             simulator: address(0),
-            executionTemplate: address(execEnvTemplate),
+            factoryLib: address(factoryLib),
             initialSurchargeRecipient: deployer,
             l2GasCalculator: address(0)
         });
         assertEq(address(atlas), expectedAtlasAddr, "Atlas address mismatch");
+
         atlasVerification = new AtlasVerification(address(atlas));
         assertEq(address(atlasVerification), expectedAtlasVerificationAddr, "AtlasVerification address mismatch");
-        mockFactory = new MockFactory({ _executionTemplate: address(execEnvTemplate) });
+
+        mockFactory = new MockFactory({ factoryLib: address(factoryLib) });
         assertEq(address(mockFactory), expectedFactoryAddr, "Factory address mismatch");
+
         dAppControl = new DummyDAppControl(expectedAtlasAddr, deployer, CallConfigBuilder.allFalseCallConfig());
         vm.stopPrank();
     }
 
     function test_createExecutionEnvironment() public {
         uint32 callConfig = dAppControl.CALL_CONFIG();
-        bytes memory creationCode = mockFactory.getMimicCreationCode(user, address(dAppControl), callConfig);
+        // NOTE: getMimicCreationCode is now in FactoryLib
+        bytes memory creationCode = factoryLib.getMimicCreationCode(user, address(dAppControl), callConfig);
         address expectedExecutionEnvironment = address(
             uint160(
                 uint256(
@@ -152,7 +167,7 @@ contract FactoryTest is Test {
         assertEq(predictedEE, actualEE, "Predicted and actual EE addrs should match 2");
 
         (predictedEE,, exists) = mockFactory.getExecutionEnvironment(user, address(dAppControl));
-        
+
         assertTrue(exists, "Execution environment should exist - exist should return true");
         assertFalse(predictedEE.code.length == 0, "Execution environment should exist - code at addr");
         assertEq(predictedEE, actualEE, "Predicted and actual EE addrs should match 2");
@@ -167,6 +182,10 @@ contract FactoryTest is Test {
         uint32 _callConfig = 789;
 
         bytes32 expectedComputeSalt = keccak256(abi.encodePacked(baseSalt, _user, _control, _callConfig));
-        assertEq(expectedComputeSalt, mockFactory.computeSalt(_user, _control, _callConfig), "user salt not computed correctly - depends on base salt");
+        assertEq(
+            expectedComputeSalt,
+            mockFactory.computeSalt(_user, _control, _callConfig),
+            "user salt not computed correctly - depends on base salt"
+        );
     }
 }

--- a/test/FlashLoan.t.sol
+++ b/test/FlashLoan.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 
@@ -116,7 +116,7 @@ contract MockGasAccounting is TestAtlas, BaseTest {
     }
 
     function setSolverLock(address _solverFrom) external {
-        _setSolverLock(uint256(uint160(_solverFrom)));
+        t_solverLock = (uint256(uint160(_solverFrom)));
     }
 
     function _balanceOf(address account) external view returns (uint112, uint112) {
@@ -315,7 +315,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
 
         // Verify the balances after contribution
         assertEq(address(mockGasAccounting).balance, contributeValue);
-        assertEq(mockGasAccounting.getDeposits(), contributeValue);
+        assertEq(mockGasAccounting.deposits(), contributeValue);
     }
 
     function test_multipleContributes() public {
@@ -334,7 +334,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
 
         // Verify the balances after the first contribution
         assertEq(address(mockGasAccounting).balance, firstContributeValue);
-        assertEq(mockGasAccounting.getDeposits(), firstContributeValue);
+        assertEq(mockGasAccounting.deposits(), firstContributeValue);
 
         // Perform the second valid contribute call
         vm.prank(executionEnvironment);
@@ -342,7 +342,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
 
         // Verify the balances after the second contribution
         assertEq(address(mockGasAccounting).balance, totalContributeValue);
-        assertEq(mockGasAccounting.getDeposits(), totalContributeValue);
+        assertEq(mockGasAccounting.deposits(), totalContributeValue);
     }
 
     function test_contribute_withZeroValue() public {
@@ -358,7 +358,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
 
         // Verify the balances after the contribution is zero
         assertEq(address(mockGasAccounting).balance, contributeValue);
-        assertEq(mockGasAccounting.getDeposits(), contributeValue);
+        assertEq(mockGasAccounting.deposits(), contributeValue);
     }
 
     function test_borrow_preOpsPhase() public {
@@ -373,7 +373,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         assertEq(
             solverOneEOA.balance, borrowedAmount, "Execution environment balance should be equal to borrowed amount"
         );
-        assertEq(borrowedAmount, mockGasAccounting.getWithdrawals(), "Withdrawals should be equal to borrowed amount");
+        assertEq(borrowedAmount, mockGasAccounting.withdrawals(), "Withdrawals should be equal to borrowed amount");
     }
 
     function test_borrow_userOperationPhase() public {
@@ -390,7 +390,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
             borrowedAmount,
             "Execution environment balance should be equal to borrowed amount"
         );
-        assertEq(borrowedAmount, mockGasAccounting.getWithdrawals(), "Withdrawals should be equal to borrowed amount");
+        assertEq(borrowedAmount, mockGasAccounting.withdrawals(), "Withdrawals should be equal to borrowed amount");
     }
 
     function test_borrow_preSolverPhase() public {
@@ -407,7 +407,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
             borrowedAmount,
             "Execution environment balance should be equal to borrowed amount"
         );
-        assertEq(borrowedAmount, mockGasAccounting.getWithdrawals(), "Withdrawals should be equal to borrowed amount");
+        assertEq(borrowedAmount, mockGasAccounting.withdrawals(), "Withdrawals should be equal to borrowed amount");
     }
 
     function test_borrow_solverOperationPhase() public {
@@ -423,12 +423,12 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
             borrowedAmount,
             "Execution environment balance should be equal to borrowed amount"
         );
-        assertEq(borrowedAmount, mockGasAccounting.getWithdrawals(), "Withdrawals should be equal to borrowed amount");
+        assertEq(borrowedAmount, mockGasAccounting.withdrawals(), "Withdrawals should be equal to borrowed amount");
     }
 
     function test_borrow_postSolverPhase_reverts() public {
         uint256 borrowedAmount = 1e18;
-        uint256 withdrawalsBefore = mockGasAccounting.getWithdrawals();
+        uint256 withdrawalsBefore = mockGasAccounting.withdrawals();
         fundContract(borrowedAmount);
 
         mockGasAccounting.setLock(executionEnvironment, 0, uint8(ExecutionPhase.PostSolver));
@@ -437,12 +437,12 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         mockGasAccounting.borrow(borrowedAmount);
 
         assertEq(executionEnvironment.balance, 0, "Execution environment balance should remain zero");
-        assertEq(withdrawalsBefore, mockGasAccounting.getWithdrawals(), "Withdrawals should remain unchanged");
+        assertEq(withdrawalsBefore, mockGasAccounting.withdrawals(), "Withdrawals should remain unchanged");
     }
 
     function test_borrow_allocateValuePhase_reverts() public {
         uint256 borrowedAmount = 1e18;
-        uint256 withdrawalsBefore = mockGasAccounting.getWithdrawals();
+        uint256 withdrawalsBefore = mockGasAccounting.withdrawals();
         fundContract(borrowedAmount);
 
         mockGasAccounting.setLock(executionEnvironment, 0, uint8(ExecutionPhase.AllocateValue));
@@ -451,12 +451,12 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         mockGasAccounting.borrow(borrowedAmount);
 
         assertEq(executionEnvironment.balance, 0, "Execution environment balance should remain zero");
-        assertEq(withdrawalsBefore, mockGasAccounting.getWithdrawals(), "Withdrawals should remain unchanged");
+        assertEq(withdrawalsBefore, mockGasAccounting.withdrawals(), "Withdrawals should remain unchanged");
     }
 
     function test_borrow_postOpsPhase_reverts() public {
         uint256 borrowedAmount = 1e18;
-        uint256 withdrawalsBefore = mockGasAccounting.getWithdrawals();
+        uint256 withdrawalsBefore = mockGasAccounting.withdrawals();
         fundContract(borrowedAmount);
 
         mockGasAccounting.setLock(executionEnvironment, 0, uint8(ExecutionPhase.PostOps));
@@ -465,7 +465,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         mockGasAccounting.borrow(borrowedAmount);
 
         assertEq(executionEnvironment.balance, 0, "Execution environment balance should remain zero");
-        assertEq(withdrawalsBefore, mockGasAccounting.getWithdrawals(), "Withdrawals should remain unchanged");
+        assertEq(withdrawalsBefore, mockGasAccounting.withdrawals(), "Withdrawals should remain unchanged");
     }
 
     function test_multipleBorrows() public {
@@ -529,7 +529,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
             "Final contract balance should be initial balance minus total borrowed amount"
         );
         assertEq(
-            totalBorrowAmount, mockGasAccounting.getWithdrawals(), "Withdrawals should equal total borrowed amount"
+            totalBorrowAmount, mockGasAccounting.withdrawals(), "Withdrawals should equal total borrowed amount"
         );
     }
 
@@ -661,7 +661,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         vm.prank(executionEnvironment);
         mockGasAccounting.contribute{ value: 10 ether }();
 
-        assertEq(mockGasAccounting.getClaims(), 10 ether, "Claims should be set to 10 ether");
+        assertEq(mockGasAccounting.claims(), 10 ether, "Claims should be set to 10 ether");
         assertEq(address(mockGasAccounting).balance, 10 ether, "mockGasAccounting should have 10 ether");
     }
 
@@ -735,7 +735,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         assertEq(currentSolver, solverOneEOA, "Current solver should match execution environment");
 
         // Verify that deposits did not increase
-        assertEq(mockGasAccounting.getDeposits(), initialClaims, "Deposits should remain unchanged");
+        assertEq(mockGasAccounting.deposits(), initialClaims, "Deposits should remain unchanged");
     }
 
     function test_reconcileWithETH() public {
@@ -762,7 +762,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         assertEq(currentSolver, solverOneEOA, "Current solver should match execution environment");
 
         // Verify that deposits increased by the reconciled amount
-        assertEq(mockGasAccounting.getDeposits(), initialClaims, "Deposits should match the amount sent as msg.value");
+        assertEq(mockGasAccounting.deposits(), initialClaims, "Deposits should match the amount sent as msg.value");
     }
 
     function test_assign_zeroAmount() public {
@@ -784,7 +784,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
 
         // Get initial values
         uint256 bondedTotalSupplyBefore = mockGasAccounting.bondedTotalSupply();
-        uint256 depositsBefore = mockGasAccounting.getDeposits();
+        uint256 depositsBefore = mockGasAccounting.deposits();
 
         uint256 deficit = mockGasAccounting.assign(solverOp.from, assignedAmount, assignedAmount, true);
         assertEq(deficit, 0, "Deficit should be 0");
@@ -793,7 +793,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         assertEq(lastAccessedBlock, uint32(block.number));
 
         uint256 bondedTotalSupplyAfter = mockGasAccounting.bondedTotalSupply();
-        uint256 depositsAfter = mockGasAccounting.getDeposits();
+        uint256 depositsAfter = mockGasAccounting.deposits();
 
         assertEq(bondedTotalSupplyAfter, bondedTotalSupplyBefore - assignedAmount);
         assertEq(depositsAfter, depositsBefore + assignedAmount);
@@ -809,7 +809,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         mockGasAccounting.increaseBondedBalance(solverOp.from, bondedAmount); // Set bonded balance to 500
 
         uint256 bondedTotalSupplyBefore = mockGasAccounting.bondedTotalSupply();
-        uint256 depositsBefore = mockGasAccounting.getDeposits();
+        uint256 depositsBefore = mockGasAccounting.deposits();
 
         // Call the assign function and capture the deficit
         uint256 deficit = mockGasAccounting.assign(solverOp.from, assignedAmount, assignedAmount, true);
@@ -825,7 +825,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
             bondedTotalSupplyBefore - assignedAmount,
             "Bonded total supply mismatch"
         );
-        assertEq(mockGasAccounting.getDeposits(), depositsBefore + assignedAmount, "Deposits mismatch");
+        assertEq(mockGasAccounting.deposits(), depositsBefore + assignedAmount, "Deposits mismatch");
 
         // Retrieve and check the updated balances
         (uint112 bonded, uint112 unbonding) = mockGasAccounting._balanceOf(solverOp.from);
@@ -843,13 +843,13 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         mockGasAccounting.increaseBondedBalance(solverOp.from, bondedAmount);
 
         uint256 bondedTotalSupplyBefore = mockGasAccounting.bondedTotalSupply();
-        uint256 depositsBefore = mockGasAccounting.getDeposits();
+        uint256 depositsBefore = mockGasAccounting.deposits();
         uint256 deficit = mockGasAccounting.assign(solverOp.from, assignedAmount, assignedAmount, true);
         assertEq(deficit, assignedAmount - (unbondingAmount + bondedAmount));
         (, uint32 lastAccessedBlock,,,) = mockGasAccounting.accessData(solverOp.from);
         assertEq(lastAccessedBlock, uint32(block.number));
         assertEq(mockGasAccounting.bondedTotalSupply(), bondedTotalSupplyBefore - (unbondingAmount + bondedAmount));
-        assertEq(mockGasAccounting.getDeposits(), depositsBefore + (unbondingAmount + bondedAmount));
+        assertEq(mockGasAccounting.deposits(), depositsBefore + (unbondingAmount + bondedAmount));
         (uint112 bonded, uint112 unbonding) = mockGasAccounting._balanceOf(solverOp.from);
         assertEq(unbonding, 0);
         assertEq(bonded, 0);
@@ -912,14 +912,14 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
 
         mockGasAccounting.increaseBondedBalance(solverOp.from, bondedAmount);
         uint256 bondedTotalSupplyBefore = mockGasAccounting.bondedTotalSupply();
-        uint256 depositsBefore = mockGasAccounting.getDeposits();
+        uint256 depositsBefore = mockGasAccounting.deposits();
         (uint112 unbondingBefore,) = mockGasAccounting._balanceOf(solverOp.from);
         vm.expectRevert(AtlasErrors.ValueTooLarge.selector);
         mockGasAccounting.assign(solverOp.from, assignedAmount, assignedAmount, true);
 
         // Check assign reverted with overflow, and accounting values did not change
         assertEq(mockGasAccounting.bondedTotalSupply(), bondedTotalSupplyBefore);
-        assertEq(mockGasAccounting.getDeposits(), depositsBefore);
+        assertEq(mockGasAccounting.deposits(), depositsBefore);
         (uint112 unbonding,) = mockGasAccounting._balanceOf(solverOp.from);
         assertEq(unbonding, unbondingBefore);
     }
@@ -929,7 +929,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         uint256 lastAccessedBlock;
 
         uint256 bondedTotalSupplyBefore = mockGasAccounting.bondedTotalSupply();
-        uint256 withdrawalsBefore = mockGasAccounting.getWithdrawals();
+        uint256 withdrawalsBefore = mockGasAccounting.withdrawals();
         (uint112 bondedBefore,,,,) = mockGasAccounting.accessData(solverOp.from);
         (, lastAccessedBlock,,,) = mockGasAccounting.accessData(solverOp.from);
         assertEq(lastAccessedBlock, 0);
@@ -942,7 +942,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         assertEq(lastAccessedBlock, uint32(block.number));
         assertEq(mockGasAccounting.bondedTotalSupply(), bondedTotalSupplyBefore + creditedAmount);
         assertEq(bondedAfter, bondedBefore + uint112(creditedAmount));
-        assertEq(mockGasAccounting.getWithdrawals(), withdrawalsBefore + creditedAmount);
+        assertEq(mockGasAccounting.withdrawals(), withdrawalsBefore + creditedAmount);
 
         // Testing uint112 boundary values for casting from uint256 to uint112 in _credit()
         uint256 overflowAmount = uint256(type(uint112).max) + 1;
@@ -954,7 +954,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         // Setup
         solverOp.data = "";
         uint256 gasWaterMark = gasleft() + 5000;
-        uint256 initialWriteoffs = mockGasAccounting.getWriteoffs();
+        uint256 initialWriteoffs = mockGasAccounting.writeoffs();
 
         // Simulate solver not responsible for failure
         uint256 result = EscrowBits._NO_REFUND;
@@ -971,7 +971,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         uint256 expectedWriteoffs = initialWriteoffs + AccountingMath.withSurcharges(gasUsed, DEFAULT_ATLAS_SURCHARGE_RATE, DEFAULT_BUNDLER_SURCHARGE_RATE);
         // Verify writeoffs have increased
         assertApproxEqRel(
-            mockGasAccounting.getWriteoffs(),
+            mockGasAccounting.writeoffs(),
             expectedWriteoffs,
             1e15, // 0.1% margin for error
             "Writeoffs should be approximately equal to expected value"
@@ -1040,7 +1040,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         (uint256 claimsPaidToBundler, uint256 netGasSurcharge) = mockGasAccounting.settle(ctx);
 
         // Check final balances and perform assertions
-        uint256 finalClaims = mockGasAccounting.getClaims();
+        uint256 finalClaims = mockGasAccounting.claims();
         uint256 finalBonded = mockGasAccounting.balanceOfBonded(solverOneEOA);
         uint256 finalUnbonding = mockGasAccounting.balanceOfUnbonding(solverOneEOA);
         {
@@ -1086,7 +1086,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         assertTrue(claimsPaidToBundler > 0, "Claims paid to bundler should be non-zero");
         assertTrue(netGasSurcharge > 0, "Net gas surcharge should be non-zero");
         assertLe(
-            mockGasAccounting.getClaims(),
+            mockGasAccounting.claims(),
             3 ether,
             "Final claims should be less than or equal to initial claims plus deposits"
         );

--- a/test/MainTest.t.sol
+++ b/test/MainTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";

--- a/test/Mimic.t.sol
+++ b/test/Mimic.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 import { Mimic } from "../src/contracts/common/Mimic.sol";

--- a/test/NonceManager.t.sol
+++ b/test/NonceManager.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/OEV.t.sol
+++ b/test/OEV.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/OEValt.t.sol
+++ b/test/OEValt.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/Permit69.t.sol
+++ b/test/Permit69.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/SafetyLocks.t.sol
+++ b/test/SafetyLocks.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 
@@ -56,58 +56,58 @@ contract MockSafetyLocks is SafetyLocks {
         _setLockPhase(newPhase);
     }
 
-    function setClaims(uint256 _claims) external {
-        _setClaims(_claims);
+    function setSolverLock(uint256 newSolverLock) public {
+        t_solverLock = newSolverLock;
     }
 
-    function setWithdrawals(uint256 _withdrawals) external {
-        _setWithdrawals(_withdrawals);
+    function setSolverTo(address newSolverTo) public {
+        t_solverTo = newSolverTo;
     }
 
-    function setDeposits(uint256 _deposits) external {
-        _setDeposits(_deposits);
+    function setClaims(uint256 newClaims) public {
+        t_claims = newClaims;
     }
 
-    function setFees(uint256 _fees) external {
-        _setFees(_fees);
+    function setFees(uint256 newFees) public {
+        t_fees = newFees;
     }
 
-    function setWriteoffs(uint256 _writeoffs) external {
-        _setWriteoffs(_writeoffs);
+    function setWriteoffs(uint256 newWriteoffs) public {
+        t_writeoffs = newWriteoffs;
     }
 
-     function setSolverLock(uint256 newSolverLock) external {
-        _setSolverLock(newSolverLock);
+    function setWithdrawals(uint256 newWithdrawals) public {
+        t_withdrawals = newWithdrawals;
     }
 
-    function setSolverTo(address newSolverTo) external {
-        _setSolverTo(newSolverTo);
+    function setDeposits(uint256 newDeposits) public {
+        t_deposits = newDeposits;
+    }
+
+    // Transient Var View Functions
+
+    function claims() external view returns (uint256) {
+        return t_claims;
+    }
+
+    function fees() external view returns (uint256) {
+        return t_fees;
+    }
+
+    function writeoffs() external view returns (uint256) {
+        return t_writeoffs;
+    }
+
+    function withdrawals() external view returns (uint256) {
+        return t_withdrawals;
+    }
+
+    function deposits() external view returns (uint256) {
+        return t_deposits;
     }
 
     function solverTo() external view returns (address) {
-        return _solverTo();
-    }
-
-    // View functions
-
-    function getClaims() external view returns (uint256) {
-        return claims();
-    }
-
-    function getFees() external view returns (uint256) {
-        return fees();
-    }
-
-    function getWriteoffs() external view returns (uint256) {
-        return writeoffs();
-    }
-
-    function getWithdrawals() external view returns (uint256) {
-        return withdrawals();
-    }
-
-    function getDeposits() external view returns (uint256) {
-        return deposits();
+        return t_solverTo;
     }
 }
 
@@ -158,7 +158,7 @@ contract SafetyLocksTest is Test {
 
         safetyLocks.setClaims(newClaims);
 
-        uint256 claims = safetyLocks.getClaims();
+        uint256 claims = safetyLocks.claims();
         assertEq(claims, newClaims);
     }
 
@@ -167,7 +167,7 @@ contract SafetyLocksTest is Test {
 
         safetyLocks.setWithdrawals(newWithdrawals);
 
-        uint256 withdrawals = safetyLocks.getWithdrawals();
+        uint256 withdrawals = safetyLocks.withdrawals();
         assertEq(withdrawals, newWithdrawals);
     }
 
@@ -176,7 +176,7 @@ contract SafetyLocksTest is Test {
 
         safetyLocks.setDeposits(newDeposits);
 
-        uint256 deposits = safetyLocks.getDeposits();
+        uint256 deposits = safetyLocks.deposits();
         assertEq(deposits, newDeposits);
     }
 
@@ -185,7 +185,7 @@ contract SafetyLocksTest is Test {
 
         safetyLocks.setFees(newFees);
 
-        uint256 fees = safetyLocks.getFees();
+        uint256 fees = safetyLocks.fees();
         assertEq(fees, newFees);
     }
 
@@ -194,7 +194,7 @@ contract SafetyLocksTest is Test {
 
         safetyLocks.setWriteoffs(newWriteoffs);
 
-        uint256 writeoffs = safetyLocks.getWriteoffs();
+        uint256 writeoffs = safetyLocks.writeoffs();
         assertEq(writeoffs, newWriteoffs);
     }
 
@@ -245,11 +245,11 @@ contract SafetyLocksTest is Test {
         safetyLocks.setSolverLock(0x456);
 
         (address activeEnv, uint32 callConfig, uint8 phase) = safetyLocks.lock();
-        uint256 claims = safetyLocks.getClaims();
-        uint256 withdrawals = safetyLocks.getWithdrawals();
-        uint256 deposits = safetyLocks.getDeposits();
-        uint256 fees = safetyLocks.getFees();
-        uint256 writeoffs = safetyLocks.getWriteoffs();
+        uint256 claims = safetyLocks.claims();
+        uint256 withdrawals = safetyLocks.withdrawals();
+        uint256 deposits = safetyLocks.deposits();
+        uint256 fees = safetyLocks.fees();
+        uint256 writeoffs = safetyLocks.writeoffs();
         (address solverTo,,) = safetyLocks.solverLockData();
 
         assertEq(safetyLocks.isUnlocked(), false);

--- a/test/Simulator.t.sol
+++ b/test/Simulator.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/Sorter.t.sol
+++ b/test/Sorter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { BaseTest } from "./base/BaseTest.t.sol";
 

--- a/test/Storage.t.sol
+++ b/test/Storage.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 
@@ -228,53 +228,53 @@ contract StorageTest is BaseTest {
     }
 
     function test_storage_transient_claims() public {
-        assertEq(atlas.getClaims(), 0, "claims should start at 0");
+        assertEq(atlas.claims(), 0, "claims should start at 0");
 
         atlas.setClaims(100);
-        assertEq(atlas.getClaims(), 100, "claims should be 100");
+        assertEq(atlas.claims(), 100, "claims should be 100");
 
         atlas.clearTransientStorage();
-        assertEq(atlas.getClaims(), 0, "claims should be 0 again");
+        assertEq(atlas.claims(), 0, "claims should be 0 again");
     }
 
     function test_storage_transient_fees() public {
-        assertEq(atlas.getFees(), 0, "fees should start at 0");
+        assertEq(atlas.fees(), 0, "fees should start at 0");
 
         atlas.setFees(100);
-        assertEq(atlas.getFees(), 100, "fees should be 100");
+        assertEq(atlas.fees(), 100, "fees should be 100");
 
         atlas.clearTransientStorage();
-        assertEq(atlas.getFees(), 0, "fees should be 0 again");
+        assertEq(atlas.fees(), 0, "fees should be 0 again");
     }
 
     function test_storage_transient_writeoffs() public {
-        assertEq(atlas.getWriteoffs(), 0, "writeoffs should start at 0");
+        assertEq(atlas.writeoffs(), 0, "writeoffs should start at 0");
 
         atlas.setWriteoffs(100);
-        assertEq(atlas.getWriteoffs(), 100, "writeoffs should be 100");
+        assertEq(atlas.writeoffs(), 100, "writeoffs should be 100");
 
         atlas.clearTransientStorage();
-        assertEq(atlas.getWriteoffs(), 0, "writeoffs should be 0 again");
+        assertEq(atlas.writeoffs(), 0, "writeoffs should be 0 again");
     }
 
     function test_storage_transient_withdrawals() public {
-        assertEq(atlas.getWithdrawals(), 0, "withdrawals should start at 0");
+        assertEq(atlas.withdrawals(), 0, "withdrawals should start at 0");
 
         atlas.setWithdrawals(100);
-        assertEq(atlas.getWithdrawals(), 100, "withdrawals should be 100");
+        assertEq(atlas.withdrawals(), 100, "withdrawals should be 100");
 
         atlas.clearTransientStorage();
-        assertEq(atlas.getWithdrawals(), 0, "withdrawals should be 0 again");
+        assertEq(atlas.withdrawals(), 0, "withdrawals should be 0 again");
     }
 
     function test_storage_transient_deposits() public {
-        assertEq(atlas.getDeposits(), 0, "deposits should start at 0");
+        assertEq(atlas.deposits(), 0, "deposits should start at 0");
 
         atlas.setDeposits(100);
-        assertEq(atlas.getDeposits(), 100, "deposits should be 100");
+        assertEq(atlas.deposits(), 100, "deposits should be 100");
 
         atlas.clearTransientStorage();
-        assertEq(atlas.getDeposits(), 0, "deposits should be 0 again");
+        assertEq(atlas.deposits(), 0, "deposits should be 0 again");
     }
 
     function test_storage_transient_solverTo() public {
@@ -391,11 +391,11 @@ contract MockStorage is Storage {
     // For internal view functions without external versions
 
     function solverTo() public view returns (address) {
-        return _solverTo();
+        return t_solverTo;
     }
 
     function setSolverTo(address newSolverTo) public {
-        _setSolverTo(newSolverTo);
+        t_solverTo = newSolverTo;
     }
 
     function activeEnvironment() public view returns (address) {
@@ -418,34 +418,13 @@ contract MockStorage is Storage {
     // To clear all transient storage vars
     function clearTransientStorage() public {
         _setLock(address(0), 0, 0);
-        _setSolverLock(0);
-        _setSolverTo(address(0));
-        _setClaims(0);
-        _setFees(0);
-        _setWriteoffs(0);
-        _setWithdrawals(0);
-        _setDeposits(0);
-    }
-
-    // View functions
-
-    function getClaims() external view returns (uint256) {
-        return claims();
-    }
-
-    function getFees() external view returns (uint256) {
-        return fees();
-    }
-
-    function getWriteoffs() external view returns (uint256) {
-        return writeoffs();
-    }
-
-    function getWithdrawals() external view returns (uint256) {
-        return withdrawals();
-    }
-
-    function getDeposits() external view returns (uint256) {
-        return deposits();
+        t_solverLock = 0;
+        t_solverTo = address(0);
+        t_claims = 0;
+        t_fees = 0;
+        t_writeoffs = 0;
+        t_withdrawals = 0;
+        t_deposits = 0;
+        t_solverSurcharge = 0;
     }
 }

--- a/test/Surcharge.t.sol
+++ b/test/Surcharge.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 import { BaseTest } from "./base/BaseTest.t.sol";

--- a/test/SwapIntent.t.sol
+++ b/test/SwapIntent.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/SwapIntentInvertBid.t.sol
+++ b/test/SwapIntentInvertBid.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";

--- a/test/TrebleSwap.t.sol
+++ b/test/TrebleSwap.t.sol
@@ -117,7 +117,7 @@ contract TrebleSwapTest is BaseTest {
         _doMetacallAndChecks({ winningSolver: address(0) });
     }
 
-    function testTrebleSwap_Metacall_Erc20ToErc20_OneSolver() public {
+    function testTrebleSwap_Metacall_Erc20ToErc20_OneSolver_GasCheck() public {
         // Tx: https://basescan.org/tx/0x0ef4a9c24bbede2b39e12f5e5417733fa8183f372e41ee099c2c7523064c1b55
         // Swaps 197.2 USDC for at least 198,080,836.0295 WUF
 
@@ -199,7 +199,7 @@ contract TrebleSwapTest is BaseTest {
         _doMetacallAndChecks({ winningSolver: address(0) });
     }
 
-    function testTrebleSwap_Metacall_EthToErc20_OneSolver() public {
+    function testTrebleSwap_Metacall_EthToErc20_OneSolver_GasCheck() public {
         // Tx: https://basescan.org/tx/0xe138def4155bea056936038b9374546a366828ab8bf1233056f9e2fe4c6af999
         // Swaps 0.123011147164483512 ETH for at least 307.405807527716546728 DAI
 
@@ -300,6 +300,9 @@ contract TrebleSwapTest is BaseTest {
         // Estimate gas surcharge Atlas should have taken
         txGasUsed = estAtlasGasSurcharge - gasleft();
         estAtlasGasSurcharge = txGasUsed * tx.gasprice * atlas.ATLAS_SURCHARGE_RATE() / atlas.SCALE();
+
+        // For benchmarking
+        console.log("Metacall gas cost: ", txGasUsed);
 
         // Check Atlas auctionWon return value
         assertEq(auctionWon, auctionWonExpected, "auctionWon not as expected");

--- a/test/TrebleSwap.t.sol
+++ b/test/TrebleSwap.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/V2Helper.sol
+++ b/test/V2Helper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { TxBuilder } from "../src/contracts/helpers/TxBuilder.sol";
 

--- a/test/V2Helper.sol
+++ b/test/V2Helper.sol
@@ -59,12 +59,6 @@ contract V2Helper is Test, TxBuilder {
     {
         (uint256 token0Balance, uint256 token1Balance) = _getTradeAmtAndDirection(firstPool, secondPool, tokenIn);
 
-        console.log("-");
-        console.log("sell token", tokenIn);
-        console.log("token0 in ", token0Balance);
-        console.log("token1 in ", token1Balance);
-        console.log("-");
-
         return TxBuilder.buildUserOperation(
             from, firstPool, maxFeePerGas, 0, block.number + 2, buildV2SwapCalldata(token0Balance, token1Balance, from)
         );

--- a/test/V2RewardDAppControl.t.sol
+++ b/test/V2RewardDAppControl.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/base/ArbitrageTest.t.sol
+++ b/test/base/ArbitrageTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/base/BaseTest.t.sol
+++ b/test/base/BaseTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/base/BaseTest.t.sol
+++ b/test/base/BaseTest.t.sol
@@ -5,6 +5,7 @@ import "forge-std/Test.sol";
 
 import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
+import { FactoryLib } from "../../src/contracts/atlas/FactoryLib.sol";
 import { TestAtlas } from "./TestAtlas.sol";
 import { AtlasVerification } from "../../src/contracts/atlas/AtlasVerification.sol";
 import { ExecutionEnvironment } from "../../src/contracts/common/ExecutionEnvironment.sol";
@@ -76,9 +77,10 @@ contract BaseTest is Test {
         simulator = new Simulator();
 
         // Computes the addresses at which AtlasVerification will be deployed
-        address expectedAtlasAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 1);
-        address expectedAtlasVerificationAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 2);
+        address expectedAtlasAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 2);
+        address expectedAtlasVerificationAddr = vm.computeCreateAddress(deployer, vm.getNonce(deployer) + 3);
         ExecutionEnvironment execEnvTemplate = new ExecutionEnvironment(expectedAtlasAddr);
+        FactoryLib factoryLib = new FactoryLib(address(execEnvTemplate));
 
         atlas = new TestAtlas({
             escrowDuration: DEFAULT_ESCROW_DURATION,
@@ -86,7 +88,7 @@ contract BaseTest is Test {
             bundlerSurchargeRate: DEFAULT_BUNDLER_SURCHARGE_RATE,
             verification: expectedAtlasVerificationAddr,
             simulator: address(simulator),
-            executionTemplate: address(execEnvTemplate),
+            factoryLib: address(factoryLib),
             initialSurchargeRecipient: deployer,
             l2GasCalculator: address(0)
         });

--- a/test/base/DummyDAppControl.sol
+++ b/test/base/DummyDAppControl.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { DAppControl } from "../../src/contracts/dapp/DAppControl.sol";
 

--- a/test/base/GasSponsorDAppControl.sol
+++ b/test/base/GasSponsorDAppControl.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { DAppControl } from "../../src/contracts/dapp/DAppControl.sol";
 import { IAtlas } from "../../src/contracts/interfaces/IAtlas.sol";

--- a/test/base/TestAtlas.sol
+++ b/test/base/TestAtlas.sol
@@ -15,7 +15,7 @@ contract TestAtlas is Atlas {
         address simulator,
         address initialSurchargeRecipient,
         address l2GasCalculator,
-        address executionTemplate
+        address factoryLib
     )
         Atlas(
             escrowDuration,
@@ -25,7 +25,7 @@ contract TestAtlas is Atlas {
             simulator,
             initialSurchargeRecipient,
             l2GasCalculator,
-            executionTemplate
+            factoryLib
         )
     { }
 

--- a/test/base/TestAtlas.sol
+++ b/test/base/TestAtlas.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "../../src/contracts/atlas/Atlas.sol";
 
@@ -33,13 +33,14 @@ contract TestAtlas is Atlas {
 
     function clearTransientStorage() public {
         _setLock(address(0), 0, 0);
-        _setSolverLock(0);
-        _setSolverTo(address(0));
-        _setClaims(0);
-        _setFees(0);
-        _setWriteoffs(0);
-        _setWithdrawals(0);
-        _setDeposits(0);
+        t_solverLock = 0;
+        t_solverTo = address(0);
+        t_claims = 0;
+        t_fees = 0;
+        t_writeoffs = 0;
+        t_withdrawals = 0;
+        t_deposits = 0;
+        t_solverSurcharge = 0;
     }
 
     function setLock(address activeEnvironment, uint32 callConfig, uint8 phase) public {
@@ -51,52 +52,52 @@ contract TestAtlas is Atlas {
     }
 
     function setSolverLock(uint256 newSolverLock) public {
-        _setSolverLock(newSolverLock);
+        t_solverLock = newSolverLock;
     }
 
     function setSolverTo(address newSolverTo) public {
-        _setSolverTo(newSolverTo);
+        t_solverTo = newSolverTo;
     }
 
     function setClaims(uint256 newClaims) public {
-        _setClaims(newClaims);
+        t_claims = newClaims;
     }
 
     function setFees(uint256 newFees) public {
-        _setFees(newFees);
+        t_fees = newFees;
     }
 
     function setWriteoffs(uint256 newWriteoffs) public {
-        _setWriteoffs(newWriteoffs);
+        t_writeoffs = newWriteoffs;
     }
 
     function setWithdrawals(uint256 newWithdrawals) public {
-        _setWithdrawals(newWithdrawals);
+        t_withdrawals = newWithdrawals;
     }
 
     function setDeposits(uint256 newDeposits) public {
-        _setDeposits(newDeposits);
+        t_deposits = newDeposits;
     }
 
-    // View functions
+    // Transient Var View Functions
 
-    function getClaims() external view returns (uint256) {
-        return claims();
+    function claims() external view returns (uint256) {
+        return t_claims;
     }
 
-    function getFees() external view returns (uint256) {
-        return fees();
+    function fees() external view returns (uint256) {
+        return t_fees;
     }
 
-    function getWriteoffs() external view returns (uint256) {
-        return writeoffs();
+    function writeoffs() external view returns (uint256) {
+        return t_writeoffs;
     }
 
-    function getWithdrawals() external view returns (uint256) {
-        return withdrawals();
+    function withdrawals() external view returns (uint256) {
+        return t_withdrawals;
     }
 
-    function getDeposits() external view returns (uint256) {
-        return deposits();
+    function deposits() external view returns (uint256) {
+        return t_deposits;
     }
 }

--- a/test/base/TestUtils.sol
+++ b/test/base/TestUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { IDAppControl } from "../../src/contracts/interfaces/IDAppControl.sol";
 import { Mimic } from "../../src/contracts/common/Mimic.sol";

--- a/test/base/builders/DAppOperationBuilder.sol
+++ b/test/base/builders/DAppOperationBuilder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/base/builders/SolverOperationBuilder.sol
+++ b/test/base/builders/SolverOperationBuilder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/base/builders/UserOperationBuilder.sol
+++ b/test/base/builders/UserOperationBuilder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/base/interfaces/IUniswapV2Router.sol
+++ b/test/base/interfaces/IUniswapV2Router.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 interface IUniswapV2Router01 {
     function factory() external pure returns (address);

--- a/test/helpers/CallConfigBuilder.sol
+++ b/test/helpers/CallConfigBuilder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { CallConfig } from "../../src/contracts/types/ConfigTypes.sol";
 

--- a/test/helpers/DummyDAppControlBuilder.sol
+++ b/test/helpers/DummyDAppControlBuilder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import { DummyDAppControl } from "../base/DummyDAppControl.sol";
 import { CallConfig } from "../../src/contracts/types/ConfigTypes.sol";

--- a/test/libraries/CallBits.t.sol
+++ b/test/libraries/CallBits.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/libraries/CallVerification.t.sol
+++ b/test/libraries/CallVerification.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/libraries/EscrowBits.t.sol
+++ b/test/libraries/EscrowBits.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 

--- a/test/libraries/SafetyBits.t.sol
+++ b/test/libraries/SafetyBits.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity 0.8.28;
 
 import "forge-std/Test.sol";
 


### PR DESCRIPTION
### Changes (detailed changes in each sub-PR below):

- #443 
- #442 

### Size Diffs

| Contract    | Before  | After  | Diff  |
|-------------|---------|--------|-------|
| Atlas.sol       | 25,526  | 24,188 | -1,338|

The net effect on contract size is that Atlas.sol is `388 bytes` under the limit, which should be enough room for the additional logic needed in the Arbitrum version.

### Gas Diffs

| Test                                                   | Before  | After  | Diff |
|--------------------------------------------------------|---------|--------|------|
| Atlas Swap Intent with Basic RFQ                       | 382,733  | 384,088 | +1,355 |
| Ex Post Ordering                                       | 1,287,743 | 1,289,789| +2,046 |
| Chainlink OEV Standard Version                         | 434,115  | 436,573 | +2,458 |
| Treble Swap Metacall ERC20 to ERC20 with One Solver    | 677,597  | 681,346 | +3,749 |
| Treble Swap Metacall ETH to ERC20 with One Solver      | 543,766  | 546,031 | +2,265 |

Gas costs increased slightly (~0.5%), mostly due to the `delegatecall` overhead needed any time a Factory.sol function is called.