### PR TITLE
feat: Atlas v1.6.2 Audit Fixes

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
   bytecode_hash = "none"
-  optimizer_runs = 8
+  optimizer_runs = 18
   timeout = 30000
   block_gas_limit = 300000000
   gas_limit = 3000000000

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
   bytecode_hash = "none"
-  optimizer_runs = 18
+  optimizer_runs = 20
   timeout = 30000
   block_gas_limit = 300000000
   gas_limit = 3000000000

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -65,7 +65,8 @@ contract Atlas is Escrow, Factory {
         // is deducted from this _gasMarker, resulting in actual execution gas used + calldata gas costs + buffer.
         // The calldata component is added below, only if exPostBids = false.
         uint256 _gasLeft = gasleft();
-        uint256 _gasMarker = _gasLeft + _BASE_TX_GAS_USED + _FIXED_GAS_OFFSET; // This part is only execution gas.
+        uint256 _gasMarker = _gasLeft + _BASE_TX_GAS_USED + _POST_SETTLE_METACALL_GAS; // This part is only execution
+            // gas.
 
         DAppConfig memory _dConfig;
         bool _isSimulation = msg.sender == SIMULATOR;

--- a/src/contracts/atlas/Atlas.sol
+++ b/src/contracts/atlas/Atlas.sol
@@ -65,7 +65,7 @@ contract Atlas is Escrow, Factory {
         // is deducted from this _gasMarker, resulting in actual execution gas used + calldata gas costs + buffer.
         // The calldata component is added below, only if exPostBids = false.
         uint256 _gasLeft = gasleft();
-        uint256 _gasMarker = _gasLeft + _BASE_TX_GAS_USED + FIXED_GAS_OFFSET; // This part is only execution gas.
+        uint256 _gasMarker = _gasLeft + _BASE_TX_GAS_USED + _FIXED_GAS_OFFSET; // This part is only execution gas.
 
         DAppConfig memory _dConfig;
         bool _isSimulation = msg.sender == SIMULATOR;

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -681,8 +681,8 @@ contract AtlasVerification is EIP712, NonceManager, DAppIntegration {
         allSolversCalldataGas =
             GasAccLib.calldataGas(solverDataLenSum + (_SOLVER_OP_STATIC_LENGTH * solverOps.length), L2_GAS_CALCULATOR);
 
-        uint256 metacallExecutionGas = _BASE_TX_GAS_USED + _PRE_EXECUTE_METACALL_GAS + _FIXED_GAS_OFFSET + userOpGas
-            + dConfig.dappGasLimit + allSolversExecutionGas;
+        uint256 metacallExecutionGas = _BASE_TX_GAS_USED + _PRE_EXECUTE_METACALL_GAS + _POST_SETTLE_METACALL_GAS
+            + userOpGas + dConfig.dappGasLimit + allSolversExecutionGas;
 
         // In both exPostBids and normal bid modes, solvers pay for their own execution gas.
         allSolversGasLimit = allSolversExecutionGas;

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -679,17 +679,17 @@ contract AtlasVerification is EIP712, NonceManager, DAppIntegration {
         }
 
         allSolversCalldataGas =
-            GasAccLib.calldataGas(solverDataLenSum + (_SOLVER_OP_STATIC_LENGTH * solverOps.length), L2_GAS_CALCULATOR);
+            GasAccLib.calldataGas(solverDataLenSum + (_SOLVER_OP_STATIC_LENGTH * solverOpsLen), L2_GAS_CALCULATOR);
 
         uint256 metacallExecutionGas = _BASE_TX_GAS_USED + _PRE_EXECUTE_METACALL_GAS + _POST_SETTLE_METACALL_GAS
-            + userOpGas + dConfig.dappGasLimit + allSolversExecutionGas;
+            + userOpGas + dConfig.dappGasLimit + allSolversExecutionGas + (_EXECUTE_SOLVER_OVERHEAD * solverOpsLen);
 
         // In both exPostBids and normal bid modes, solvers pay for their own execution gas.
         allSolversGasLimit = allSolversExecutionGas;
 
         if (dConfig.callConfig.exPostBids()) {
             // Add extra execution gas for bid-finding loop of each solverOp
-            bidFindOverhead = (solverOpsLen * _BID_FIND_OVERHEAD) + allSolversExecutionGas;
+            bidFindOverhead = solverOpsLen * (_BID_FIND_OVERHEAD + _EXECUTE_SOLVER_OVERHEAD) + allSolversExecutionGas;
             metacallExecutionGas += bidFindOverhead;
             // NOTE: allSolversGasLimit excludes calldata in exPostBids mode.
         } else {

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -681,8 +681,8 @@ contract AtlasVerification is EIP712, NonceManager, DAppIntegration {
         allSolversCalldataGas =
             GasAccLib.calldataGas(solverDataLenSum + (_SOLVER_OP_STATIC_LENGTH * solverOps.length), L2_GAS_CALCULATOR);
 
-        uint256 metacallExecutionGas = _BASE_TX_GAS_USED + AccountingMath._FIXED_GAS_OFFSET + userOpGas
-            + dConfig.dappGasLimit + allSolversExecutionGas;
+        uint256 metacallExecutionGas =
+            _BASE_TX_GAS_USED + _FIXED_GAS_OFFSET + userOpGas + dConfig.dappGasLimit + allSolversExecutionGas;
 
         // In both exPostBids and normal bid modes, solvers pay for their own execution gas.
         allSolversGasLimit = allSolversExecutionGas;

--- a/src/contracts/atlas/AtlasVerification.sol
+++ b/src/contracts/atlas/AtlasVerification.sol
@@ -681,8 +681,8 @@ contract AtlasVerification is EIP712, NonceManager, DAppIntegration {
         allSolversCalldataGas =
             GasAccLib.calldataGas(solverDataLenSum + (_SOLVER_OP_STATIC_LENGTH * solverOps.length), L2_GAS_CALCULATOR);
 
-        uint256 metacallExecutionGas =
-            _BASE_TX_GAS_USED + _FIXED_GAS_OFFSET + userOpGas + dConfig.dappGasLimit + allSolversExecutionGas;
+        uint256 metacallExecutionGas = _BASE_TX_GAS_USED + _PRE_EXECUTE_METACALL_GAS + _FIXED_GAS_OFFSET + userOpGas
+            + dConfig.dappGasLimit + allSolversExecutionGas;
 
         // In both exPostBids and normal bid modes, solvers pay for their own execution gas.
         allSolversGasLimit = allSolversExecutionGas;

--- a/src/contracts/atlas/Storage.sol
+++ b/src/contracts/atlas/Storage.sol
@@ -26,7 +26,6 @@ contract Storage is AtlasEvents, AtlasErrors, AtlasConstants {
 
     // Gas Accounting public constants
     uint256 public constant SCALE = AccountingMath._SCALE;
-    uint256 public constant FIXED_GAS_OFFSET = AccountingMath._FIXED_GAS_OFFSET;
 
     // Transient storage slots
     uint256 internal transient t_lock; // contains activeAddress, callConfig, and phase

--- a/src/contracts/examples/fastlane-online/OuterHelpers.sol
+++ b/src/contracts/examples/fastlane-online/OuterHelpers.sol
@@ -34,7 +34,7 @@ contract OuterHelpers is FastLaneOnlineInner {
     address public immutable SIMULATOR;
 
     uint256 internal constant _BITS_FOR_INDEX = 16;
-    uint256 internal constant _SOLVER_SIM_GAS_LIM = 4_850_000;
+    uint256 internal constant _SOLVER_SIM_GAS_LIM = 5_000_000;
 
     constructor(address atlas, address protocolGuildWallet) FastLaneOnlineInner(atlas) {
         CARDANO_ENGINEER_THERAPY_FUND = msg.sender;

--- a/src/contracts/gasCalculator/BaseGasCalculator.sol
+++ b/src/contracts/gasCalculator/BaseGasCalculator.sol
@@ -12,7 +12,9 @@ interface IGasPriceOracle {
 }
 
 // NOTE: This implementation does not support the Operator Fee introduced in the Isthmus upgrade. A larger refactor of
-// Atlas would be required to support it. See https://docs.optimism.io/stack/transactions/fees#operator-fee
+// Atlas would be required to support it. See https://docs.optimism.io/stack/transactions/fees#operator-fee.
+// If the Operator Fee becomes problematic, increasing the bundler surcharge rate is a potential workaround without
+// requiring any code changes.
 
 contract BaseGasCalculator is IL2GasCalculator, Ownable {
     uint256 internal constant _GAS_PER_CALLDATA_BYTE = 8;

--- a/src/contracts/gasCalculator/BaseGasCalculator.sol
+++ b/src/contracts/gasCalculator/BaseGasCalculator.sol
@@ -11,6 +11,9 @@ interface IGasPriceOracle {
     function getL1FeeUpperBound(uint256 _unsignedTxSize) external view returns (uint256);
 }
 
+// NOTE: This implementation does not support the Operator Fee introduced in the Isthmus upgrade. A larger refactor of
+// Atlas would be required to support it. See https://docs.optimism.io/stack/transactions/fees#operator-fee
+
 contract BaseGasCalculator is IL2GasCalculator, Ownable {
     uint256 internal constant _GAS_PER_CALLDATA_BYTE = 8;
     uint256 internal constant _BASE_TX_GAS_USED = 21_000;

--- a/src/contracts/helpers/Simulator.sol
+++ b/src/contracts/helpers/Simulator.sol
@@ -25,7 +25,7 @@ contract Simulator is AtlasErrors, AtlasConstants {
     using GasAccLib for SolverOperation[];
 
     // The approx gas used between the minGasLeft check and the Atlas metacall() from this Simulator contract.
-    uint256 internal constant _ERROR_CATCHER_GAS_BUFFER = 10_000;
+    uint256 internal constant _ERROR_CATCHER_GAS_BUFFER = 15_000;
     // The approx gas used between the `simUserOperation()` or `simSolverCall()` entrypoint functions in this Simulator
     // contract, and the minGasLeft check.
     uint256 internal constant _SIM_ENTRYPOINT_GAS_BUFFER = 50_000;

--- a/src/contracts/helpers/Simulator.sol
+++ b/src/contracts/helpers/Simulator.sol
@@ -92,8 +92,8 @@ contract Simulator is AtlasErrors, AtlasConstants {
         ) + GasAccLib.metacallCalldataGas(nonSolverCalldataLength, l2GasCalculator);
 
         // metacallExecutionGas is second item in return tuple
-        metacallExecutionGas =
-            _BASE_TX_GAS_USED + _FIXED_GAS_OFFSET + userOp.gas + dConfig.dappGasLimit + allSolversExecutionGas;
+        metacallExecutionGas = _BASE_TX_GAS_USED + _PRE_EXECUTE_METACALL_GAS + _FIXED_GAS_OFFSET + userOp.gas
+            + dConfig.dappGasLimit + allSolversExecutionGas;
 
         // If exPostBids = true, add extra execution gas to account for bid-finding.
         if (dConfig.callConfig.exPostBids()) {
@@ -142,8 +142,8 @@ contract Simulator is AtlasErrors, AtlasConstants {
             uint256 metacallCalldataGas =
                 GasAccLib.metacallCalldataGas(metacallCalldataLength, IAtlas(atlas).L2_GAS_CALCULATOR());
 
-            uint256 metacallExecutionGas =
-                _BASE_TX_GAS_USED + _FIXED_GAS_OFFSET + userOp.gas + userOp.dappGasLimit + solverOp.gas;
+            uint256 metacallExecutionGas = _BASE_TX_GAS_USED + _PRE_EXECUTE_METACALL_GAS + _FIXED_GAS_OFFSET
+                + userOp.gas + userOp.dappGasLimit + solverOp.gas;
 
             totalGas = metacallExecutionGas;
 

--- a/src/contracts/helpers/Simulator.sol
+++ b/src/contracts/helpers/Simulator.sol
@@ -258,12 +258,15 @@ contract Simulator is AtlasErrors, AtlasConstants {
         uint256 minGasLeft = adjMetacallExecutionGas * _MIN_GAS_SCALING_FACTOR / _SCALE + _ERROR_CATCHER_GAS_BUFFER;
         uint256 gasLeft = gasleft();
 
+        // NOTE: Set gas limit to the max supported by your RPC's `eth_call` when calling Simulator from an offchain
+        // source if you experience the revert below. Only the expected execution gas will be forwarded to Atlas.
+
         if (gasLeft < minGasLeft) {
             revert InsufficientGasForMetacallSimulation(
                 gasLeft, // The gas left at this point that was insufficient to pass the check
                 metacallExecutionGas + metacallCalldataGas, // Suggested gas limit for a real metacall
-                _SIM_ENTRYPOINT_GAS_BUFFER + _BASE_TX_GAS_USED + minGasLeft + metacallCalldataGas // Suggested gas limit
-                    // for a sim call
+                _SIM_ENTRYPOINT_GAS_BUFFER + _BASE_TX_GAS_USED + minGasLeft + metacallCalldataGas // Suggested min gas
+                    // limit for a sim call.
             );
         }
 

--- a/src/contracts/helpers/Simulator.sol
+++ b/src/contracts/helpers/Simulator.sol
@@ -92,7 +92,7 @@ contract Simulator is AtlasErrors, AtlasConstants {
         ) + GasAccLib.metacallCalldataGas(nonSolverCalldataLength, l2GasCalculator);
 
         // metacallExecutionGas is second item in return tuple
-        metacallExecutionGas = _BASE_TX_GAS_USED + _PRE_EXECUTE_METACALL_GAS + _FIXED_GAS_OFFSET + userOp.gas
+        metacallExecutionGas = _BASE_TX_GAS_USED + _PRE_EXECUTE_METACALL_GAS + _POST_SETTLE_METACALL_GAS + userOp.gas
             + dConfig.dappGasLimit + allSolversExecutionGas;
 
         // If exPostBids = true, add extra execution gas to account for bid-finding.
@@ -142,7 +142,7 @@ contract Simulator is AtlasErrors, AtlasConstants {
             uint256 metacallCalldataGas =
                 GasAccLib.metacallCalldataGas(metacallCalldataLength, IAtlas(atlas).L2_GAS_CALCULATOR());
 
-            uint256 metacallExecutionGas = _BASE_TX_GAS_USED + _PRE_EXECUTE_METACALL_GAS + _FIXED_GAS_OFFSET
+            uint256 metacallExecutionGas = _BASE_TX_GAS_USED + _PRE_EXECUTE_METACALL_GAS + _POST_SETTLE_METACALL_GAS
                 + userOp.gas + userOp.dappGasLimit + solverOp.gas;
 
             totalGas = metacallExecutionGas;

--- a/src/contracts/helpers/Simulator.sol
+++ b/src/contracts/helpers/Simulator.sol
@@ -92,8 +92,8 @@ contract Simulator is AtlasErrors, AtlasConstants {
         ) + GasAccLib.metacallCalldataGas(nonSolverCalldataLength, l2GasCalculator);
 
         // metacallExecutionGas is second item in return tuple
-        metacallExecutionGas = _BASE_TX_GAS_USED + AccountingMath._FIXED_GAS_OFFSET + userOp.gas + dConfig.dappGasLimit
-            + allSolversExecutionGas;
+        metacallExecutionGas =
+            _BASE_TX_GAS_USED + _FIXED_GAS_OFFSET + userOp.gas + dConfig.dappGasLimit + allSolversExecutionGas;
 
         // If exPostBids = true, add extra execution gas to account for bid-finding.
         if (dConfig.callConfig.exPostBids()) {
@@ -143,7 +143,7 @@ contract Simulator is AtlasErrors, AtlasConstants {
                 GasAccLib.metacallCalldataGas(metacallCalldataLength, IAtlas(atlas).L2_GAS_CALCULATOR());
 
             uint256 metacallExecutionGas =
-                _BASE_TX_GAS_USED + AccountingMath._FIXED_GAS_OFFSET + userOp.gas + userOp.dappGasLimit + solverOp.gas;
+                _BASE_TX_GAS_USED + _FIXED_GAS_OFFSET + userOp.gas + userOp.dappGasLimit + solverOp.gas;
 
             totalGas = metacallExecutionGas;
 

--- a/src/contracts/helpers/Simulator.sol
+++ b/src/contracts/helpers/Simulator.sol
@@ -93,11 +93,12 @@ contract Simulator is AtlasErrors, AtlasConstants {
 
         // metacallExecutionGas is second item in return tuple
         metacallExecutionGas = _BASE_TX_GAS_USED + _PRE_EXECUTE_METACALL_GAS + _POST_SETTLE_METACALL_GAS + userOp.gas
-            + dConfig.dappGasLimit + allSolversExecutionGas;
+            + dConfig.dappGasLimit + allSolversExecutionGas + (_EXECUTE_SOLVER_OVERHEAD * solverOpsLen);
 
         // If exPostBids = true, add extra execution gas to account for bid-finding.
         if (dConfig.callConfig.exPostBids()) {
-            metacallExecutionGas += (solverOpsLen * _BID_FIND_OVERHEAD) + allSolversExecutionGas;
+            metacallExecutionGas +=
+                solverOpsLen * (_BID_FIND_OVERHEAD + _EXECUTE_SOLVER_OVERHEAD) + allSolversExecutionGas;
         }
     }
 

--- a/src/contracts/helpers/Simulator.sol
+++ b/src/contracts/helpers/Simulator.sol
@@ -25,7 +25,7 @@ contract Simulator is AtlasErrors, AtlasConstants {
     using GasAccLib for SolverOperation[];
 
     // The approx gas used between the minGasLeft check and the Atlas metacall() from this Simulator contract.
-    uint256 internal constant _ERROR_CATCHER_GAS_BUFFER = 15_000;
+    uint256 internal constant _ERROR_CATCHER_GAS_BUFFER = 10_000;
     // The approx gas used between the `simUserOperation()` or `simSolverCall()` entrypoint functions in this Simulator
     // contract, and the minGasLeft check.
     uint256 internal constant _SIM_ENTRYPOINT_GAS_BUFFER = 50_000;

--- a/src/contracts/helpers/Sorter.sol
+++ b/src/contracts/helpers/Sorter.sol
@@ -94,7 +94,7 @@ contract Sorter is AtlasConstants {
 
         // Execution gas a winning solver would pay for
         uint256 executionGas =
-            _BASE_TX_GAS_USED + AccountingMath._FIXED_GAS_OFFSET + solverOpGasLimit + userOp.gas + dConfig.dappGasLimit;
+            _BASE_TX_GAS_USED + _FIXED_GAS_OFFSET + solverOpGasLimit + userOp.gas + dConfig.dappGasLimit;
 
         uint256 maxSolverCost = (solverOp.maxFeePerGas * (executionGas + calldataGas)).withSurcharge(totalSurchargeRate);
 

--- a/src/contracts/helpers/Sorter.sol
+++ b/src/contracts/helpers/Sorter.sol
@@ -93,8 +93,8 @@ contract Sorter is AtlasConstants {
         ) * _GAS_PER_CALLDATA_BYTE;
 
         // Execution gas a winning solver would pay for
-        uint256 executionGas =
-            _BASE_TX_GAS_USED + _FIXED_GAS_OFFSET + solverOpGasLimit + userOp.gas + dConfig.dappGasLimit;
+        uint256 executionGas = _BASE_TX_GAS_USED + _PRE_EXECUTE_METACALL_GAS + _FIXED_GAS_OFFSET + solverOpGasLimit
+            + userOp.gas + dConfig.dappGasLimit;
 
         uint256 maxSolverCost = (solverOp.maxFeePerGas * (executionGas + calldataGas)).withSurcharge(totalSurchargeRate);
 

--- a/src/contracts/helpers/Sorter.sol
+++ b/src/contracts/helpers/Sorter.sol
@@ -93,8 +93,8 @@ contract Sorter is AtlasConstants {
         ) * _GAS_PER_CALLDATA_BYTE;
 
         // Execution gas a winning solver would pay for
-        uint256 executionGas = _BASE_TX_GAS_USED + _PRE_EXECUTE_METACALL_GAS + _FIXED_GAS_OFFSET + solverOpGasLimit
-            + userOp.gas + dConfig.dappGasLimit;
+        uint256 executionGas = _BASE_TX_GAS_USED + _PRE_EXECUTE_METACALL_GAS + _POST_SETTLE_METACALL_GAS
+            + solverOpGasLimit + userOp.gas + dConfig.dappGasLimit;
 
         uint256 maxSolverCost = (solverOp.maxFeePerGas * (executionGas + calldataGas)).withSurcharge(totalSurchargeRate);
 

--- a/src/contracts/libraries/AccountingMath.sol
+++ b/src/contracts/libraries/AccountingMath.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.28;
 library AccountingMath {
     uint256 internal constant _MAX_BUNDLER_REFUND_RATE = 8000; // out of 10_000 = 80%
     uint256 internal constant _SCALE = 10_000; // 10_000 / 10_000 = 100%
-    uint256 internal constant _FIXED_GAS_OFFSET = 150_000; // in gas units
 
     function withSurcharge(uint256 amount, uint256 surchargeRate) internal pure returns (uint256 adjustedAmount) {
         adjustedAmount = amount * (_SCALE + surchargeRate) / _SCALE;

--- a/src/contracts/types/AtlasConstants.sol
+++ b/src/contracts/types/AtlasConstants.sol
@@ -35,6 +35,8 @@ contract AtlasConstants {
         // `execute()` function call. For gas limit estimation purposes.
     uint256 internal constant _POST_SETTLE_METACALL_GAS = 70_000; // Approx gas used from the gasleft() measurement
         // taken at the start of `_settle()`. For full metacall gas reimbursement purposes.
+    uint256 internal constant _EXECUTE_SOLVER_OVERHEAD = 45_000; // Approx upper bound gas used by each
+        // `_executeSolverOperation()` call, excluding the `_solverOpWrapper()` gas. For gas limit estimation purposes.
     uint256 internal constant _SOLVER_OP_STATIC_LENGTH = GasAccLib._SOLVER_OP_STATIC_LENGTH; // SolverOperation calldata
         // length excluding solverOp.data
     uint256 internal constant _BUNDLER_FAULT_OFFSET = 4500; // Extra gas to write off if solverOp failure is bundler

--- a/src/contracts/types/AtlasConstants.sol
+++ b/src/contracts/types/AtlasConstants.sol
@@ -31,6 +31,7 @@ contract AtlasConstants {
     // Calldata bytes charged at half the upper rate of 16 gas per byte (i.e. charged at 8 gas per byte), for both zero
     // and non-zero bytes of calldata.
     uint256 internal constant _BASE_TX_GAS_USED = 21_000;
+    uint256 internal constant _FIXED_GAS_OFFSET = 150_000; // in gas units
     uint256 internal constant _SOLVER_OP_STATIC_LENGTH = GasAccLib._SOLVER_OP_STATIC_LENGTH; // SolverOperation calldata
         // length excluding solverOp.data
     uint256 internal constant _BUNDLER_FAULT_OFFSET = 4500; // Extra gas to write off if solverOp failure is bundler

--- a/src/contracts/types/AtlasConstants.sol
+++ b/src/contracts/types/AtlasConstants.sol
@@ -33,7 +33,8 @@ contract AtlasConstants {
     uint256 internal constant _BASE_TX_GAS_USED = 21_000;
     uint256 internal constant _PRE_EXECUTE_METACALL_GAS = 75_000; // Approx gas used from start of metacall to the
         // `execute()` function call. For gas limit estimation purposes.
-    uint256 internal constant _FIXED_GAS_OFFSET = 150_000; // in gas units
+    uint256 internal constant _POST_SETTLE_METACALL_GAS = 70_000; // Approx gas used from the gasleft() measurement
+        // taken at the start of `_settle()`. For full metacall gas reimbursement purposes.
     uint256 internal constant _SOLVER_OP_STATIC_LENGTH = GasAccLib._SOLVER_OP_STATIC_LENGTH; // SolverOperation calldata
         // length excluding solverOp.data
     uint256 internal constant _BUNDLER_FAULT_OFFSET = 4500; // Extra gas to write off if solverOp failure is bundler

--- a/src/contracts/types/AtlasConstants.sol
+++ b/src/contracts/types/AtlasConstants.sol
@@ -31,6 +31,8 @@ contract AtlasConstants {
     // Calldata bytes charged at half the upper rate of 16 gas per byte (i.e. charged at 8 gas per byte), for both zero
     // and non-zero bytes of calldata.
     uint256 internal constant _BASE_TX_GAS_USED = 21_000;
+    uint256 internal constant _PRE_EXECUTE_METACALL_GAS = 75_000; // Approx gas used from start of metacall to the
+        // `execute()` function call. For gas limit estimation purposes.
     uint256 internal constant _FIXED_GAS_OFFSET = 150_000; // in gas units
     uint256 internal constant _SOLVER_OP_STATIC_LENGTH = GasAccLib._SOLVER_OP_STATIC_LENGTH; // SolverOperation calldata
         // length excluding solverOp.data

--- a/src/contracts/types/AtlasConstants.sol
+++ b/src/contracts/types/AtlasConstants.sol
@@ -31,8 +31,8 @@ contract AtlasConstants {
     // Calldata bytes charged at half the upper rate of 16 gas per byte (i.e. charged at 8 gas per byte), for both zero
     // and non-zero bytes of calldata.
     uint256 internal constant _BASE_TX_GAS_USED = 21_000;
-    uint256 internal constant _PRE_EXECUTE_METACALL_GAS = 75_000; // Approx gas used from start of metacall to the
-        // `execute()` function call. For gas limit estimation purposes.
+    uint256 internal constant _PRE_EXECUTE_METACALL_GAS = 150_000; // Approx gas used from start of metacall to the
+        // `execute()` function call, including EE deployment cost. For gas limit estimation purposes.
     uint256 internal constant _POST_SETTLE_METACALL_GAS = 70_000; // Approx gas used from the gasleft() measurement
         // taken at the start of `_settle()`. For full metacall gas reimbursement purposes.
     uint256 internal constant _EXECUTE_SOLVER_OVERHEAD = 45_000; // Approx upper bound gas used by each

--- a/test/FLOnline.t.sol
+++ b/test/FLOnline.t.sol
@@ -53,7 +53,7 @@ contract FastLaneOnlineTest is BaseTest {
 
     // Only Atlas surcharge kept if all fail, bundler surcharge paid to bundler
     uint256 constant SURCHARGE_PER_SOLVER_IF_ALL_FAIL = 16_000e9; // 16k Gwei (avg, differs for ERC20/native in/out)
-    uint256 constant ERR_MARGIN = 0.18e18; // 18% error margin
+    uint256 constant ERR_MARGIN = 0.20e18; // 20% error margin
     address internal constant NATIVE_TOKEN = address(0);
 
     address protocolGuildWallet = 0x25941dC771bB64514Fc8abBce970307Fb9d477e9;

--- a/test/Storage.t.sol
+++ b/test/Storage.t.sol
@@ -13,7 +13,6 @@ contract StorageTest is BaseTest {
     using stdStorage for StdStorage;
 
     uint256 constant DEFAULT_SCALE = 10_000; // out of 10_000 = 100%
-    uint256 constant DEFAULT_FIXED_GAS_OFFSET = 150_000;
 
     function setUp() public override {
         super.setUp();

--- a/test/Storage.t.sol
+++ b/test/Storage.t.sol
@@ -31,7 +31,6 @@ contract StorageTest is BaseTest {
         assertEq(atlas.decimals(), 18, "decimals set incorrectly");
 
         assertEq(atlas.SCALE(), DEFAULT_SCALE, "SCALE set incorrectly");
-        assertEq(atlas.FIXED_GAS_OFFSET(), DEFAULT_FIXED_GAS_OFFSET, "FIXED_GAS_OFFSET set incorrectly");
     }
 
     // View Functions for internal storage variables


### PR DESCRIPTION
Fixes made during the Spearbit audit of Atlas v1.6.2

### Changes:

- Bumped `optimizer_runs` to 18 (max possible before Atlas.sol exceeds the 24 576 byte contract size limit).
- Introduced `_PRE_EXECUTE_METACALL_GAS` constant, to capture execution gas missing from the components during gas limit estimation. Used in Simulator.sol to estimate a metacall's gas limit, and AtlasVerification.sol to check if the current metacall has an appropriate amount of gas. This constant reflects the execution gas used from the `gasleft()` measurement taken at the start of the metacall, to just before `execute()` is called in the metacall.
- Measured `_PRE_EXECUTE_METACALL_GAS` across a variety of metacalls, with results ranging from 71k - 74k gas, when excluding the deployment of the EE. When including deployment of the EE, this gas can range from 150k - 250k with the latter being an outlier due to unusually large `userOp.data`. Constant has thus been set to 150k gas.
- Renamed `_FIXED_GAS_OFFSET` to `_POST_SETTLE_METACALL_GAS` to better indicate that it represents the approx. gas used after the final `gasleft()` measurement is taken at the start of `_settle()`, to the end of the metacall. Adjusted its value from 150k to 70k (based on measurements taken across a variety of metacalls).
- Added `_EXECUTE_SOLVER_OVERHEAD` constant, as an approx upper bound of the overhead gas of each `_executeSolverOperation()` call, (excluding the `_solverOpWrapper()` call as the `solverOp.gas` value accounts for that gas). Used in Simulator.sol and AtlasVerification.sol for metacall gas limit estimation. Constant has been set to 45k which is the upper bound across a variety of metacalls. This constant is added once per solverOp to the gas limit of metacalls where `exPostBids = false`, and twice per solverOp where `exPostBids = true`.
- Subtracted the 21k gas (`_BASE_TX_GAS_USED`) from the gas limit forwarded to Atlas when simulating a metacall because, similar to calldata gas costs, that amount has already been subtracted at the Simulator point of entry.
- Added comments in the BaseGasCalculator and Simulator with info around acknowledged findings.