### PR TITLE
fix: simulator gas calc bugs

### DIFF
--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -678,7 +678,7 @@ contract AtlasVerification is EIP712, NonceManager, DAppIntegration {
         }
 
         allSolversCalldataGas =
-            GasAccLib.calldataGas(solverDataLenSum + (_SOLVER_OP_BASE_CALLDATA * solverOps.length), L2_GAS_CALCULATOR);
+            GasAccLib.calldataGas(solverDataLenSum + (_SOLVER_OP_STATIC_LENGTH * solverOpsLen), L2_GAS_CALCULATOR);
 
         uint256 metacallExecutionGas = _BASE_TX_GAS_USED + AccountingMath._FIXED_GAS_OFFSET + userOpGas
             + dConfig.dappGasLimit + allSolversExecutionGas;

--- a/src/contracts/helpers/Simulator.sol
+++ b/src/contracts/helpers/Simulator.sol
@@ -65,9 +65,9 @@ contract Simulator is AtlasErrors, AtlasConstants {
             allSolversExecutionGas += Math.min(solverOps[i].gas, dConfig.solverGasLimit);
         }
 
-        uint256 metacallCalldataGas = (_SOLVER_OP_BASE_CALLDATA * solverOpsLen)
-            + GasAccLib.calldataGas(solverDataLenSum, l2GasCalculator)
-            + GasAccLib.metacallCalldataGas(nonSolverCalldataLength, l2GasCalculator);
+        uint256 metacallCalldataGas = GasAccLib.calldataGas(
+            solverDataLenSum + (_SOLVER_OP_STATIC_LENGTH * solverOpsLen), l2GasCalculator
+        ) + GasAccLib.metacallCalldataGas(nonSolverCalldataLength, l2GasCalculator);
 
         uint256 metacallExecutionGas = _BASE_TX_GAS_USED + AccountingMath._FIXED_GAS_OFFSET + userOp.gas
             + dConfig.dappGasLimit + allSolversExecutionGas;
