### PR TITLE
fix: userOp graceful return gas offset

### DIFF
--- a/src/contracts/types/AtlasConstants.sol
+++ b/src/contracts/types/AtlasConstants.sol
@@ -23,6 +23,7 @@ contract AtlasConstants {
     // Escrow constants
     uint256 internal constant _VALIDATION_GAS_LIMIT = 500_000;
     uint256 internal constant _FASTLANE_GAS_BUFFER = 125_000; // integer amount
+    uint256 internal constant _GRACEFUL_RETURN_GAS_OFFSET = 40_000;
 
     // Gas Accounting constants
     uint256 internal constant _CALLDATA_LENGTH_PREMIUM = 32; // 16 (default) * 2
@@ -38,7 +39,8 @@ contract AtlasConstants {
     uint256 internal constant _SOLVER_FULFILLED_MASK = 1 << 162;
 
     // Used to set Lock phase without changing the activeEnvironment or callConfig.
-    uint256 internal constant _LOCK_PHASE_MASK = uint256(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00);
+    uint256 internal constant _LOCK_PHASE_MASK =
+        uint256(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00);
 
     // ValidCalls error threshold before which the metacall reverts, and after which it returns gracefully to store
     // nonces as used.

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -221,6 +221,33 @@ contract EscrowTest is BaseTest {
         assertTrue(auctionWon, "2nd auction should have been won");
     }
 
+    function test_executeUserOperation_gracefullyReturnsWhenUserOpOOG() public {
+        // userOp.gas should be more than ceiling calculated in _executeUserOperation()
+        uint256 userGasLim = 500_000;
+        uint256 metacallGasLim = 300_000; // will trigger use of userOp gas ceiling
+
+        defaultAtlasWithCallConfig(defaultCallConfig().build());
+        UserOperation memory userOp = validUserOperation(address(dAppControl))
+            .withData(
+                abi.encodeWithSelector(
+                    dAppControl.burnEntireGasLimit.selector)
+            ).withGas(userGasLim)
+            .signAndBuild(address(atlasVerification), userPK);
+        deal(address(dummySolver), defaultBidAmount);
+        SolverOperation[] memory solverOps = new SolverOperation[](1);
+        solverOps[0] = validSolverOperation(userOp)
+            .withBidAmount(defaultBidAmount)
+            .withData(abi.encode(1))
+            .signAndBuild(address(atlasVerification), solverOnePK);
+        DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).build();
+
+        // Send msg.value so it must be sent back, testing the upper bound of remaining gas for graceful return 
+        deal(userEOA, 1 ether);
+        vm.prank(userEOA);
+        bool auctionWon = atlas.metacall{gas: metacallGasLim, value: 1 ether}(userOp, solverOps, dappOp);
+        assertEq(auctionWon, false, "call should not revert but auction should not be won either");
+    }
+
     // Ensure metacall reverts with the proper error when the allocateValue hook reverts.
     function test_executeAllocateValueCall_failure_SkipCoverage() public {
         defaultAtlasWithCallConfig(

--- a/test/base/DummyDAppControl.sol
+++ b/test/base/DummyDAppControl.sol
@@ -118,6 +118,14 @@ contract DummyDAppControl is DAppControl {
         return returnValue;
     }
 
+    // Used to use all gas available during a call to get OOG error.
+    function burnEntireGasLimit() public {
+        uint256 _uselessSum;
+        while (true) {
+            _uselessSum += uint256(keccak256(abi.encodePacked(_uselessSum, gasleft()))) / 1e18;
+        }
+    }
+
     // Revert settings
 
     function setPreOpsShouldRevert(bool _preOpsShouldRevert) public {


### PR DESCRIPTION
Changes:

- Ensures that even if `userOp.gas` limit is larger than metacall's entire gas limit, and all gas is burnt, the effective userOp gas limit is reduced to retain enough gas to safely refund the bundler any msg.value sent and return gracefully to persist any storage changes e.g. user nonces.
- `_GRACEFUL_RETURN_GAS_OFFSET` set conservatively as `40_000`, but tested to work with as low as `38_000`.