### PR TITLE
feat: add `bidAmount` to `SolverTxResult` event

### DIFF
--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -206,7 +206,7 @@ abstract contract Escrow is AtlETH {
 
                 if (_result.executionSuccessful()) {
                     // First successful solver call that paid what it bid
-                    emit SolverTxResult(solverOp.solver, solverOp.from, true, true, _result);
+                    emit SolverTxResult(solverOp.solver, solverOp.from, true, true, _result, bidAmount);
 
                     ctx.solverSuccessful = true;
                     ctx.solverOutcome = uint24(_result);
@@ -221,7 +221,7 @@ abstract contract Escrow is AtlETH {
         // Account for failed SolverOperation gas costs
         _handleSolverAccounting(solverOp, _gasWaterMark, _result, !prevalidated);
 
-        emit SolverTxResult(solverOp.solver, solverOp.from, _result.executedWithError(), false, _result);
+        emit SolverTxResult(solverOp.solver, solverOp.from, _result.executedWithError(), false, _result, bidAmount);
 
         return 0;
     }

--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -206,7 +206,9 @@ abstract contract Escrow is AtlETH {
 
                 if (_result.executionSuccessful()) {
                     // First successful solver call that paid what it bid
-                    emit SolverTxResult(solverOp.solver, solverOp.from, true, true, _result, bidAmount);
+                    emit SolverTxResult(
+                        solverOp.solver, solverOp.from, true, true, _result, bidAmount, solverOp.bidToken
+                    );
 
                     ctx.solverSuccessful = true;
                     ctx.solverOutcome = uint24(_result);
@@ -221,7 +223,9 @@ abstract contract Escrow is AtlETH {
         // Account for failed SolverOperation gas costs
         _handleSolverAccounting(solverOp, _gasWaterMark, _result, !prevalidated);
 
-        emit SolverTxResult(solverOp.solver, solverOp.from, _result.executedWithError(), false, _result, bidAmount);
+        emit SolverTxResult(
+            solverOp.solver, solverOp.from, _result.executedWithError(), false, _result, bidAmount, solverOp.bidToken
+        );
 
         return 0;
     }

--- a/src/contracts/types/AtlasEvents.sol
+++ b/src/contracts/types/AtlasEvents.sol
@@ -21,7 +21,12 @@ contract AtlasEvents {
 
     // Escrow events
     event SolverTxResult(
-        address indexed solverTo, address indexed solverFrom, bool executed, bool success, uint256 result
+        address indexed solverTo,
+        address indexed solverFrom,
+        bool executed,
+        bool success,
+        uint256 result,
+        uint256 bidAmount
     );
 
     // Factory events

--- a/src/contracts/types/AtlasEvents.sol
+++ b/src/contracts/types/AtlasEvents.sol
@@ -26,7 +26,8 @@ contract AtlasEvents {
         bool executed,
         bool success,
         uint256 result,
-        uint256 bidAmount
+        uint256 bidAmount,
+        address bidToken
     );
 
     // Factory events

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -41,11 +41,6 @@ contract EscrowTest is BaseTest {
     uint256 private constant _SOLVER_GAS_BUFFER = 5; // out of 100
     uint256 private constant _FASTLANE_GAS_BUFFER = 125_000; // integer amount
 
-    event MEVPaymentSuccess(address bidToken, uint256 bidAmount);
-    event SolverTxResult(
-        address indexed solverTo, address indexed solverFrom, bool executed, bool success, uint256 result
-    );
-
     function defaultCallConfig() public returns (CallConfigBuilder) {
         return new CallConfigBuilder();
     }
@@ -662,7 +657,14 @@ contract EscrowTest is BaseTest {
         DAppOperation memory dappOp = validDAppOperation(userOp, solverOps).build();
 
         vm.expectEmit(false, false, false, true, address(atlas));
-        emit SolverTxResult(solverOps[0].solver, solverOps[0].from, solverOpExecuted, solverOpSuccess, expectedResult);
+        emit AtlasEvents.SolverTxResult(
+            solverOps[0].solver,
+            solverOps[0].from,
+            solverOpExecuted,
+            solverOpSuccess,
+            expectedResult,
+            solverOps[0].bidAmount
+        );
 
         vm.prank(userEOA);
         if (metacallShouldRevert) vm.expectRevert(); // Metacall should revert, the reason isn't important, we're only checking the event

--- a/test/Escrow.t.sol
+++ b/test/Escrow.t.sol
@@ -663,7 +663,8 @@ contract EscrowTest is BaseTest {
             solverOpExecuted,
             solverOpSuccess,
             expectedResult,
-            solverOps[0].bidAmount
+            solverOps[0].bidAmount,
+            solverOps[0].bidToken
         );
 
         vm.prank(userEOA);

--- a/test/FlashLoan.t.sol
+++ b/test/FlashLoan.t.sol
@@ -110,7 +110,7 @@ contract FlashLoanTest is BaseTest {
         vm.startPrank(userEOA);
         vm.expectEmit(true, true, true, true);
         uint256 result = (1 << uint256(SolverOutcome.BidNotPaid));
-        emit AtlasEvents.SolverTxResult(address(solver), solverOneEOA, true, false, result);
+        emit AtlasEvents.SolverTxResult(address(solver), solverOneEOA, true, false, result, solverOps[0].bidAmount);
         vm.expectRevert();
         atlas.metacall({ userOp: userOp, solverOps: solverOps, dAppOp: dAppOp });
         vm.stopPrank();
@@ -153,7 +153,7 @@ contract FlashLoanTest is BaseTest {
         vm.expectEmit(true, true, true, true);
         result = (1 << uint256(SolverOutcome.CallValueTooHigh));
         console.log("result", result);
-        emit AtlasEvents.SolverTxResult(address(solver), solverOneEOA, false, false, result);
+        emit AtlasEvents.SolverTxResult(address(solver), solverOneEOA, false, false, result, solverOps[0].bidAmount);
         vm.expectRevert();
         atlas.metacall({ userOp: userOp, solverOps: solverOps, dAppOp: dAppOp });
         vm.stopPrank();
@@ -213,7 +213,7 @@ contract FlashLoanTest is BaseTest {
         vm.startPrank(userEOA);
         result = 0;
         vm.expectEmit(true, true, true, true);
-        emit AtlasEvents.SolverTxResult(_solver, solverOneEOA, true, true, result);
+        emit AtlasEvents.SolverTxResult(_solver, solverOneEOA, true, true, result, solverOps[0].bidAmount);
         atlas.metacall({ userOp: userOp, solverOps: solverOps, dAppOp: dAppOp });
         vm.stopPrank();
 


### PR DESCRIPTION
### Changes:

- Adds the solver's `bidAmount` and `bidToken` to the SolverTxResult event, which is emitted for each failed or successful solverOp that is attempted in a metacall. 

### Contract Size Impact:

| Contract | Before | After | Diff |
|----------|--------|-------|------|
| Atlas    | 24,227 | 24,304|  +77  |

### Gas Cost Impact

| Test                                                | Before   | After   | Diff |
|-----------------------------------------------------|----------|---------|------|
| Atlas Swap Intent with Basic RFQ                    | 384,317  | 385,098 | 781  |
| Ex Post Ordering                                    | 1,290,018| 1,290,799 | 781  |
| Chainlink OEV Standard Version                      | 436,802  | 437,583 | 781  |
| Treble Swap Metacall ERC20 to ERC20 with One Solver | 681,575  | 682,356 | 781  |
| Treble Swap Metacall ETH to ERC20 with One Solver   | 546,260  | 547,041 | 781  |