@@ -114,7 +114,7 @@ contract Simulator is AtlasErrors, AtlasConstants {
             // In normal bid mode, solvers each pay for their own solverOp calldata gas, and the winning solver pays for
             // the other non-solver calldata gas as well. In this calculation, there's only 1 solverOp so no need to
             // subtract calldata of other solverOps as they aren't any.
-            uint256 metacallCalldataLength = (_SOLVER_OP_BASE_CALLDATA + solverOp.data.length)
+            uint256 metacallCalldataLength = (_SOLVER_OP_STATIC_LENGTH + solverOp.data.length)
                 + (USER_OP_STATIC_LENGTH + userOp.data.length) + DAPP_OP_LENGTH + _EXTRA_CALLDATA_LENGTH;
 
             uint256 metacallCalldataGas =

--- a/src/contracts/helpers/Sorter.sol
+++ b/src/contracts/helpers/Sorter.sol
@@ -87,7 +87,7 @@ contract Sorter is AtlasConstants {
 
         // Calldata gas a winning solver would pay for: non-solverOp calldata + their own solverOp calldata
         uint256 calldataGas = (
-            USER_OP_STATIC_LENGTH + DAPP_OP_LENGTH + _SOLVER_OP_BASE_CALLDATA + _EXTRA_CALLDATA_LENGTH
+            USER_OP_STATIC_LENGTH + DAPP_OP_LENGTH + _SOLVER_OP_STATIC_LENGTH + _EXTRA_CALLDATA_LENGTH
                 + userOp.data.length + solverOp.data.length
         ) * _CALLDATA_LENGTH_PREMIUM_HALVED;
 

--- a/src/contracts/libraries/GasAccLib.sol
+++ b/src/contracts/libraries/GasAccLib.sol
@@ -34,7 +34,7 @@ library GasAccLib {
     using AccountingMath for uint256;
     using SafeCast for uint256;
 
-    uint256 internal constant _SOLVER_OP_BASE_CALLDATA = 608;
+    uint256 internal constant _SOLVER_OP_STATIC_LENGTH = 608;
     uint256 internal constant _CALLDATA_LENGTH_PREMIUM_HALVED = 8;
 
     function pack(GasLedger memory gasLedger) internal pure returns (uint256) {
@@ -90,10 +90,10 @@ library GasAccLib {
     function solverOpCalldataGas(uint256 calldataLength, address l2GasCalculator) internal view returns (uint256 gas) {
         if (l2GasCalculator == address(0)) {
             // Default to using mainnet gas calculations
-            // _SOLVER_OP_BASE_CALLDATA = SolverOperation calldata length excluding solverOp.data
-            gas = (calldataLength + _SOLVER_OP_BASE_CALLDATA) * _CALLDATA_LENGTH_PREMIUM_HALVED;
+            // _SOLVER_OP_STATIC_LENGTH = SolverOperation calldata length excluding solverOp.data
+            gas = (calldataLength + _SOLVER_OP_STATIC_LENGTH) * _CALLDATA_LENGTH_PREMIUM_HALVED;
         } else {
-            gas = IL2GasCalculator(l2GasCalculator).getCalldataGas(calldataLength + _SOLVER_OP_BASE_CALLDATA);
+            gas = IL2GasCalculator(l2GasCalculator).getCalldataGas(calldataLength + _SOLVER_OP_STATIC_LENGTH);
         }
     }
 
@@ -106,18 +106,11 @@ library GasAccLib {
         }
     }
 
-    function metacallCalldataGas(
-        uint256 msgDataLength,
-        address l2GasCalculator
-    )
-        internal
-        view
-        returns (uint256 calldataGas)
-    {
+    function metacallCalldataGas(uint256 msgDataLength, address l2GasCalculator) internal view returns (uint256 gas) {
         if (l2GasCalculator == address(0)) {
-            calldataGas = msgDataLength * _CALLDATA_LENGTH_PREMIUM_HALVED;
+            gas = msgDataLength * _CALLDATA_LENGTH_PREMIUM_HALVED;
         } else {
-            calldataGas = IL2GasCalculator(l2GasCalculator).initialGasUsed(msgDataLength);
+            gas = IL2GasCalculator(l2GasCalculator).initialGasUsed(msgDataLength);
         }
     }
 }

--- a/src/contracts/types/AtlasConstants.sol
+++ b/src/contracts/types/AtlasConstants.sol
@@ -31,7 +31,7 @@ contract AtlasConstants {
     // Half of the upper gas cost per byte of calldata (16 gas). Multiplied by msg.data.length. Equivalent to
     // `msg.data.length / 2 * 16` because 2 hex chars per byte.
     uint256 internal constant _BASE_TX_GAS_USED = 21_000;
-    uint256 internal constant _SOLVER_OP_BASE_CALLDATA = GasAccLib._SOLVER_OP_BASE_CALLDATA; // SolverOperation calldata
+    uint256 internal constant _SOLVER_OP_STATIC_LENGTH = GasAccLib._SOLVER_OP_STATIC_LENGTH; // SolverOperation calldata
         // length excluding solverOp.data
     uint256 internal constant _BUNDLER_FAULT_OFFSET = 4500; // Extra gas to write off if solverOp failure is bundler
         // fault in `_handleSolverFailAccounting()`. Value is worst-case gas measured for bundler fault.

--- a/test/GasAccLib.t.sol
+++ b/test/GasAccLib.t.sol
@@ -98,7 +98,7 @@ contract GasAccLibTest is Test {
         uint256 calldataLength = 500;
 
         // First, the default calculation, using address(0) as the GasCalculator:
-        uint256 expectedDefaultGas = (calldataLength + GasAccLib._SOLVER_OP_BASE_CALLDATA) * GasAccLib._CALLDATA_LENGTH_PREMIUM_HALVED;
+        uint256 expectedDefaultGas = (calldataLength + GasAccLib._SOLVER_OP_STATIC_LENGTH) * GasAccLib._CALLDATA_LENGTH_PREMIUM_HALVED;
 
         assertEq(GasAccLib.solverOpCalldataGas(calldataLength, address(0)), expectedDefaultGas, "solverOpCalldataGas (default) unexpected");
 


### PR DESCRIPTION
### Changes

- Fixed a bug in the solver calldata gas calculation in Simulator where static calldata lengths were not being scaled by gas cost.
- Renamed `_SOLVER_OP_BASE_CALLDATA` to `_SOLVER_OP_STATIC_LENGTH` for clarity.