### PR TITLE
feat: Atlas v1.6.2

### DIFF
--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -696,17 +696,21 @@ contract AtlasVerification is EIP712, NonceManager, DAppIntegration {
             allSolversGasLimit += allSolversCalldataGas;
         }
 
-        uint256 _execGasUpperTolerance = _UPPER_BASE_EXEC_GAS_TOLERANCE + solverOpsLen * _TOLERANCE_PER_SOLVER;
-        uint256 _execGasLowerTolerance = _LOWER_BASE_EXEC_GAS_TOLERANCE + solverOpsLen * _TOLERANCE_PER_SOLVER;
+        // If checkMetacallGasLimit is enabled, verify that the execution gas measured by gasleft() at the start of the
+        // metacall is in line with the expected gas limit, based on the userOp, solverOps, and dAppOp.
+        if (dConfig.callConfig.checkMetacallGasLimit()) {
+            uint256 _execGasUpperTolerance = _UPPER_BASE_EXEC_GAS_TOLERANCE + solverOpsLen * _TOLERANCE_PER_SOLVER;
+            uint256 _execGasLowerTolerance = _LOWER_BASE_EXEC_GAS_TOLERANCE + solverOpsLen * _TOLERANCE_PER_SOLVER;
 
-        // Gas limit set by the bundler cannot be too high or too low. Use Simulator contract to estimate gas limit.
-        // If gas limit is too low, the bonded balance threshold checked may not cover all gas reimbursements.
-        if (metacallGasLeft < metacallExecutionGas - _execGasLowerTolerance) {
-            verifyCallsResult = ValidCallsResult.MetacallGasLimitTooLow;
-        }
-        // If gas limit is too high, the bonded balance threshold checked could unexpectedly price out solvers.
-        if (metacallGasLeft > metacallExecutionGas + _execGasUpperTolerance) {
-            verifyCallsResult = ValidCallsResult.MetacallGasLimitTooHigh;
+            // Gas limit set by the bundler cannot be too high or too low. Use Simulator contract to estimate gas limit.
+            // If gas limit is too low, the bonded balance threshold checked may not cover all gas reimbursements.
+            if (metacallGasLeft < metacallExecutionGas - _execGasLowerTolerance) {
+                verifyCallsResult = ValidCallsResult.MetacallGasLimitTooLow;
+            }
+            // If gas limit is too high, the bonded balance threshold checked could unexpectedly price out solvers.
+            if (metacallGasLeft > metacallExecutionGas + _execGasUpperTolerance) {
+                verifyCallsResult = ValidCallsResult.MetacallGasLimitTooHigh;
+            }
         }
 
         return (verifyCallsResult, allSolversGasLimit, allSolversCalldataGas, bidFindOverhead);

--- a/src/contracts/examples/ex-post-mev-example/V2ExPost.sol
+++ b/src/contracts/examples/ex-post-mev-example/V2ExPost.sol
@@ -61,7 +61,8 @@ contract V2ExPost is DAppControl {
                 trustedOpHash: false,
                 invertBidValue: false,
                 exPostBids: true,
-                multipleSuccessfulSolvers: false
+                multipleSuccessfulSolvers: false,
+                checkMetacallGasLimit: true
             })
         )
     { }

--- a/src/contracts/examples/fastlane-online/FastLaneControl.sol
+++ b/src/contracts/examples/fastlane-online/FastLaneControl.sol
@@ -48,7 +48,8 @@ contract FastLaneOnlineControl is DAppControl, FastLaneOnlineErrors {
                 trustedOpHash: false,
                 invertBidValue: false,
                 exPostBids: false,
-                multipleSuccessfulSolvers: false
+                multipleSuccessfulSolvers: false,
+                checkMetacallGasLimit: true
             })
         )
     { }

--- a/src/contracts/examples/gas-filler/Filler.sol
+++ b/src/contracts/examples/gas-filler/Filler.sol
@@ -88,7 +88,8 @@ contract Filler is DAppControl {
                 trustedOpHash: false,
                 invertBidValue: true,
                 exPostBids: false,
-                multipleSuccessfulSolvers: false
+                multipleSuccessfulSolvers: false,
+                checkMetacallGasLimit: true
             })
         )
     { }

