### PR TITLE
feat: add `userOpFailed` hook

### DIFF
--- a/src/contracts/atlas/SafetyLocks.sol
+++ b/src/contracts/atlas/SafetyLocks.sol
@@ -89,4 +89,29 @@ abstract contract SafetyLocks is Storage {
             callDepth: 0
         });
     }
+
+    function _buildUserOpFailedContext(
+        address executionEnvironment,
+        address bundler,
+        bool isSimulation
+    )
+        internal
+        pure
+        returns (Context memory)
+    {
+        return Context({
+            executionEnvironment: executionEnvironment,
+            userOpHash: bytes32(0),
+            bundler: bundler,
+            solverSuccessful: false,
+            paymentsSuccessful: false,
+            solverIndex: 0,
+            solverCount: 0,
+            phase: uint8(ExecutionPhase.UserOpFailed),
+            solverOutcome: 0,
+            bidFind: false,
+            isSimulation: isSimulation,
+            callDepth: 0
+        });
+    }
 }

--- a/src/contracts/common/ExecutionEnvironment.sol
+++ b/src/contracts/common/ExecutionEnvironment.sol
@@ -86,6 +86,15 @@ contract ExecutionEnvironment is Base {
         }
     }
 
+    function userOpFailedWrapper(UserOperation calldata userOp) external onlyAtlasEnvironment {
+        bytes memory _data = _forward(abi.encodeCall(IDAppControl.userOpFailedCall, userOp));
+        bool _success;
+
+        (_success,) = _control().delegatecall(_data);
+
+        if (!_success) revert AtlasErrors.UserOpFailedWrapperDelegatecallFail();
+    }
+
     /// @notice The postOpsWrapper function may be called by Atlas as the last phase of a `metacall` transaction.
     /// @dev This contract is called by the Atlas contract, and delegatecalls the DAppControl contract via the
     /// corresponding `postOpsCall` function.

--- a/src/contracts/dapp/ControlTemplate.sol
+++ b/src/contracts/dapp/ControlTemplate.sol
@@ -62,6 +62,28 @@ abstract contract DAppControlTemplate {
     function _checkUserOperation(UserOperation memory) internal virtual { }
 
     /////////////////////////////////////////////////////////
+    //         USER OPERATION FAILED                       //
+    /////////////////////////////////////////////////////////
+    //
+    // UserOpFailedHook:
+    // Data should be decoded as:
+    //
+    //     bytes memory userOpData
+    //
+
+    // _userOpFailedCall
+    // Details:
+    //  userOpFailed/delegate =
+    //      Inputs: User's calldata
+    //      Function: Executing the function set by DAppControl
+    //      Container: Inside of the FastLane ExecutionEnvironment
+    //      Access: With storage access (read + write) only to the ExecutionEnvironment
+    //
+    // DApp exposure: Trustless
+    // User exposure: Trustless
+    function _userOpFailedCall(UserOperation calldata) internal virtual { }
+
+    /////////////////////////////////////////////////////////
     //                MEV ALLOCATION                       //
     /////////////////////////////////////////////////////////
     //

--- a/src/contracts/dapp/DAppControl.sol
+++ b/src/contracts/dapp/DAppControl.sol
@@ -77,6 +77,17 @@ abstract contract DAppControl is DAppControlTemplate, ExecutionBase {
         return _preOpsCall(userOp);
     }
 
+    /// @notice The userOpFailed hook which is called if the UserOperation fails, before the metacall tx ends.
+    /// @param userOp The UserOperation struct.
+    function userOpFailedCall(UserOperation calldata userOp)
+        external
+        validControl
+        onlyAtlasEnvironment
+        onlyPhase(ExecutionPhase.UserOpFailed)
+    {
+        _userOpFailedCall(userOp);
+    }
+
     /// @notice The preSolverCall hook which may be called before the SolverOperation is executed.
     /// @dev Should revert if any DApp-specific checks fail to indicate non-fulfillment.
     /// @param solverOp The SolverOperation to be executed after this hook has been called.

--- a/src/contracts/interfaces/IDAppControl.sol
+++ b/src/contracts/interfaces/IDAppControl.sol
@@ -16,6 +16,8 @@ interface IDAppControl {
 
     function allocateValueCall(address bidToken, uint256 bidAmount, bytes calldata data) external;
 
+    function userOpFailedCall(UserOperation calldata userOp) external;
+
     function getDAppConfig(UserOperation calldata userOp) external view returns (DAppConfig memory dConfig);
 
     function getCallConfig() external view returns (CallConfig memory callConfig);

--- a/src/contracts/interfaces/IExecutionEnvironment.sol
+++ b/src/contracts/interfaces/IExecutionEnvironment.sol
@@ -11,6 +11,8 @@ interface IExecutionEnvironment {
 
     function userWrapper(UserOperation calldata userOp) external payable returns (bytes memory userReturnData);
 
+    function userOpFailedWrapper(UserOperation calldata userOp) external;
+
     function postOpsWrapper(bool solved, bytes calldata returnData) external;
 
     function solverPreTryCatch(

--- a/src/contracts/types/AtlasErrors.sol
+++ b/src/contracts/types/AtlasErrors.sol
@@ -38,6 +38,7 @@ contract AtlasErrors {
     error SolverSimFail(uint256 solverOutcomeResult); // uint param is result returned in `verifySolverOp`
     error AllocateValueSimFail();
     error PostOpsSimFail();
+    error UserOpFailedHookSimFail();
     error ValidCalls(ValidCallsResult);
 
     // Execution Environment
@@ -51,6 +52,7 @@ contract AtlasErrors {
     error PostOpsDelegatecallFail();
     error PostOpsDelegatecallReturnedFalse();
     error AllocateValueDelegatecallFail();
+    error UserOpFailedWrapperDelegatecallFail();
     error NotEnvironmentOwner();
     error ExecutionEnvironmentBalanceTooLow();
 
@@ -60,6 +62,7 @@ contract AtlasErrors {
     // error SolverFail(); // Only sim version of err is used
     error AllocateValueFail();
     error PostOpsFail();
+    error UserOpFailedHookFail();
     error InvalidAccess();
 
     // Escrow

--- a/src/contracts/types/LockTypes.sol
+++ b/src/contracts/types/LockTypes.sol
@@ -25,5 +25,6 @@ enum ExecutionPhase {
     PostSolver,
     AllocateValue,
     PostOps,
+    UserOpFailed,
     FullyLocked
 }


### PR DESCRIPTION
### Changes:

- When a metacall fails due to the UserOperation call reverting with the `UserOpFail` error, the rest of the hooks are skipped, and Atlas executes an additional `UserOpFailed` hook.
- The `UserOpFailed` hook is called on the DAppControl, and includes the `UserOperation memory userOp` parameter as well as the relevant properties available via the appended packed `Context` var. DAppControls can implement this hook in the same way other hooks are implemented.
- The execution of the new `UserOpFailed` hook happens in the `catch` block of the `metacall` function. This means that any accounting changes that would have occured in `_settle()` are skipped.
- If the `UserOpFailed` hook reverts, the entire metacall will always revert. 


### To Do:

- Set gas limit for `UserOpFailed` hook - maybe specified in dAppOp.
- Add `needsUserOpFailedHook()` setting to `CallConfig` to make this new call conditional.
- Enforce `needsUserOpFailedHook()` and `allowsReuseUserOps()` settings are mutually exclusive.
- Check new errors are handled correctly in Simulator.
- Tests