### PR TITLE
Mark 0 bidAmounts as BidNotPaid

### DIFF
--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -510,8 +510,7 @@ abstract contract Escrow is AtlETH {
             if (bidAmount != 0) {
                 // If solverCall() was successful, intentionally leave uint256 result unset as 0 indicates success.
                 solverTracker = abi.decode(_data, (SolverTracker));
-            }
-            else {
+            } else {
                 result = 1 << uint256(SolverOutcome.BidNotPaid);
             }
         } else {

--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -511,6 +511,7 @@ abstract contract Escrow is AtlETH {
                 // If solverCall() was successful, intentionally leave uint256 result unset as 0 indicates success.
                 solverTracker = abi.decode(_data, (SolverTracker));
             } else {
+                // If solverCall() was successful but bidAmount was 0, do not end auction, keep executing solvers. 
                 result = 1 << uint256(SolverOutcome.BidNotPaid);
             }
         } else {

--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -507,8 +507,13 @@ abstract contract Escrow is AtlETH {
             address(this).call{ gas: gasLimit }(abi.encodeCall(this.solverCall, (ctx, solverOp, bidAmount, returnData)));
 
         if (_success) {
-            // If solverCall() was successful, intentionally leave uint256 result unset as 0 indicates success.
-            solverTracker = abi.decode(_data, (SolverTracker));
+            if (bidAmount != 0) {
+                // If solverCall() was successful, intentionally leave uint256 result unset as 0 indicates success.
+                solverTracker = abi.decode(_data, (SolverTracker));
+            }
+            else {
+                result = 1 << uint256(SolverOutcome.BidNotPaid);
+            }
         } else {
             // If solverCall() failed, catch the error and encode the failure case in the result uint accordingly.
             bytes4 _errorSwitch = bytes4(_data);


### PR DESCRIPTION
Mark 0 bidAmounts as BidNotPaid so: 
- we keep iterating to next solverOp.
- we assign 0 bidAmounts to gas accounting as if they reverted. 
- we still do not revert SolverOps with bidAmount = 0.