--- a/src/contracts/examples/generalized-backrun/GeneralizedBackrunUserBundler.sol
+++ b/src/contracts/examples/generalized-backrun/GeneralizedBackrunUserBundler.sol
@@ -72,7 +72,8 @@ contract GeneralizedBackrunUserBundler is DAppControl {
                 trustedOpHash: true,
                 invertBidValue: false,
                 exPostBids: false,
-                multipleSuccessfulSolvers: false
+                multipleSuccessfulSolvers: false,
+                checkMetacallGasLimit: true
             })
         )
     { }

--- a/src/contracts/examples/intents-example/SwapIntentDAppControl.sol
+++ b/src/contracts/examples/intents-example/SwapIntentDAppControl.sol
@@ -64,7 +64,8 @@ contract SwapIntentDAppControl is DAppControl {
                 trustedOpHash: true,
                 invertBidValue: false,
                 exPostBids: false,
-                multipleSuccessfulSolvers: false
+                multipleSuccessfulSolvers: false,
+                checkMetacallGasLimit: true
             })
         )
     { }

--- a/src/contracts/examples/intents-example/SwapIntentInvertBidDAppControl.sol
+++ b/src/contracts/examples/intents-example/SwapIntentInvertBidDAppControl.sol
@@ -65,7 +65,8 @@ contract SwapIntentInvertBidDAppControl is DAppControl {
                 trustedOpHash: true,
                 invertBidValue: true,
                 exPostBids: false,
-                multipleSuccessfulSolvers: false
+                multipleSuccessfulSolvers: false,
+                checkMetacallGasLimit: true
             })
         )
     {

--- a/src/contracts/examples/intents-example/V4SwapIntent.sol
+++ b/src/contracts/examples/intents-example/V4SwapIntent.sol
@@ -59,7 +59,8 @@ contract V4SwapIntentControl is DAppControl {
                 trustedOpHash: false,
                 invertBidValue: false,
                 exPostBids: false,
-                multipleSuccessfulSolvers: false
+                multipleSuccessfulSolvers: false,
+                checkMetacallGasLimit: true
             })
         )
     {

--- a/src/contracts/examples/oev-example/ChainlinkDAppControl.sol
+++ b/src/contracts/examples/oev-example/ChainlinkDAppControl.sol
@@ -77,7 +77,8 @@ contract ChainlinkDAppControl is DAppControl {
                 trustedOpHash: true,
                 invertBidValue: false,
                 exPostBids: false,
-                multipleSuccessfulSolvers: false
+                multipleSuccessfulSolvers: false,
+                checkMetacallGasLimit: true
             })
         )
     { }

--- a/src/contracts/examples/oev-example/ChainlinkDAppControlAlt.sol
+++ b/src/contracts/examples/oev-example/ChainlinkDAppControlAlt.sol
@@ -73,7 +73,8 @@ contract ChainlinkDAppControl is DAppControl {
                 trustedOpHash: true,
                 invertBidValue: false,
                 exPostBids: false,
-                multipleSuccessfulSolvers: false
+                multipleSuccessfulSolvers: false,
+                checkMetacallGasLimit: true
             })
         )
     { }

--- a/src/contracts/examples/trebleswap/TrebleSwapDAppControl.sol
+++ b/src/contracts/examples/trebleswap/TrebleSwapDAppControl.sol
@@ -54,7 +54,8 @@ contract TrebleSwapDAppControl is DAppControl {
                 trustedOpHash: false,
                 invertBidValue: false,
                 exPostBids: false,
-                multipleSuccessfulSolvers: false
+                multipleSuccessfulSolvers: false,
+                checkMetacallGasLimit: true
             })
         )
     { }

