### PR TITLE
chore: upgrade to Foundry v1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly-0d8302880b79fa9c3c4aa52ab446583dece19a34 # 2024-08-29 release
 
       - name: Check formatting
         run: forge fmt --check
@@ -35,8 +33,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly-0d8302880b79fa9c3c4aa52ab446583dece19a34 # 2024-08-29 release
 
       - name: Install dependencies
         run: forge install
@@ -80,8 +76,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly-0d8302880b79fa9c3c4aa52ab446583dece19a34 # 2024-08-29 release
 
       - name: Install dependencies
         run: forge install

--- a/foundry.toml
+++ b/foundry.toml
@@ -24,4 +24,4 @@
   quote_style = "double"
   tab_width = 4
   wrap_comments = true
-  ignore = ["./**/*.t.sol"]
+  ignore = ["./**/*.t.sol", "src/contracts/atlas/Storage.sol"]

--- a/src/contracts/examples/v4-example/V4DAppControl.sol
+++ b/src/contracts/examples/v4-example/V4DAppControl.sol
@@ -142,8 +142,7 @@ contract V4DAppControl is DAppControl {
         } else {
             if (params.amountSpecified > 0) {
                 // Buying Pool's token0 with amountSpecified of User's token1
-            }
-            else {
+            } else {
                 // Buying amountSpecified of Pool's token0 with User's token1
             }
         }

--- a/test/AccountingMath.t.sol
+++ b/test/AccountingMath.t.sol
@@ -8,6 +8,7 @@ contract AccountingMathTest is Test {
     uint256 DEFAULT_ATLAS_SURCHARGE_RATE = 1_000_000; // 10%
     uint256 DEFAULT_BUNDLER_SURCHARGE_RATE = 1_000_000; // 10%
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testWithBundlerSurcharge() public {
         assertEq(AccountingMath.withSurcharge(0, DEFAULT_BUNDLER_SURCHARGE_RATE), uint256(0));
         assertEq(AccountingMath.withSurcharge(1, DEFAULT_BUNDLER_SURCHARGE_RATE), uint256(1));
@@ -18,6 +19,7 @@ contract AccountingMathTest is Test {
         AccountingMath.withSurcharge(type(uint256).max, DEFAULT_BUNDLER_SURCHARGE_RATE);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testWithoutBundlerSurcharge() public {
         assertEq(AccountingMath.withoutSurcharge(0, DEFAULT_BUNDLER_SURCHARGE_RATE), uint256(0));
         assertEq(AccountingMath.withoutSurcharge(1, DEFAULT_BUNDLER_SURCHARGE_RATE), uint256(0));
@@ -28,6 +30,7 @@ contract AccountingMathTest is Test {
         AccountingMath.withoutSurcharge(type(uint256).max, DEFAULT_BUNDLER_SURCHARGE_RATE);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testWithAtlasAndBundlerSurcharges() public {
         assertEq(
             AccountingMath.withSurcharges(0, DEFAULT_ATLAS_SURCHARGE_RATE, DEFAULT_BUNDLER_SURCHARGE_RATE), uint256(0)
@@ -50,6 +53,7 @@ contract AccountingMathTest is Test {
         AccountingMath.withSurcharges(type(uint256).max, DEFAULT_ATLAS_SURCHARGE_RATE, DEFAULT_BUNDLER_SURCHARGE_RATE);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testGetAtlasSurcharge() public {
         assertEq(AccountingMath.getSurcharge(0, DEFAULT_ATLAS_SURCHARGE_RATE), uint256(0));
         assertEq(AccountingMath.getSurcharge(10, DEFAULT_ATLAS_SURCHARGE_RATE), uint256(1));
@@ -62,6 +66,7 @@ contract AccountingMathTest is Test {
         AccountingMath.getSurcharge(type(uint256).max, DEFAULT_ATLAS_SURCHARGE_RATE);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testSolverGasLimitScaledDown() public {
         assertEq(AccountingMath.solverGasLimitScaledDown(0, 100), uint256(0));
         assertEq(AccountingMath.solverGasLimitScaledDown(50, 100), uint256(47)); // 50 * 10_000_000 / 10_500_000


### PR DESCRIPTION
### Changes:

- Allow depth=1 reverts in AccountingMath lib tests
- Ignore Storage.sol in `forge fmt` as Foundry v1.0 still doesn't recognize the `transient` keyword. Targeted for v1.1
- Bump GitHub actions CI to use Foundry v1.0

See migration guide here: https://book.getfoundry.sh/guides/v1.0-migration