### PR TITLE
Arbitrum/atlas v1.7 experimental

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
   bytecode_hash = "none"
-  optimizer_runs = 50
+  optimizer_runs = 8
   timeout = 30000
   block_gas_limit = 300000000
   gas_limit = 3000000000

--- a/script/set-gas-calculator-arbitrum.s.sol
+++ b/script/set-gas-calculator-arbitrum.s.sol
@@ -11,8 +11,10 @@ contract SetArbGasCalculatorScript is DeployBaseScript {
     ArbitrumGasCalculator public gasCalculator = ArbitrumGasCalculator(0x870584178A64f409B00De32816D56756772E6cb4);
 
     // GAS CALCULATOR SETTINGS
-    uint128 newM = 4000;
-    uint128 newC = 0;
+    uint64 newA = 0;
+    uint64 newB = 0;
+    uint64 newR = 0;
+    uint64 newC = 0;
 
     function run() external {
         console.log("\n=== DEPLOYING GasCalculator ===\n");
@@ -27,23 +29,27 @@ contract SetArbGasCalculatorScript is DeployBaseScript {
         uint256 chainId = block.chainid;
         address deploymentAddr;
 
-        (uint128 m, uint128 c) = gasCalculator.getCalibrationVars();
+        (uint64 a, uint64 b, uint64 r, uint64 c) = gasCalculator.getCalibrationVars();
 
-        console.log("old m:", m);
+        console.log("old a:", a);
+        console.log("old b:", b);
+        console.log("old r:", r);
         console.log("old c:", c);
 
         vm.startBroadcast(deployerPrivateKey);
 
         // Check if chainId is Arbitrum One or Arbitrum Sepolia
         if (chainId == 42_161 || chainId == 421_614) {
-            gasCalculator.setCalibrationVars(newM, newC);
+            gasCalculator.setCalibrationVars(newA, newB, newR, newC);
         } else {
             revert("Error: Chain ID not supported");
         }
 
         vm.stopBroadcast();
 
-        console.log("new m:", newM);
+        console.log("new a:", newA);
+        console.log("new b:", newB);
+        console.log("new r:", newR);
         console.log("new c:", newC);
     }
 }

--- a/script/set-gas-calculator-arbitrum.s.sol
+++ b/script/set-gas-calculator-arbitrum.s.sol
@@ -8,13 +8,11 @@ import { ArbitrumGasCalculator } from "src/contracts/gasCalculator/ArbitrumGasCa
 
 // Deploy script for the Arbitrum L2GasCalculator
 contract SetArbGasCalculatorScript is DeployBaseScript {
-
     ArbitrumGasCalculator public gasCalculator = ArbitrumGasCalculator(0x870584178A64f409B00De32816D56756772E6cb4);
 
     // GAS CALCULATOR SETTINGS
     uint128 newM = 4000;
     uint128 newC = 0;
-    
 
     function run() external {
         console.log("\n=== DEPLOYING GasCalculator ===\n");

--- a/src/contracts/atlas/Escrow.sol
+++ b/src/contracts/atlas/Escrow.sol
@@ -331,7 +331,7 @@ abstract contract Escrow is AtlETH {
 
         // Calldata gas is only included if NOT in exPostBids mode.
         if (!dConfig.callConfig.exPostBids()) {
-            _calldataGas = GasAccLib.solverOpCalldataGas(solverOp.data.length, L2_GAS_CALCULATOR);
+            _calldataGas = GasAccLib.solverOpCalldataGas(solverOp.data, L2_GAS_CALCULATOR);
         }
 
         // Reset solver's max approved gas spend to 0 at start of each new solver execution

--- a/src/contracts/atlas/GasAccounting.sol
+++ b/src/contracts/atlas/GasAccounting.sol
@@ -13,8 +13,6 @@ import { AccountingMath } from "../libraries/AccountingMath.sol";
 import { GasAccLib, GasLedger, BorrowsLedger } from "../libraries/GasAccLib.sol";
 import { SafeBlockNumber } from "../libraries/SafeBlockNumber.sol";
 import { SolverOperation } from "../types/SolverOperation.sol";
-import { DAppConfig } from "../types/ConfigTypes.sol";
-import { IL2GasCalculator } from "../interfaces/IL2GasCalculator.sol";
 import "../types/EscrowTypes.sol";
 import "../types/LockTypes.sol";
 
@@ -306,7 +304,7 @@ abstract contract GasAccounting is SafetyLocks {
         // Solvers do not pay for calldata gas in exPostBids mode.
         uint256 _calldataGas;
         if (!exPostBids) {
-            _calldataGas = GasAccLib.solverOpCalldataGas(solverOp.data.length, L2_GAS_CALCULATOR);
+            _calldataGas = GasAccLib.solverOpCalldataGas(solverOp.data, L2_GAS_CALCULATOR);
         }
 
         // Solver execution max gas is calculated as solverOp.gas, with a ceiling of dConfig.solverGasLimit
@@ -409,8 +407,7 @@ abstract contract GasAccounting is SafetyLocks {
         // Start at the solver after the current solverIdx, because current solverIdx is the winner
         for (uint256 i = winningSolverIdx + 1; i < solverOps.length; ++i) {
             address _from = solverOps[i].from;
-            uint256 _calldataGasCost =
-                GasAccLib.solverOpCalldataGas(solverOps[i].data.length, L2_GAS_CALCULATOR) * tx.gasprice;
+            uint256 _calldataGasCost = GasAccLib.solverOpCalldataGas(solverOps[i].data, L2_GAS_CALCULATOR) * tx.gasprice;
 
             // Verify the solverOp, and write off solver's calldata gas if included due to bundler fault
             uint256 _result =

--- a/src/contracts/examples/fastlane-online/FastLaneControl.sol
+++ b/src/contracts/examples/fastlane-online/FastLaneControl.sol
@@ -10,7 +10,6 @@ import { DAppControl } from "../../dapp/DAppControl.sol";
 import { CallConfig } from "../../types/ConfigTypes.sol";
 import "../../types/UserOperation.sol";
 import "../../types/SolverOperation.sol";
-import "../../types/LockTypes.sol";
 import { IAtlas } from "../../interfaces/IAtlas.sol";
 
 import { SwapIntent, BaselineCall } from "./FastLaneTypes.sol";

--- a/src/contracts/examples/fastlane-online/FastLaneOnlineInner.sol
+++ b/src/contracts/examples/fastlane-online/FastLaneOnlineInner.sol
@@ -1,22 +1,8 @@
 //SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-// Base Imports
-import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
-import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-
 // Atlas Imports
 import { DAppControl } from "../../dapp/DAppControl.sol";
-import { DAppOperation } from "../../types/DAppOperation.sol";
-import { CallConfig } from "../../types/ConfigTypes.sol";
-import "../../types/UserOperation.sol";
-import "../../types/SolverOperation.sol";
-import "../../types/LockTypes.sol";
-
-// Interface Import
-import { IAtlasVerification } from "../../interfaces/IAtlasVerification.sol";
-import { IExecutionEnvironment } from "../../interfaces/IExecutionEnvironment.sol";
-import { IAtlas } from "../../interfaces/IAtlas.sol";
 
 import { FastLaneOnlineControl } from "./FastLaneControl.sol";
 import { BaseStorage } from "./BaseStorage.sol";

--- a/src/contracts/examples/fastlane-online/FastLaneOnlineOuter.sol
+++ b/src/contracts/examples/fastlane-online/FastLaneOnlineOuter.sol
@@ -3,24 +3,19 @@ pragma solidity 0.8.28;
 
 // Base Imports
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
-import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
 // Atlas Imports
 import { DAppControl } from "../../dapp/DAppControl.sol";
 import { DAppOperation } from "../../types/DAppOperation.sol";
-import { CallConfig } from "../../types/ConfigTypes.sol";
 import "../../types/UserOperation.sol";
 import "../../types/SolverOperation.sol";
-import "../../types/LockTypes.sol";
 
 // Interface Import
 import { IAtlasVerification } from "../../interfaces/IAtlasVerification.sol";
-import { IExecutionEnvironment } from "../../interfaces/IExecutionEnvironment.sol";
 import { IAtlas } from "../../interfaces/IAtlas.sol";
 import { ISimulator } from "../../interfaces/ISimulator.sol";
 
 import { FastLaneOnlineControl } from "./FastLaneControl.sol";
-import { FastLaneOnlineInner } from "./FastLaneOnlineInner.sol";
 import { SolverGateway } from "./SolverGateway.sol";
 
 import { SwapIntent, BaselineCall } from "./FastLaneTypes.sol";

--- a/src/contracts/examples/fastlane-online/OuterHelpers.sol
+++ b/src/contracts/examples/fastlane-online/OuterHelpers.sol
@@ -4,24 +4,18 @@ pragma solidity 0.8.28;
 // Base Imports
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
 import { LibSort } from "solady/utils/LibSort.sol";
-import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
 // Atlas Imports
 import { DAppControl } from "../../dapp/DAppControl.sol";
 import { DAppOperation } from "../../types/DAppOperation.sol";
-import { CallConfig } from "../../types/ConfigTypes.sol";
 import "../../types/UserOperation.sol";
 import "../../types/SolverOperation.sol";
-import "../../types/LockTypes.sol";
-import "../../types/EscrowTypes.sol";
 
 // Interface Import
 import { IAtlasVerification } from "../../interfaces/IAtlasVerification.sol";
-import { IExecutionEnvironment } from "../../interfaces/IExecutionEnvironment.sol";
 import { IAtlas } from "../../interfaces/IAtlas.sol";
 import { ISimulator } from "../../interfaces/ISimulator.sol";
 
-import { FastLaneOnlineControl } from "./FastLaneControl.sol";
 import { FastLaneOnlineInner } from "./FastLaneOnlineInner.sol";
 
 import { SwapIntent, BaselineCall, Reputation } from "./FastLaneTypes.sol";
@@ -34,7 +28,7 @@ contract OuterHelpers is FastLaneOnlineInner {
     address public immutable SIMULATOR;
 
     uint256 internal constant _BITS_FOR_INDEX = 16;
-    uint256 internal constant _SOLVER_SIM_GAS_LIM = 4_850_000;
+    uint256 internal constant _SOLVER_SIM_GAS_LIM = 4_900_000;
 
     constructor(address atlas, address protocolGuildWallet) FastLaneOnlineInner(atlas) {
         CARDANO_ENGINEER_THERAPY_FUND = msg.sender;

--- a/src/contracts/examples/fastlane-online/SolverGateway.sol
+++ b/src/contracts/examples/fastlane-online/SolverGateway.sol
@@ -3,25 +3,15 @@ pragma solidity 0.8.28;
 
 // Base Imports
 import { SafeTransferLib } from "solady/utils/SafeTransferLib.sol";
-import { IERC20 } from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
 // Atlas Imports
-import { DAppControl } from "../../dapp/DAppControl.sol";
-import { DAppOperation } from "../../types/DAppOperation.sol";
-import { CallConfig } from "../../types/ConfigTypes.sol";
 import "../../types/UserOperation.sol";
 import "../../types/SolverOperation.sol";
-import "../../types/LockTypes.sol";
-import "../../types/EscrowTypes.sol";
 import { SafeBlockNumber } from "../../libraries/SafeBlockNumber.sol";
 
 // Interface Import
-import { IAtlasVerification } from "../../interfaces/IAtlasVerification.sol";
-import { IExecutionEnvironment } from "../../interfaces/IExecutionEnvironment.sol";
 import { IAtlas } from "../../interfaces/IAtlas.sol";
-import { ISimulator } from "../../interfaces/ISimulator.sol";
 
-import { FastLaneOnlineControl } from "./FastLaneControl.sol";
 import { OuterHelpers } from "./OuterHelpers.sol";
 
 import { SwapIntent, BaselineCall, Reputation } from "./FastLaneTypes.sol";

--- a/src/contracts/gasCalculator/ArbitrumGasCalculator.sol
+++ b/src/contracts/gasCalculator/ArbitrumGasCalculator.sol
@@ -6,6 +6,10 @@ import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { ArbGasInfo } from "nitro-contracts/src/precompiles/ArbGasInfo.sol";
 import { IL2GasCalculator } from "src/contracts/interfaces/IL2GasCalculator.sol";
 
+// TODO in GasAccLib - need a way to get calldata price for static SolverOp.
+// For now that can be a constant amount of zero and non-zero bytes, that get put through getCalldataGas() to get a
+// number to add to solverOp.data cost.
+
 // NOTE: For Arbitrum gas pricing calibration. Replace with constants once calibrated.
 // - getCalldataGas: Y = A(zero bytes)(gasPerL1Byte) + B(non-zero bytes)(gasPerL1Byte) + C
 // - initialGasUsed: Y = A(zero bytes)(gasPerL1Byte) + B(non-zero bytes)(gasPerL1Byte) + R(perL2TxInArbGas) + C
@@ -74,7 +78,7 @@ contract ArbitrumGasCalculator is IL2GasCalculator, Ownable {
 
     /// @notice Calculate the initial gas used for a transaction
     /// @param data The calldata for which to calculate the gas cost
-    /// @return gasUsed The amount of gas used
+    /// @return gasUsed The initial gas used for the metacall in ArbGas units
     function initialGasUsed(bytes calldata data) external view override returns (uint256 gasUsed) {
         // Get the number of zero and non-zero bytes in the calldata
         uint256 zeroByteCount = data.countZeroBytesCalldata();

--- a/src/contracts/gasCalculator/ArbitrumGasCalculator.sol
+++ b/src/contracts/gasCalculator/ArbitrumGasCalculator.sol
@@ -5,12 +5,14 @@ import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { ArbGasInfo } from "nitro-contracts/src/precompiles/ArbGasInfo.sol";
 import { IL2GasCalculator } from "src/contracts/interfaces/IL2GasCalculator.sol";
 
-// TODO Remove this when Arbitrum calldata gas calculation is calibrated
-// Temporary struct to hold all calldata calibration variables in a single slot.
-// Gas Per L2 Calldata Byte = calldataLength * perL1CalldataByte * (M / SCALE) + C
+// NOTE: For Arbitrum gas pricing calibration. Replace with constants once calibrated.
+// - getCalldataGas: Y = A(zero bytes)(gasPerL1Byte) + B(non-zero bytes)(gasPerL1Byte) + C
+// - initialGasUsed: Y = A(zero bytes)(gasPerL1Byte) + B(non-zero bytes)(gasPerL1Byte) + R(perL2TxInArbGas) + C
 struct CalibrationVars {
-    uint128 M; // Coefficient for calldata length
-    uint128 C; // Constant offset
+    uint64 A; // zero byte calldata sensitivity to gasPerL1Byte
+    uint64 B; // non-zero byte calldata sensitivity to gasPerL1Byte
+    uint64 R; // initialGasUsed sensitivity to perL2TxInArbGas
+    uint64 C; // constant offset
 }
 
 /// @title ArbitrumGasCalculator
@@ -20,34 +22,47 @@ contract ArbitrumGasCalculator is IL2GasCalculator, Ownable {
     ArbGasInfo public constant ARB_GAS_INFO = ArbGasInfo(address(0x000000000000000000000000000000000000006C));
 
     // Denominator for M in calldata gas calibration
-    uint128 public constant SCALE = 10_000; // 10_000 / 10_000 = 100%
+    uint64 public constant SCALE = 10_000; // 10_000 / 10_000 = 100%
 
     CalibrationVars internal s_gasVars = CalibrationVars({
-        M: SCALE, // Scaling factor of 100%
-        C: 0 // Offset of 0
+        A: 200, // calldata starts as 2% of perL1TxInArbGas per zero byte
+        B: 9_600, // calldata starts as 96% of perL1TxInArbGas per non-zero byte
+        R: SCALE, // initialGasUsed starts as +100% of perL2TxInArbGas
+        C: 0     // constant offset starts as 0
      });
 
     /// @notice Constructor
     constructor() Ownable(msg.sender) { }
 
-    function getCalibrationVars() external view returns (uint128 M, uint128 C) {
+    // ------------------------------------------------------- //
+    //                      OWNER FUNCTIONS                    //
+    // ------------------------------------------------------- //
+
+    function getCalibrationVars() external view returns (uint64 A, uint64 B, uint64 R, uint64 C) {
         // Return the current calibration variables
-        return (s_gasVars.M, s_gasVars.C);
+        return (s_gasVars.A, s_gasVars.B, s_gasVars.R, s_gasVars.C);
     }
 
-    function setCalibrationVars(uint128 M, uint128 C) external onlyOwner {
+    function setCalibrationVars(uint64 A, uint64 B, uint64 R, uint64 C) external onlyOwner {
         // Set the calibration variables for gas calculation
-        s_gasVars = CalibrationVars({ M: M, C: C });
+        s_gasVars = CalibrationVars({ A: A, B: B, R: R, C: C });
     }
+
+    // ------------------------------------------------------- //
+    //                    EXTERNAL FUNCTIONS                   //
+    // ------------------------------------------------------- //
 
     /// @notice Calculate the calldata cost in gas units on Arbitrum
     /// @param calldataLength Length of the calldata in bytes
     /// @return calldataGas The gas cost of the calldata in ArbGas
-    function getCalldataGas(uint256 calldataLength) external view override returns (uint256 calldataGas) {
+    function getCalldataGas(bytes calldata data) external view override returns (uint256 calldataGas) {
+
+        // TODO get zero and non-zero byte counts from data
+
         // Get the price per L1 calldata byte in ArbGas
-        (, uint256 perL1CalldataByte,) = ARB_GAS_INFO.getPricesInArbGas();
+        (uint256 perL2TxInArbGas, uint256 perL1CalldataByteInArbGas,) = ARB_GAS_INFO.getPricesInArbGas();
         CalibrationVars memory gasVars = s_gasVars;
-        return calldataLength * perL1CalldataByte * gasVars.M / SCALE + gasVars.C;
+        return calldataLength * perL1CalldataByteInArbGas * gasVars.B / SCALE + gasVars.C;
     }
 
     /// @notice Calculate the initial gas used for a transaction
@@ -59,4 +74,10 @@ contract ArbitrumGasCalculator is IL2GasCalculator, Ownable {
         CalibrationVars memory gasVars = s_gasVars;
         return calldataLength * perL1CalldataByte * gasVars.M / SCALE + gasVars.C;
     }
+
+    // ------------------------------------------------------- //
+    //                     INTERNAL HELPERS                    //
+    // ------------------------------------------------------- //
+
+    
 }

--- a/src/contracts/gasCalculator/BaseGasCalculator.sol
+++ b/src/contracts/gasCalculator/BaseGasCalculator.sol
@@ -24,11 +24,13 @@ contract BaseGasCalculator is IL2GasCalculator, Ownable {
     }
 
     /// @notice Calculate the calldata cost in gas units on a L2 with a different fee structure than mainnet
-    /// @param calldataLength The length of the calldata in bytes
-    /// @return calldataGas The gas of the calldata in ETH
-    function getCalldataGas(uint256 calldataLength) external view override returns (uint256 calldataGas) {
+    /// @param data The calldata for which to calculate the gas cost
+    /// @return calldataGas The gas cost of the calldata in gas units
+    function getCalldataGas(bytes calldata data) external view override returns (uint256 calldataGas) {
         // `getL1FeeUpperBound` returns the upper bound of the L1 fee in wei. It expects an unsigned transaction size in
         // bytes, *not calldata length only*, which makes this function a rough estimate.
+
+        uint256 calldataLength = data.length;
 
         // Base execution gas.
         calldataGas = calldataLength * _CALLDATA_LENGTH_PREMIUM_HALVED;
@@ -56,9 +58,10 @@ contract BaseGasCalculator is IL2GasCalculator, Ownable {
     }
 
     /// @notice Gets the cost of initial gas used for a transaction with a different calldata fee than mainnet
-    /// @param calldataLength The length of the calldata in bytes
-    function initialGasUsed(uint256 calldataLength) external pure override returns (uint256 gasUsed) {
-        return calldataLength * _CALLDATA_LENGTH_PREMIUM_HALVED;
+    /// @param data The calldata for which to calculate the initial gas used
+    /// @return gasUsed The initial gas used for the metacall in gas units
+    function initialGasUsed(bytes calldata data) external pure override returns (uint256 gasUsed) {
+        return data.length * _CALLDATA_LENGTH_PREMIUM_HALVED;
     }
 
     /// @notice Sets the calldata length offset

--- a/src/contracts/interfaces/IAtlasVerification.sol
+++ b/src/contracts/interfaces/IAtlasVerification.sol
@@ -21,12 +21,7 @@ interface IAtlasVerification {
         bool isSimulation
     )
         external
-        returns (
-            uint256 allSolversGasLimit,
-            uint256 allSolversCalldataGas,
-            uint256 bidFindOverhead,
-            ValidCallsResult verifyCallsResult
-        );
+        returns (uint256 allSolversGasLimit, uint256 bidFindOverhead, ValidCallsResult verifyCallsResult);
     function verifySolverOp(
         SolverOperation calldata solverOp,
         bytes32 userOpHash,

--- a/src/contracts/interfaces/IL2GasCalculator.sol
+++ b/src/contracts/interfaces/IL2GasCalculator.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.28;
 
 interface IL2GasCalculator {
     /// @notice Calculate the cost (in gas units) of calldata in ETH on a L2 with a different fee structure than mainnet
-    function getCalldataGas(uint256 calldataLength) external view returns (uint256 calldataGas);
+    function getCalldataGas(bytes calldata data) external view returns (uint256 calldataGas);
 
     /// @notice Gets the cost (in gas units) of initial gas used for a tx with a different calldata fee than mainnet
-    function initialGasUsed(uint256 calldataLength) external view returns (uint256 gasUsed);
+    function initialGasUsed(bytes calldata data) external view returns (uint256 gasUsed);
 }

--- a/test/ArbitrumGasCalculator.t.sol
+++ b/test/ArbitrumGasCalculator.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.28;
+
+import "forge-std/Test.sol";
+
+import { ArbitrumGasCalculator } from "../src/contracts/gasCalculator/ArbitrumGasCalculator.sol";
+import { ArbitrumTest } from "./Arbitrum.t.sol";
+
+contract ArbitrumGasCalculatorTest is ArbitrumTest {
+
+    function setUp() public virtual override {
+        // Arbitrum.t.sol's setUp handles forking Arbitrum
+        // and deploying the Arbitrum L2GasCalculator
+        super.setUp();
+    }
+
+    function test_ArbitrumGasCalculator_TEMP() public {
+    
+    }
+}

--- a/test/AtlasVerification.t.sol
+++ b/test/AtlasVerification.t.sol
@@ -150,7 +150,6 @@ contract AtlasVerificationBase is BaseTest {
     // TODO update tests to check allSolversGasLimit, allSolversCalldataGas, bidFindOverhead return values
     function doValidateCalls(ValidCallsCall memory call) public returns (
         uint256 allSolversGasLimit,
-        uint256 allSolversCalldataGas,
         uint256 bidFindOverhead,
         ValidCallsResult result
     ) {
@@ -160,7 +159,7 @@ contract AtlasVerificationBase is BaseTest {
         call.metacallGasLeft = _gasLim(call.userOp, call.solverOps) - 10_000; 
 
         vm.startPrank(address(atlas));
-        (allSolversGasLimit,  allSolversCalldataGas, bidFindOverhead, result) = atlasVerification.validateCalls(
+        (allSolversGasLimit, bidFindOverhead, result) = atlasVerification.validateCalls(
             config,
             call.userOp,
             call.solverOps,
@@ -181,7 +180,7 @@ contract AtlasVerificationBase is BaseTest {
     function callAndAssert(ValidCallsCall memory call, ValidCallsResult expected) public {
         ValidCallsResult result;
         // TODO add tests for new return values
-        (,,, result) = doValidateCalls(call);
+        (,, result) = doValidateCalls(call);
         assertValidCallsResult(result, expected);
     }
 
@@ -1850,7 +1849,7 @@ contract AtlasVerificationValidCallsTest is AtlasVerificationBase {
 
     function testGetDomainSeparatorInAtlasVerification() public view {
         bytes32 hashedName = keccak256(bytes("AtlasVerification"));
-        bytes32 hashedVersion = keccak256(bytes("1.6.1"));
+        bytes32 hashedVersion = keccak256(bytes("1.7"));
         bytes32 typeHash = keccak256(
             "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
         );

--- a/test/MultipleSolversFourTest.t.sol
+++ b/test/MultipleSolversFourTest.t.sol
@@ -42,6 +42,8 @@ contract MultipleSolversFourTest is BaseTest, AtlasErrors {
 
     uint256 solverBidAmount = 1 ether;
 
+    MemoryToCalldataHelper calldataHelper;
+
     function setUp() public override {
         super.setUp();
 
@@ -78,6 +80,8 @@ contract MultipleSolversFourTest is BaseTest, AtlasErrors {
         vm.deal(address(solver4), 10 * solverBidAmount);
         vm.prank(solverFourEOA);
         atlas.depositAndBond{value: 5 ether}(5 ether);
+
+        calldataHelper = new MemoryToCalldataHelper();
     }
 
     function buildUserOperation(uint256 signerPK) internal view returns (UserOperation memory) {
@@ -217,7 +221,7 @@ contract MultipleSolversFourTest is BaseTest, AtlasErrors {
         console.log("Solver1 max win gas:", solver1MaxWinGas);
         
         // Verify simulator calculation
-        uint256 solver1CalldataGas = GasAccLib.solverOpCalldataGas(solverOp1.data.length, atlas.L2_GAS_CALCULATOR());
+        uint256 solver1CalldataGas = calldataHelper.solverOpCalldataGas(solverOp1.data, atlas.L2_GAS_CALCULATOR());
         uint256 solver1ExpectedGas = (solver1CalldataGas + (solverOp1.gas + 21000)) * solverOp1.maxFeePerGas;
         solver1ExpectedGas = solver1ExpectedGas * 120 / 100; // 20% surcharge
         assertApproxEqAbs(solver1MaxWinGas, solver1ExpectedGas, solver1ExpectedGas / 20, "Solver1 gas estimation mismatch");
@@ -253,7 +257,7 @@ contract MultipleSolversFourTest is BaseTest, AtlasErrors {
         console.log("Solver2 max win gas:", solver2MaxWinGas);
         
         // Verify simulator calculation
-        uint256 solver2CalldataGas = GasAccLib.solverOpCalldataGas(solverOp2.data.length, atlas.L2_GAS_CALCULATOR());
+        uint256 solver2CalldataGas = calldataHelper.solverOpCalldataGas(solverOp2.data, atlas.L2_GAS_CALCULATOR());
         uint256 solver2ExpectedGas = (solver2CalldataGas + (solverOp2.gas + 21000)) * solverOp2.maxFeePerGas;
         solver2ExpectedGas = solver2ExpectedGas * 120 / 100; // 20% surcharge
         assertApproxEqAbs(solver2MaxWinGas, solver2ExpectedGas, solver2ExpectedGas / 20, "Solver2 gas estimation mismatch");
@@ -289,7 +293,7 @@ contract MultipleSolversFourTest is BaseTest, AtlasErrors {
         console.log("Solver3 max win gas:", solver3MaxWinGas);
         
         // Verify simulator calculation
-        uint256 solver3CalldataGas = GasAccLib.solverOpCalldataGas(solverOp3.data.length, atlas.L2_GAS_CALCULATOR());
+        uint256 solver3CalldataGas = calldataHelper.solverOpCalldataGas(solverOp3.data, atlas.L2_GAS_CALCULATOR());
         uint256 solver3ExpectedGas = (solver3CalldataGas + (solverOp3.gas + 21000)) * solverOp3.maxFeePerGas;
         solver3ExpectedGas = solver3ExpectedGas * 120 / 100; // 20% surcharge
         assertApproxEqAbs(solver3MaxWinGas, solver3ExpectedGas, solver3ExpectedGas / 20, "Solver3 gas estimation mismatch");
@@ -325,7 +329,7 @@ contract MultipleSolversFourTest is BaseTest, AtlasErrors {
         console.log("Solver4 max win gas:", solver4MaxWinGas);
         
         // Verify simulator calculation
-        uint256 solver4CalldataGas = GasAccLib.solverOpCalldataGas(solverOp4.data.length, atlas.L2_GAS_CALCULATOR());
+        uint256 solver4CalldataGas = calldataHelper.solverOpCalldataGas(solverOp4.data, atlas.L2_GAS_CALCULATOR());
         uint256 solver4ExpectedGas = (solver4CalldataGas + (solverOp4.gas + 21000)) * solverOp4.maxFeePerGas;
         solver4ExpectedGas = solver4ExpectedGas * 120 / 100; // 20% surcharge
         assertApproxEqAbs(solver4MaxWinGas, solver4ExpectedGas, solver4ExpectedGas / 20, "Solver4 gas estimation mismatch");
@@ -689,5 +693,15 @@ contract MockSolver is SolverBase {
             revert("revertWhileSolving");
         }
         executed = true;
+    }
+}
+
+contract MemoryToCalldataHelper {
+    function solverOpCalldataGas(bytes calldata data, address l2GasCalculator) external view returns (uint256 gas) {
+        return GasAccLib.solverOpCalldataGas(data, l2GasCalculator);
+    }
+
+    function metacallCalldataGas(bytes calldata data, address l2GasCalculator) external view returns (uint256 gas) {
+        return GasAccLib.metacallCalldataGas(data, l2GasCalculator);
     }
 }

--- a/test/base/MockL2GasCalculator.sol
+++ b/test/base/MockL2GasCalculator.sol
@@ -7,12 +7,12 @@ import { IL2GasCalculator } from "../../src/contracts/interfaces/IL2GasCalculato
 // Very basic MockL2GasCalculator for testing, just returns 5x what the default (address(0)) gas calculator would.
 contract MockL2GasCalculator is IL2GasCalculator {
     // Should return 5x the default calldata gas
-    function getCalldataGas(uint256 calldataLength) external view returns (uint256 calldataGas) {
-        return calldataLength * GasAccLib._CALLDATA_LENGTH_PREMIUM_HALVED * 5;
+    function getCalldataGas(bytes calldata data) external view returns (uint256 calldataGas) {
+        return data.length * GasAccLib._CALLDATA_LENGTH_PREMIUM_HALVED * 5;
     }
 
     // Should return 5x the default initial gas used
-    function initialGasUsed(uint256 calldataLength) external view returns (uint256 gasUsed) {
-        return calldataLength * GasAccLib._CALLDATA_LENGTH_PREMIUM_HALVED * 5;
+    function initialGasUsed(bytes calldata data) external view returns (uint256 gasUsed) {
+        return data.length * GasAccLib._CALLDATA_LENGTH_PREMIUM_HALVED * 5;
     }
 }

--- a/test/base/TestAtlasVerification.sol
+++ b/test/base/TestAtlasVerification.sol
@@ -19,12 +19,7 @@ contract TestAtlasVerification is AtlasVerification {
     )
         public
         view
-        returns (
-            ValidCallsResult validCallsResult,
-            uint256 allSolversGasLimit,
-            uint256 allSolversCalldataGas,
-            uint256 bidFindOverhead
-        )
+        returns (ValidCallsResult validCallsResult, uint256 allSolversGasLimit, uint256 bidFindOverhead)
     {
         return _getAndVerifyGasLimits(solverOps, dConfig, userOpGas, metacallGasLeft);
     }


### PR DESCRIPTION
### Changes vs Arbitrum Atlas v1.6.1

- Calldata gas is calculated as a function of the actual calldata bytes, passed to GasAccLib and the L2GasCalculator, instead of just the calldata length as a uint. This gives us the optionality to either just use the length, or analyse the zero to non-zero byte ratio.
- The Arbitrum L2GasCalculator is more configurable now:
  - With the actual calldata bytes of 1) the standard metacall params and 2) the solverOp.data, being passed in, we can use `countZeroBytesCalldata()` from Solady to get the number of zero and non-zero calldata bytes. This seems useful as the empirical metacall data from Artbitrum one shows that the compression ratio is highly correlated to how much of the calldata is zero bytes.
  - `initialGasUsed()` now has 4 coefficients that can be adjusted:
  ```
  Y = A(zero bytes)(gasPerL1Byte) + B(non-zero bytes)(gasPerL1Byte) + R(perL2TxInArbGas) + C
  ```
  - `getCalldataGas()` now has 3 coefficients that can be adjusted:
  ```
  Y = A(zero bytes)(gasPerL1Byte) + B(non-zero bytes)(gasPerL1Byte) + C
  ```
- An inline assembly helper `_endOfMetacallArgs()` has been added to calculate the index of the end of the standard `metacall()` calldata. This should be a very gas efficient calculation as it uses the last dynamic bytes field, `dAppOp.signature`, as an anchor point, which avoids any looping through solverOps etc. It is important to get the slice of calldata this way as opposed to just using `msg.data` because it prevents charging the winning solver for any extra calldata packed onto the metacall by a bundler.
- In foundry.toml, `optimizer_runs` has been lowered from 50 to 8, to keep Atlas within the ~24.5 kb size limit. This may have a small impact on gas efficiency.

### To Do

- [ ] A longer term solution is needed in GasAccLib, in `solverOpCalldataGas()` where the gas per byte of the static solverOp calldata is estimated assuming the ratio of zero to non-zero bytes is similar to that of the dynamic `solverOp.data` part. This may not be a reliable assumption.
- [ ] In the Simulator, in any functions that take a single SolverOperation calldata param should be refactored to take a SolverOperation array with that single SolverOperation as the only item in the array. This would let us keep the SolverOperation in calldata instead of copying it into a memory form, which then requires separate versions of some of the gas accounting functions for calldata and memory.
- [ ] Simulator should be refactored and cleaned up in general.
- [ ] The Arbitrum L2GasCalculator needs to be rigorously tested, especially around the ability to robustly count zero vs non-zero calldata bytes.