--- a/src/contracts/examples/v2-example-router/V2RewardDAppControl.sol
+++ b/src/contracts/examples/v2-example-router/V2RewardDAppControl.sol
@@ -61,7 +61,8 @@ contract V2RewardDAppControl is DAppControl {
                 trustedOpHash: true,
                 invertBidValue: false,
                 exPostBids: true,
-                multipleSuccessfulSolvers: false
+                multipleSuccessfulSolvers: false,
+                checkMetacallGasLimit: true
             })
         )
     {

--- a/src/contracts/examples/v2-example/V2DAppControl.sol
+++ b/src/contracts/examples/v2-example/V2DAppControl.sol
@@ -75,7 +75,8 @@ contract V2DAppControl is DAppControl {
                 trustedOpHash: false,
                 invertBidValue: false,
                 exPostBids: false,
-                multipleSuccessfulSolvers: false
+                multipleSuccessfulSolvers: false,
+                checkMetacallGasLimit: true
             })
         )
     {

--- a/src/contracts/examples/v4-example/V4DAppControl.sol
+++ b/src/contracts/examples/v4-example/V4DAppControl.sol
@@ -72,7 +72,8 @@ contract V4DAppControl is DAppControl {
                 trustedOpHash: false,
                 invertBidValue: false,
                 exPostBids: false,
-                multipleSuccessfulSolvers: false
+                multipleSuccessfulSolvers: false,
+                checkMetacallGasLimit: true
             })
         )
     {

--- a/src/contracts/libraries/CallBits.sol
+++ b/src/contracts/libraries/CallBits.sol
@@ -73,6 +73,9 @@ library CallBits {
         if (callConfig.multipleSuccessfulSolvers) {
             encodedCallConfig ^= _ONE << uint32(CallConfigIndex.MultipleSuccessfulSolvers);
         }
+        if (callConfig.checkMetacallGasLimit) {
+            encodedCallConfig ^= _ONE << uint32(CallConfigIndex.CheckMetacallGasLimit);
+        }
     }
 
     function decodeCallConfig(uint32 encodedCallConfig) internal pure returns (CallConfig memory callConfig) {
@@ -96,6 +99,7 @@ library CallBits {
         callConfig.invertBidValue = invertsBidValue(encodedCallConfig);
         callConfig.exPostBids = exPostBids(encodedCallConfig);
         callConfig.multipleSuccessfulSolvers = multipleSuccessfulSolvers(encodedCallConfig);
+        callConfig.checkMetacallGasLimit = checkMetacallGasLimit(encodedCallConfig);
     }
 
     function needsSequentialUserNonces(uint32 callConfig) internal pure returns (bool sequential) {
@@ -176,5 +180,9 @@ library CallBits {
 
     function multipleSuccessfulSolvers(uint32 callConfig) internal pure returns (bool) {
         return (callConfig & (1 << uint32(CallConfigIndex.MultipleSuccessfulSolvers))) != 0;
+    }
+
+    function checkMetacallGasLimit(uint32 callConfig) internal pure returns (bool) {
+        return (callConfig & (1 << uint32(CallConfigIndex.CheckMetacallGasLimit))) != 0;
     }
 }

--- a/src/contracts/types/ConfigTypes.sol
+++ b/src/contracts/types/ConfigTypes.sol
@@ -75,6 +75,9 @@ struct CallConfig {
     // multipleSolvers: If true, the metacall will proceed even if a solver successfully pays their bid, and will be
     // charged in gas as if it was reverted. If false, the auction ends after the first successful solver.
     bool multipleSuccessfulSolvers;
+    // checkMetacallGasLimit: If true, the execution gas measured by `gasleft()` at the start of the metacall is
+    // verified to be in line with the expected gas limit, based on the userOp, solverOps, and dAppOp.
+    bool checkMetacallGasLimit;
 }
 
 enum CallConfigIndex {
@@ -98,5 +101,6 @@ enum CallConfigIndex {
     TrustedOpHash,
     InvertBidValue,
     ExPostBids,
-    MultipleSuccessfulSolvers
+    MultipleSuccessfulSolvers,
+    CheckMetacallGasLimit
 }

--- a/test/FlashLoan.t.sol
+++ b/test/FlashLoan.t.sol
@@ -324,7 +324,8 @@ contract DummyDAppControlBuilder is DAppControl {
                 trustedOpHash: false,
                 invertBidValue: false,
                 exPostBids: false,
-                multipleSuccessfulSolvers: false
+                multipleSuccessfulSolvers: false,
+                checkMetacallGasLimit: true
             })
         )
     {

--- a/test/MultipleSolversFourTest.t.sol
+++ b/test/MultipleSolversFourTest.t.sol
@@ -628,7 +628,8 @@ contract MultipleSolversDAppControl is DAppControl {
                 trustedOpHash: false,
                 invertBidValue: false,
                 exPostBids: false,
-                multipleSuccessfulSolvers: true
+                multipleSuccessfulSolvers: true,
+                checkMetacallGasLimit: true
             })
         )
     {}

--- a/test/MultipleSolversLockStateTest.t.sol
+++ b/test/MultipleSolversLockStateTest.t.sol
@@ -266,7 +266,8 @@ contract SolverLockDAppControl is DAppControl {
                 trustedOpHash: false,
                 invertBidValue: false,
                 exPostBids: false,
-                multipleSuccessfulSolvers: true
+                multipleSuccessfulSolvers: true,
+                checkMetacallGasLimit: true
             })
         )
     {}

