### PR TITLE
feat: make surcharges settable

### DIFF
--- a/src/contracts/atlas/AtlETH.sol
+++ b/src/contracts/atlas/AtlETH.sol
@@ -251,9 +251,7 @@ abstract contract AtlETH is Permit69 {
     /// @dev This function can only be called by the current surcharge recipient.
     /// It transfers the accumulated surcharge amount to the surcharge recipient's address.
     function withdrawSurcharge() external {
-        if (msg.sender != S_surchargeRecipient) {
-            revert InvalidAccess();
-        }
+        _onlySurchargeRecipient();
 
         uint256 _paymentAmount = S_cumulativeSurcharge;
         S_cumulativeSurcharge = 0; // Clear before transfer to prevent reentrancy
@@ -268,10 +266,9 @@ abstract contract AtlETH is Permit69 {
     /// If the caller is not the current surcharge recipient, it reverts with an `InvalidAccess` error.
     /// @param newRecipient The address of the new surcharge recipient.
     function transferSurchargeRecipient(address newRecipient) external {
+        _onlySurchargeRecipient();
+
         address _surchargeRecipient = S_surchargeRecipient;
-        if (msg.sender != _surchargeRecipient) {
-            revert InvalidAccess();
-        }
 
         S_pendingSurchargeRecipient = newRecipient;
         emit SurchargeRecipientTransferStarted(_surchargeRecipient, newRecipient);

--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -49,7 +49,7 @@ abstract contract GasAccounting is SafetyLocks {
         t_claims = _rawClaims.withSurcharge(BUNDLER_SURCHARGE_RATE);
 
         // Atlas surcharge is based on the raw claims value.
-        t_fees = _rawClaims.getSurcharge(ATLAS_SURCHARGE_RATE);
+        t_fees = _rawClaims.getSurcharge(S_atlasSurchargeRate);
         t_deposits = msg.value;
 
         // Explicitly set other transient vars to 0 in case multiple metacalls in single tx.
@@ -288,10 +288,10 @@ abstract contract GasAccounting is SafetyLocks {
         if (result.bundlersFault()) {
             // CASE: Solver is not responsible for the failure of their operation, so we blame the bundler
             // and reduce the total amount refunded to the bundler
-            t_writeoffs += _gasUsed.withSurcharges(ATLAS_SURCHARGE_RATE, BUNDLER_SURCHARGE_RATE);
+            t_writeoffs += _gasUsed.withSurcharges(S_atlasSurchargeRate, BUNDLER_SURCHARGE_RATE);
         } else {
             // CASE: Solver failed, so we calculate what they owe.
-            uint256 _gasUsedWithSurcharges = _gasUsed.withSurcharges(ATLAS_SURCHARGE_RATE, BUNDLER_SURCHARGE_RATE);
+            uint256 _gasUsedWithSurcharges = _gasUsed.withSurcharges(S_atlasSurchargeRate, BUNDLER_SURCHARGE_RATE);
             uint256 _surchargesOnly = _gasUsedWithSurcharges - _gasUsed;
 
             // In `_assign()`, the failing solver's bonded AtlETH balance is reduced by `_gasUsedWithSurcharges`. Any
@@ -309,7 +309,7 @@ abstract contract GasAccounting is SafetyLocks {
     }
 
     function _writeOffBidFindGasCost(uint256 gasUsed) internal {
-        t_writeoffs += gasUsed.withSurcharges(ATLAS_SURCHARGE_RATE, BUNDLER_SURCHARGE_RATE);
+        t_writeoffs += gasUsed.withSurcharges(S_atlasSurchargeRate, BUNDLER_SURCHARGE_RATE);
     }
 
     /// @param ctx Context struct containing relevant context information for the Atlas auction.
@@ -358,7 +358,7 @@ abstract contract GasAccounting is SafetyLocks {
             // be offset by any gas surcharge paid by failed solvers, which would have been added to deposits or
             // writeoffs in _handleSolverAccounting(). As such, the winning solver does not pay for surcharge on the gas
             // used by other solvers.
-            netAtlasGasSurcharge = _fees - _gasRemainder.getSurcharge(ATLAS_SURCHARGE_RATE);
+            netAtlasGasSurcharge = _fees - _gasRemainder.getSurcharge(S_atlasSurchargeRate);
             adjustedWithdrawals += netAtlasGasSurcharge;
             S_cumulativeSurcharge = _surcharge + netAtlasGasSurcharge;
         } else {
@@ -366,8 +366,8 @@ abstract contract GasAccounting is SafetyLocks {
             uint256 _solverSurcharge = t_solverSurcharge;
             if (_solverSurcharge > 0) {
                 netAtlasGasSurcharge = _solverSurcharge.getPortionFromTotalSurcharge({
-                    targetSurchargeRate: ATLAS_SURCHARGE_RATE,
-                    totalSurchargeRate: ATLAS_SURCHARGE_RATE + BUNDLER_SURCHARGE_RATE
+                    targetSurchargeRate: S_atlasSurchargeRate,
+                    totalSurchargeRate: S_atlasSurchargeRate + BUNDLER_SURCHARGE_RATE
                 });
 
                 // When no winning solvers, bundler max refund is 80% of metacall gas cost. The remaining 20% can be

--- a/src/contracts/atlas/Storage.sol
+++ b/src/contracts/atlas/Storage.sol
@@ -18,7 +18,6 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
     address public immutable SIMULATOR;
     address public immutable L2_GAS_CALCULATOR;
     uint256 public immutable ESCROW_DURATION;
-    uint256 public immutable BUNDLER_SURCHARGE_RATE;
 
     // AtlETH public constants
     // These constants double as interface functions for the ERC20 standard, hence the lowercase naming convention.
@@ -48,7 +47,7 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
     uint256 internal S_bondedTotalSupply;
 
     // Surcharge-related storage
-    uint256 internal S_atlasSurchargeRate; // Atlas surcharge rate
+    uint256 internal S_surchargeRates; // left 128 bits: Atlas rate, right 128 bits: Bundler rate
     uint256 internal S_cumulativeSurcharge; // Cumulative gas surcharges collected
     address internal S_surchargeRecipient; // Fastlane surcharge recipient
     address internal S_pendingSurchargeRecipient; // For 2-step transfer process
@@ -72,9 +71,13 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
         SIMULATOR = simulator;
         L2_GAS_CALCULATOR = l2GasCalculator;
         ESCROW_DURATION = escrowDuration;
-        BUNDLER_SURCHARGE_RATE = bundlerSurchargeRate;
 
-        S_atlasSurchargeRate = atlasSurchargeRate;
+        // Check Atlas and Bundler gas surcharges fit in 128 bits each
+        if(atlasSurchargeRate > type(uint128).max || bundlerSurchargeRate > type(uint128).max) {
+            revert SurchargeRateTooHigh();
+        }
+
+        S_surchargeRates = atlasSurchargeRate << 128 | bundlerSurchargeRate;
         S_cumulativeSurcharge = msg.value;
         S_surchargeRecipient = initialSurchargeRecipient;
 
@@ -85,10 +88,15 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
     //                     Storage Setters                  //
     // ---------------------------------------------------- //
 
-    function setAtlasSurchargeRate(uint256 newSurchargeRate) external {
+    function setSurchargeRates(uint256 newAtlasRate, uint256 newBundlerRate) external {
         _onlySurchargeRecipient();
-        S_atlasSurchargeRate = newSurchargeRate;
-        // TODO consider adding event
+
+        // Check Atlas and Bundler gas surcharges fit in 128 bits each
+        if(newAtlasRate > type(uint128).max || newBundlerRate > type(uint128).max) {
+            revert SurchargeRateTooHigh();
+        }
+
+        S_surchargeRates = newAtlasRate << 128 | newBundlerRate;
     }
 
     function _onlySurchargeRecipient() internal view {
@@ -145,7 +153,23 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
     }
 
     function atlasSurchargeRate() external view returns (uint256) {
-        return S_atlasSurchargeRate;
+        // Includes only the left 128 bits to isolate the Atlas rate
+        return S_surchargeRates >> 128;
+    }
+
+    function bundlerSurchargeRate() external view returns (uint256) {
+        // Includes only the right 128 bits to isolate the bundler rate
+        return S_surchargeRates & ((1 << 128) - 1);
+    }
+
+    // ---------------------------------------------------- //
+    //               Storage Internal Getters               //
+    // ---------------------------------------------------- //
+
+    function _surchargeRates() internal view returns (uint256 atlasRate, uint256 bundlerRate) {
+        uint256 _bothRates = S_surchargeRates;
+        atlasRate = _bothRates >> 128;
+        bundlerRate = _bothRates & ((1 << 128) - 1);
     }
 
     // ---------------------------------------------------- //

--- a/src/contracts/interfaces/IAtlas.sol
+++ b/src/contracts/interfaces/IAtlas.sol
@@ -45,9 +45,11 @@ interface IAtlas {
     function depositAndBond(uint256 amountToBond) external payable;
     function unbond(uint256 amount) external;
     function redeem(uint256 amount) external;
+
     function withdrawSurcharge() external;
     function transferSurchargeRecipient(address newRecipient) external;
     function becomeSurchargeRecipient() external;
+    function setAtlasSurchargeRate(uint256 rate) external;
 
     // Permit69.sol
     function transferUserERC20(
@@ -101,4 +103,5 @@ interface IAtlas {
     function cumulativeSurcharge() external view returns (uint256);
     function surchargeRecipient() external view returns (address);
     function pendingSurchargeRecipient() external view returns (address);
+    function atlasSurchargeRate() external view returns (uint256);
 }

--- a/src/contracts/interfaces/IAtlas.sol
+++ b/src/contracts/interfaces/IAtlas.sol
@@ -49,7 +49,7 @@ interface IAtlas {
     function withdrawSurcharge() external;
     function transferSurchargeRecipient(address newRecipient) external;
     function becomeSurchargeRecipient() external;
-    function setAtlasSurchargeRate(uint256 rate) external;
+    function setSurchargeRates(uint128 newAtlasRate, uint128 newBundlerRate) external;
 
     // Permit69.sol
     function transferUserERC20(
@@ -104,4 +104,5 @@ interface IAtlas {
     function surchargeRecipient() external view returns (address);
     function pendingSurchargeRecipient() external view returns (address);
     function atlasSurchargeRate() external view returns (uint256);
+    function bundlerSurchargeRate() external view returns (uint256);
 }

--- a/src/contracts/types/AtlasErrors.sol
+++ b/src/contracts/types/AtlasErrors.sol
@@ -103,6 +103,9 @@ contract AtlasErrors {
     error NotInitialized();
     error AlreadyInitialized();
 
+    // Storage
+    error SurchargeRateTooHigh();
+
     // AtlasVerification
     error NoUnusedNonceInBitmap();
 

--- a/test/FLOnline.t.sol
+++ b/test/FLOnline.t.sol
@@ -1302,7 +1302,7 @@ contract FastLaneOnlineTest is BaseTest {
 
         // Calculate estimated Atlas gas surcharge taken from call above
         txGasUsed = estAtlasGasSurcharge - gasleft();
-        estAtlasGasSurcharge = txGasUsed * defaultGasPrice * atlas.ATLAS_SURCHARGE_RATE() / atlas.SCALE();
+        estAtlasGasSurcharge = txGasUsed * defaultGasPrice * atlas.atlasSurchargeRate() / atlas.SCALE();
 
         assertTrue(
             result == swapCallShouldSucceed,

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -71,7 +71,6 @@ contract MockGasAccounting is TestAtlas, BaseTest {
         external
         returns (
             uint256 adjustedWithdrawals,
-            uint256 adjustedDeposits,
             uint256 adjustedClaims,
             uint256 adjustedWriteoffs,
             uint256 netAtlasGasSurcharge
@@ -282,7 +281,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         claims = rawClaims
             * (
                 mockGasAccounting.SCALE() + mockGasAccounting.atlasSurchargeRate()
-                    + mockGasAccounting.BUNDLER_SURCHARGE_RATE()
+                    + mockGasAccounting.bundlerSurchargeRate()
             ) / mockGasAccounting.SCALE();
     }
 

--- a/test/GasAccounting.t.sol
+++ b/test/GasAccounting.t.sol
@@ -281,7 +281,7 @@ contract GasAccountingTest is AtlasConstants, BaseTest {
         uint256 rawClaims = (_gasMarker + mockGasAccounting.FIXED_GAS_OFFSET()) * tx.gasprice;
         claims = rawClaims
             * (
-                mockGasAccounting.SCALE() + mockGasAccounting.ATLAS_SURCHARGE_RATE()
+                mockGasAccounting.SCALE() + mockGasAccounting.atlasSurchargeRate()
                     + mockGasAccounting.BUNDLER_SURCHARGE_RATE()
             ) / mockGasAccounting.SCALE();
     }

--- a/test/Storage.t.sol
+++ b/test/Storage.t.sol
@@ -29,7 +29,6 @@ contract StorageTest is BaseTest {
         assertEq(atlas.symbol(), "atlETH", "symbol set incorrectly");
         assertEq(atlas.decimals(), 18, "decimals set incorrectly");
 
-        assertEq(atlas.ATLAS_SURCHARGE_RATE(), DEFAULT_ATLAS_SURCHARGE_RATE, "ATLAS_SURCHARGE_RATE set incorrectly");
         assertEq(
             atlas.BUNDLER_SURCHARGE_RATE(), DEFAULT_BUNDLER_SURCHARGE_RATE, "BUNDLER_SURCHARGE_RATE set incorrectly"
         );
@@ -141,6 +140,13 @@ contract StorageTest is BaseTest {
         vm.prank(deployer);
         atlas.transferSurchargeRecipient(userEOA);
         assertEq(atlas.pendingSurchargeRecipient(), userEOA, "pendingSurchargeRecipient should be userEOA");
+    }
+
+    function test_storage_view_atlasSurchargeRate() public {
+        assertEq(atlas.atlasSurchargeRate(), DEFAULT_ATLAS_SURCHARGE_RATE, "atlasSurchargeRate set incorrectly");
+        vm.prank(deployer);
+        atlas.setAtlasSurchargeRate(100);
+        assertEq(atlas.atlasSurchargeRate(), 100, "atlasSurchargeRate set incorrectly");
     }
 
     // Transient Storage Getters and Setters

--- a/test/Storage.t.sol
+++ b/test/Storage.t.sol
@@ -5,6 +5,7 @@ import "forge-std/Test.sol";
 
 import { Storage } from "../src/contracts/atlas/Storage.sol";
 import "../src/contracts/types/LockTypes.sol";
+import { AtlasErrors } from "../src/contracts/types/AtlasErrors.sol";
 
 import { BaseTest } from "./base/BaseTest.t.sol";
 
@@ -29,9 +30,6 @@ contract StorageTest is BaseTest {
         assertEq(atlas.symbol(), "atlETH", "symbol set incorrectly");
         assertEq(atlas.decimals(), 18, "decimals set incorrectly");
 
-        assertEq(
-            atlas.BUNDLER_SURCHARGE_RATE(), DEFAULT_BUNDLER_SURCHARGE_RATE, "BUNDLER_SURCHARGE_RATE set incorrectly"
-        );
         assertEq(atlas.SCALE(), DEFAULT_SCALE, "SCALE set incorrectly");
         assertEq(atlas.FIXED_GAS_OFFSET(), DEFAULT_FIXED_GAS_OFFSET, "FIXED_GAS_OFFSET set incorrectly");
     }
@@ -145,8 +143,38 @@ contract StorageTest is BaseTest {
     function test_storage_view_atlasSurchargeRate() public {
         assertEq(atlas.atlasSurchargeRate(), DEFAULT_ATLAS_SURCHARGE_RATE, "atlasSurchargeRate set incorrectly");
         vm.prank(deployer);
-        atlas.setAtlasSurchargeRate(100);
+        atlas.setSurchargeRates(100, 200);
         assertEq(atlas.atlasSurchargeRate(), 100, "atlasSurchargeRate set incorrectly");
+    }
+
+    function test_storage_view_bundlerSurchargeRate() public {
+        assertEq(atlas.bundlerSurchargeRate(), DEFAULT_BUNDLER_SURCHARGE_RATE, "bundlerSurchargeRate set incorrectly");
+        vm.prank(deployer);
+        atlas.setSurchargeRates(100, 200);
+        assertEq(atlas.bundlerSurchargeRate(), 200, "bundlerSurchargeRate set incorrectly");
+    }
+
+    // Storage Setters
+
+    function test_storage_setSurchargeRates() public {
+        uint256 tooHigh = uint256(type(uint128).max) + 1;
+
+        vm.prank(deployer);
+        vm.expectRevert(AtlasErrors.SurchargeRateTooHigh.selector);
+        atlas.setSurchargeRates(tooHigh, 456);
+
+        vm.prank(deployer);
+        vm.expectRevert(AtlasErrors.SurchargeRateTooHigh.selector);
+        atlas.setSurchargeRates(123, tooHigh);
+
+        vm.prank(userEOA);
+        vm.expectRevert(AtlasErrors.InvalidAccess.selector);
+        atlas.setSurchargeRates(123, 456);
+
+        vm.prank(deployer);
+        atlas.setSurchargeRates(123, 456);
+        assertEq(atlas.atlasSurchargeRate(), 123, "atlasSurchargeRate set incorrectly");
+        assertEq(atlas.bundlerSurchargeRate(), 456, "bundlerSurchargeRate set incorrectly");
     }
 
     // Transient Storage Getters and Setters

--- a/test/TrebleSwap.t.sol
+++ b/test/TrebleSwap.t.sol
@@ -299,7 +299,7 @@ contract TrebleSwapTest is BaseTest {
 
         // Estimate gas surcharge Atlas should have taken
         txGasUsed = estAtlasGasSurcharge - gasleft();
-        estAtlasGasSurcharge = txGasUsed * tx.gasprice * atlas.ATLAS_SURCHARGE_RATE() / atlas.SCALE();
+        estAtlasGasSurcharge = txGasUsed * tx.gasprice * atlas.atlasSurchargeRate() / atlas.SCALE();
 
         // For benchmarking
         console.log("Metacall gas cost: ", txGasUsed);


### PR DESCRIPTION
### Changes:

- Store Atlas and Bundler surcharge rates in a shared storage slot, instead of constants.
- Allow `surchargeRecipient` to change these surcharge rates.
- Removed `adjustedDeposits` var from `_adjustAccountingForFees()` as it wasn't used at all, to alleviate Stack Too Deep.

### Contract Size Impact

| Contract          | Before         | Only Atlas      | Atlas + Bundler |
|-------------------|----------------|-----------------|-----------------|
| Atlas.sol         | 24,107 (469)  | 23,939 (637)    | 23,822 (754)    |

### Gas Cost Impact

| Test                                                | Before   | Only Atlas | Atlas + Bundler | Diff   |
|-----------------------------------------------------|----------|------------|-----------------|--------|
| Atlas Swap Intent with Basic RFQ                    | 385,450  | 387,818    | 387,948         | 2,498  |
| Ex Post Ordering                                    | 1,291,164| 1,293,641  | 1,293,855       | 2,691  |
| Chainlink OEV Standard Version                      | 437,902  | 440,270    | 440,422         | 2,520  |
| Treble Swap Metacall ERC20 to ERC20 with One Solver | 682,768  | 685,136    | 685,266         | 2,498  |
| Treble Swap Metacall ETH to ERC20 with One Solver   | 547,424  | 549,792    | 549,944         | 2,520  |