### PR TITLE
fix: gas model fixes

### DIFF
--- a/script/base/deploy-base.s.sol
+++ b/script/base/deploy-base.s.sol
@@ -74,8 +74,8 @@ contract DeployBaseScript is Script {
         uint256 chainId = block.chainid;
         if (chainId == 137 || chainId == 80_002) {
             // POLYGON and AMOY
-            atlasSurchargeRate = 5_000_000; // 50%
-            bundlerSurchargeRate = 5_000_000; // 50%
+            atlasSurchargeRate = 500_000; // 5%
+            bundlerSurchargeRate = 2_000_000; // 20%
         } else {
             // Default - for all other chains
             atlasSurchargeRate = 1_000_000; // 10%

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -67,7 +67,7 @@ contract Atlas is Escrow, Factory {
         returns (bool auctionWon)
     {
         uint256 _gasMarker = L2_GAS_CALCULATOR == address(0)
-            ? gasleft() + _BASE_TRANSACTION_GAS_USED + (msg.data.length * _CALLDATA_LENGTH_PREMIUM)
+            ? gasleft() + _BASE_TRANSACTION_GAS_USED + (msg.data.length * _CALLDATA_LENGTH_PREMIUM_HALVED)
             : gasleft() + IL2GasCalculator(L2_GAS_CALCULATOR).initialGasUsed(msg.data.length);
 
         bool _isSimulation = msg.sender == SIMULATOR;

--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -521,7 +521,7 @@ abstract contract GasAccounting is SafetyLocks {
         if (L2_GAS_CALCULATOR == address(0)) {
             // Default to using mainnet gas calculations
             // _SOLVER_OP_BASE_CALLDATA = SolverOperation calldata length excluding solverOp.data
-            calldataCost = (calldataLength + _SOLVER_OP_BASE_CALLDATA) * _CALLDATA_LENGTH_PREMIUM * tx.gasprice;
+            calldataCost = (calldataLength + _SOLVER_OP_BASE_CALLDATA) * _CALLDATA_LENGTH_PREMIUM_HALVED * tx.gasprice;
         } else {
             calldataCost =
                 IL2GasCalculator(L2_GAS_CALCULATOR).getCalldataCost(calldataLength + _SOLVER_OP_BASE_CALLDATA);

--- a/src/contracts/gasCalculator/BaseGasCalculator.sol
+++ b/src/contracts/gasCalculator/BaseGasCalculator.sol
@@ -12,7 +12,7 @@ interface IGasPriceOracle {
 }
 
 contract BaseGasCalculator is IL2GasCalculator, Ownable {
-    uint256 internal constant _CALLDATA_LENGTH_PREMIUM = 16;
+    uint256 internal constant _CALLDATA_LENGTH_PREMIUM_HALVED = 8;
     uint256 internal constant _BASE_TRANSACTION_GAS_USED = 21_000;
 
     address public immutable GAS_PRICE_ORACLE;
@@ -31,7 +31,7 @@ contract BaseGasCalculator is IL2GasCalculator, Ownable {
         // bytes, *not calldata length only*, which makes this function a rough estimate.
 
         // Base execution cost.
-        calldataCost = calldataLength * _CALLDATA_LENGTH_PREMIUM * tx.gasprice;
+        calldataCost = calldataLength * _CALLDATA_LENGTH_PREMIUM_HALVED * tx.gasprice;
 
         // L1 data cost.
         // `getL1FeeUpperBound` adds 68 to the size because it expects an unsigned transaction size.
@@ -55,7 +55,7 @@ contract BaseGasCalculator is IL2GasCalculator, Ownable {
     /// @notice Gets the cost of initial gas used for a transaction with a different calldata fee than mainnet
     /// @param calldataLength The length of the calldata in bytes
     function initialGasUsed(uint256 calldataLength) external pure override returns (uint256 gasUsed) {
-        return _BASE_TRANSACTION_GAS_USED + (calldataLength * _CALLDATA_LENGTH_PREMIUM);
+        return _BASE_TRANSACTION_GAS_USED + (calldataLength * _CALLDATA_LENGTH_PREMIUM_HALVED);
     }
 
     /// @notice Sets the calldata length offset

--- a/src/contracts/helpers/Sorter.sol
+++ b/src/contracts/helpers/Sorter.sol
@@ -81,7 +81,7 @@ contract Sorter is AtlasConstants {
             AccountingMath.solverGasLimitScaledDown(solverOp.gas, dConfig.solverGasLimit) + _FASTLANE_GAS_BUFFER;
 
         uint256 calldataCost =
-            (solverOp.data.length + _SOLVER_OP_BASE_CALLDATA) * _CALLDATA_LENGTH_PREMIUM * solverOp.maxFeePerGas;
+            (solverOp.data.length + _SOLVER_OP_BASE_CALLDATA) * _CALLDATA_LENGTH_PREMIUM_HALVED * solverOp.maxFeePerGas;
         uint256 gasCost = (solverOp.maxFeePerGas * gasLimit) + calldataCost;
         if (solverBalance < gasCost) {
             return false;

--- a/src/contracts/libraries/AccountingMath.sol
+++ b/src/contracts/libraries/AccountingMath.sol
@@ -5,7 +5,7 @@ library AccountingMath {
     uint256 internal constant _MAX_BUNDLER_REFUND_RATE = 8_000_000; // out of 10_000_000 = 80%
     uint256 internal constant _SOLVER_GAS_LIMIT_BUFFER_PERCENTAGE = 500_000; // out of 10_000_000 = 5%
     uint256 internal constant _SCALE = 10_000_000; // 10_000_000 / 10_000_000 = 100%
-    uint256 internal constant _FIXED_GAS_OFFSET = 85_000;
+    uint256 internal constant _FIXED_GAS_OFFSET = 120_000;
 
     function withSurcharge(uint256 amount, uint256 surchargeRate) internal pure returns (uint256 adjustedAmount) {
         adjustedAmount = amount * (_SCALE + surchargeRate) / _SCALE;

--- a/src/contracts/types/AtlasConstants.sol
+++ b/src/contracts/types/AtlasConstants.sol
@@ -26,7 +26,9 @@ contract AtlasConstants {
     uint256 internal constant _GRACEFUL_RETURN_GAS_OFFSET = 40_000;
 
     // Gas Accounting constants
-    uint256 internal constant _CALLDATA_LENGTH_PREMIUM = 32; // 16 (default) * 2
+    uint256 internal constant _CALLDATA_LENGTH_PREMIUM_HALVED = 8; // Half of the upper gas cost per byte of calldata
+        // (16 gas). Multiplied by msg.data.length. Equivalent to `msg.data.length / 2 * 16` because 2 hex chars per
+        // byte.
     uint256 internal constant _BASE_TRANSACTION_GAS_USED = 21_000;
     uint256 internal constant _SOLVER_OP_BASE_CALLDATA = 608; // SolverOperation calldata length excluding solverOp.data
     uint256 internal constant _SOLVER_BASE_GAS_USED = 5000; // Base gas charged to solver in `_handleSolverAccounting()`

--- a/test/FLOnline.t.sol
+++ b/test/FLOnline.t.sol
@@ -52,7 +52,7 @@ contract FastLaneOnlineTest is BaseTest {
     }
 
     // Only Atlas surcharge kept if all fail, bundler surcharge paid to bundler
-    uint256 constant SURCHARGE_PER_SOLVER_IF_ALL_FAIL = 14_000e9; // 14k Gwei (avg, differs for ERC20/native in/out)
+    uint256 constant SURCHARGE_PER_SOLVER_IF_ALL_FAIL = 12_000e9; // 12k Gwei (avg, differs for ERC20/native in/out)
     uint256 constant ERR_MARGIN = 0.22e18; // 22% error margin
     address internal constant NATIVE_TOKEN = address(0);
 

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -162,8 +162,8 @@ contract MockGasAccounting is TestAtlas, BaseTest {
         return _activeEnvironment();
     }
 
-    function getCalldataLengthPremium() external pure returns (uint256) {
-        return _CALLDATA_LENGTH_PREMIUM;
+    function getCalldataLengthPremiumHalved() external pure returns (uint256) {
+        return _CALLDATA_LENGTH_PREMIUM_HALVED;
     }
 
     function getContractGasPrice() external view returns (uint256) {

--- a/test/Storage.t.sol
+++ b/test/Storage.t.sol
@@ -12,7 +12,7 @@ contract StorageTest is BaseTest {
     using stdStorage for StdStorage;
 
     uint256 constant DEFAULT_SCALE = 10_000_000; // out of 10_000_000 = 100%
-    uint256 constant DEFAULT_FIXED_GAS_OFFSET = 85_000;
+    uint256 constant DEFAULT_FIXED_GAS_OFFSET = 120_000;
 
     function setUp() public override {
         super.setUp();


### PR DESCRIPTION
Changes:

- Lower calldata gas cost estimation to 16 gas per byte (2 hex chars per byte)
- Increase FIXED_GAS_OFFSET from 85k to 120k gas
- Lower Atlas gas surcharge from 50% to 5% on Polygon
- Lower Bundler gas surcharge from 50% to 20% on Polygon