--- a/test/MultipleSolversTest.t.sol
+++ b/test/MultipleSolversTest.t.sol
@@ -327,7 +327,8 @@ contract MultipleSolversDAppControl is DAppControl {
                 trustedOpHash: false,
                 invertBidValue: false,
                 exPostBids: false,
-                multipleSuccessfulSolvers: true
+                multipleSuccessfulSolvers: true,
+                checkMetacallGasLimit: true
             })
         )
     {}

--- a/test/helpers/CallConfigBuilder.sol
+++ b/test/helpers/CallConfigBuilder.sol
@@ -26,6 +26,7 @@ contract CallConfigBuilder is Test {
     bool invertBidValue;
     bool exPostBids;
     bool multipleSuccessfulSolvers;
+    bool checkMetacallGasLimit;
 
     function withUserNoncesSequential(bool _sequential) public returns (CallConfigBuilder) {
         userNoncesSequential = _sequential;
@@ -122,6 +123,16 @@ contract CallConfigBuilder is Test {
         return this;
     }
 
+    function withMultipleSuccessfulSolvers(bool _multipleSuccessfulSolvers) public returns (CallConfigBuilder) {
+        multipleSuccessfulSolvers = _multipleSuccessfulSolvers;
+        return this;
+    }
+
+    function withCheckMetacallGasLimit(bool _checkMetacallGasLimit) public returns (CallConfigBuilder) {
+        checkMetacallGasLimit = _checkMetacallGasLimit;
+        return this;
+    }
+
     function build() public view returns (CallConfig memory) {
         return CallConfig(
             userNoncesSequential,
@@ -143,7 +154,8 @@ contract CallConfigBuilder is Test {
             trustedOpHash,
             invertBidValue,
             exPostBids,
-            multipleSuccessfulSolvers
+            multipleSuccessfulSolvers,
+            checkMetacallGasLimit
         );
     }
 }

--- a/test/libraries/CallBits.t.sol
+++ b/test/libraries/CallBits.t.sol
@@ -34,7 +34,8 @@ contract CallBitsTest is Test {
             trustedOpHash: false,
             invertBidValue: true,
             exPostBids: false,
-            multipleSuccessfulSolvers: false
+            multipleSuccessfulSolvers: true,
+            checkMetacallGasLimit: false
         });
 
         callConfig2 = CallConfig({
@@ -57,19 +58,20 @@ contract CallBitsTest is Test {
             trustedOpHash: !callConfig1.trustedOpHash,
             invertBidValue: !callConfig1.invertBidValue,
             exPostBids: !callConfig1.exPostBids,
-            multipleSuccessfulSolvers: !callConfig1.multipleSuccessfulSolvers
+            multipleSuccessfulSolvers: !callConfig1.multipleSuccessfulSolvers,
+            checkMetacallGasLimit: !callConfig1.checkMetacallGasLimit
         });
     }
 
     function testEncodeCallConfig() public view {
-        string memory expectedBitMapString = "00000000000000101010101010101010";
+        string memory expectedBitMapString = "00000000000010101010101010101010";
         assertEq(
             TestUtils.uint32ToBinaryString(CallBits.encodeCallConfig(callConfig1)),
             expectedBitMapString,
             "callConfig1 incorrect"
         );
 
-        expectedBitMapString = "00000000000011010101010101010101";
+        expectedBitMapString = "00000000000101010101010101010101";
         assertEq(
             TestUtils.uint32ToBinaryString(CallBits.encodeCallConfig(callConfig2)),
             expectedBitMapString,
@@ -99,7 +101,8 @@ contract CallBitsTest is Test {
         assertEq(decodedCallConfig.trustedOpHash, false, "trustedOpHash 1 incorrect");
         assertEq(decodedCallConfig.invertBidValue, true, "invertBidValue 1 incorrect");
         assertEq(decodedCallConfig.exPostBids, false, "exPostBids 1 incorrect");
-        assertEq(decodedCallConfig.multipleSuccessfulSolvers, false, "multipleSuccessfulSolvers 1 incorrect");
+        assertEq(decodedCallConfig.multipleSuccessfulSolvers, true, "multipleSuccessfulSolvers 1 incorrect");
+        assertEq(decodedCallConfig.checkMetacallGasLimit, false, "checkMetacallGasLimit 1 incorrect");
 
         encodedCallConfig = CallBits.encodeCallConfig(callConfig2);
         decodedCallConfig = encodedCallConfig.decodeCallConfig();
@@ -122,7 +125,8 @@ contract CallBitsTest is Test {
         assertEq(decodedCallConfig.trustedOpHash, true, "trustedOpHash 2 incorrect");
         assertEq(decodedCallConfig.invertBidValue, false, "invertBidValue 2 incorrect");
         assertEq(decodedCallConfig.exPostBids, true, "exPostBids 2 incorrect");
-        assertEq(decodedCallConfig.multipleSuccessfulSolvers, true, "multipleSuccessfulSolvers 2 incorrect");
+        assertEq(decodedCallConfig.multipleSuccessfulSolvers, false, "multipleSuccessfulSolvers 2 incorrect");
+        assertEq(decodedCallConfig.checkMetacallGasLimit, true, "checkMetacallGasLimit 2 incorrect");
     }
 
     function testConfigParameters() public view {
@@ -146,7 +150,8 @@ contract CallBitsTest is Test {
         assertEq(encodedCallConfig.allowsTrustedOpHash(), false, "allowsTrustedOpHash 1 incorrect");
         assertEq(encodedCallConfig.invertsBidValue(), true, "invertsBidValue 1 incorrect");
         assertEq(encodedCallConfig.exPostBids(), false, "exPostBids 1 incorrect");
-        assertEq(encodedCallConfig.multipleSuccessfulSolvers(), false, "multipleSuccessfulSolverss 1 incorrect");
+        assertEq(encodedCallConfig.multipleSuccessfulSolvers(), true, "multipleSuccessfulSolverss 1 incorrect");
+        assertEq(encodedCallConfig.checkMetacallGasLimit(), false, "checkMetacallGasLimit 1 incorrect");
 
         encodedCallConfig = CallBits.encodeCallConfig(callConfig2);
         assertEq(encodedCallConfig.needsSequentialUserNonces(), true, "needsSequentialUserNonces 2 incorrect");
@@ -168,6 +173,7 @@ contract CallBitsTest is Test {
         assertEq(encodedCallConfig.allowsTrustedOpHash(), true, "allowsTrustedOpHash 2 incorrect");
         assertEq(encodedCallConfig.invertsBidValue(), false, "invertsBidValue 2 incorrect");
         assertEq(encodedCallConfig.exPostBids(), true, "exPostBids 2 incorrect");
-        assertEq(encodedCallConfig.multipleSuccessfulSolvers(), true, "multipleSuccessfulSolvers 2 incorrect");
+        assertEq(encodedCallConfig.multipleSuccessfulSolvers(), false, "multipleSuccessfulSolvers 2 incorrect");
+        assertEq(encodedCallConfig.checkMetacallGasLimit(), true, "checkMetacallGasLimit 2 incorrect");
     }
 }


### PR DESCRIPTION
Changes:

- Added a `checkMetacallGasLimit` option to Call Config. When enabled, AtlasVerification will check that the execution gas measured as the start of the metacall is in line with the estimated correct gas limit, considering the userOp, solverOps, and dAppOp. When disabled, AtlasVerification skips these gas limit checks, allowing the bundler to set a higher than suggested gas limit.
- NOTE: If `checkMetacallGasLimit` is disabled, there is a risk that solvers should be aware of - that the bundler could set an unreasonably high gas limit which may prevent solverOps from executing if the solver doesn't have enough bonded atlETH to cover the full gas limit + surcharges should they win.