### PR TITLE
fix: solver gas subsidies disabled in `multipleSuccessfulSolvers` mode

### DIFF
--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -722,9 +722,10 @@ abstract contract Escrow is AtlETH {
         // not fully repay the borrowed amount, the `postSolverCall` might have covered the outstanding debt via
         // `contribute()`. This final check ensures that the solver has fulfilled their repayment obligations before
         // proceeding.
+        bool _multiSuccesfulSolvers = _callConfig.multipleSuccessfulSolvers();
         (, bool _calledback, bool _fulfilled) = _solverLockData();
         if (!_calledback) revert CallbackNotCalled();
-        if (!_fulfilled && !_isBalanceReconciled()) revert BalanceNotReconciled();
+        if (!_fulfilled && !_isBalanceReconciled(_multiSuccesfulSolvers)) revert BalanceNotReconciled();
 
         // Check if this is an on-chain, ex post bid search by verifying the `ctx.bidFind` flag.
         // If the flag is set, revert with `BidFindSuccessful` and include the solver's bid amount in `solverTracker`.

--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -593,13 +593,14 @@ abstract contract GasAccounting is SafetyLocks {
 
     /// @notice Checks all obligations have been reconciled: native borrows AND gas liabilities.
     /// @return True if both dimensions are reconciled, false otherwise.
-    function _isBalanceReconciled() internal view returns (bool) {
+    function _isBalanceReconciled(bool multipleSuccessfulSolvers) internal view returns (bool) {
         GasLedger memory gL = t_gasLedger.toGasLedger();
         BorrowsLedger memory bL = t_borrowsLedger.toBorrowsLedger();
 
-        // DApp's excess repayments via `contribute()` can offset solverGasLiability
+        // DApp's excess repayments via `contribute()` can offset solverGasLiability.
+        // NOTE: This solver gas subsidy feature is disabled in multipleSuccessfulSolvers mode.
         uint256 _netRepayments;
-        if (bL.repays > bL.borrows) _netRepayments = bL.repays - bL.borrows;
+        if (!multipleSuccessfulSolvers && bL.repays > bL.borrows) _netRepayments = bL.repays - bL.borrows;
 
         // gL.maxApprovedGasSpend only stores the gas units, must be scaled by tx.gasprice
         uint256 _maxApprovedGasValue = gL.maxApprovedGasSpend * tx.gasprice;


### PR DESCRIPTION
Changes:

- Disabled the ability for net repayments to contribute to the solvers approved amount when evaluating if the solver can repay their gas liability in `_isBalanceReconciled()`.
- Added test to show `_isBalanceReconciled()` returns false in `multipleSuccessfulSolvers` mode, when it would otherwise return true due to the net repayment subsidy.